### PR TITLE
fix: ensure remote development works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules
 .vscode-test/
 *.vsix
 .DS_Store
+## Ignore executables and zips created (in the download process) when running the extension in dev mode
 cs
 cs.last-modified
+cs-*-*
+cs-*.last-modified
 *.zip

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,9 +8,14 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
-*.zip
+
+## Ignore executables and zips created (in the download process) when running the extension in dev mode
 cs
 cs.last-modified
+cs-*-*
+cs-*.last-modified
+*.zip
+
 screenshots
 *.vsix
 .DS_Store


### PR DESCRIPTION
There were issues when the remote platform was different from the host platform (e.g. linux vs windows). Basically when installing the extension into the remote platform it was copied from the host platform, which could mean an incompatible codescene binary followed along.

There is a remaining issue if you use devcontainers on an m1 mac as it cannot run amd64 binaries. We need to produce actual arm64 binaries to solve it.

