### PR TITLE
test: add basic test checking if activation works

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,15 +1,25 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
 
-suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+suite('Extension Test Suite', function () {
+  vscode.window.showInformationMessage('Start all tests.');
+  this.timeout(10000);
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
+  suiteSetup(async function () {
+    await vscode.extensions.getExtension('codescene.codescene-vscode')?.activate();
+  });
+
+  test('Extension is active', () => {
+    assert.ok(vscode.extensions.getExtension('codescene.codescene-vscode')?.isActive);
+  });
+
+  test('Diagnostics are registered', async () => {
+    const emptyDiags = vscode.languages.getDiagnostics();
+
+    // It should be empty because we haven't opened any files yet.
+    assert.strictEqual(emptyDiags.length, 0);
+
+    // I wanted to try to open a file and see that the diagnostics are
+    // registered, but I couldn't get it to work. TBD.
+  });
 });


### PR DESCRIPTION
This is a good basic sanity check because it allows us to test a real activation on windows, macos and linux.

