### PR TITLE
perf: add execution times by language to telemetry

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -4,6 +4,7 @@ export interface ExecResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  duration: number;
 }
 
 export interface Command {
@@ -48,7 +49,7 @@ export class SimpleExecutor implements Executor {
         }
         const end = Date.now();
         console.log(`CodeScene: ${logName} with pid ${childProcess.pid} took ${end - start} milliseconds`);
-        resolve({ stdout, stderr, exitCode: error?.code || 0 });
+        resolve({ stdout, stderr, exitCode: error?.code || 0, duration: end - start });
       });
 
       if (input && childProcess.stdin) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,8 +135,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Send execution stats by language
     if (stats.analysis.length > 0) {
-      for (const language of stats.analysis) {
-        Telemetry.instance.logUsage('stats', {stats: { analysis: language }});
+      for (const byLanguage of stats.analysis) {
+        Telemetry.instance.logUsage('stats', {stats: { analysis: byLanguage }});
       }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { createRulesTemplate } from './rules-template';
 import { outputChannel } from './log';
 import Telemetry from './telemetry';
 import { CachingReviewer, FilteringReviewer, SimpleReviewer } from './review/reviewer';
+import { StatsCollector } from './stats';
 
 
 function getSupportedLanguages(extension: vscode.Extension<any>): string[] {
@@ -127,6 +128,20 @@ export async function activate(context: vscode.ExtensionContext) {
     codeLensProvider.update();
   });
   context.subscriptions.push(fileSystemWatcher);
+
+  // Setup a scheduled event for sending statistics
+  setInterval(() => {
+    const stats = StatsCollector.instance.stats;
+
+    // Send execution stats by language
+    if (stats.analysis.length > 0) {
+      for (const language of stats.analysis) {
+        Telemetry.instance.logUsage('stats', {stats: { analysis: language }});
+      }
+    }
+
+    StatsCollector.instance.clear();
+  }, 1800 * 1000);
 }
 
 // This method is called when your extension is deactivated

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -4,6 +4,7 @@ import { getFileExtension } from '../utils';
 import { LimitingExecutor, SimpleExecutor } from '../executor';
 import { produceDiagnostic, reviewIssueToDiagnostics } from './utils';
 import { ReviewResult } from './model';
+import { StatsCollector } from '../stats';
 
 export interface ReviewOpts {
   [key: string]: string | boolean;
@@ -33,7 +34,9 @@ export class SimpleReviewer implements Reviewer {
       document.getText()
     );
 
-    const diagnostics = result.then(({ stdout }) => {
+    const diagnostics = result.then(({ stdout, duration }) => {
+      StatsCollector.instance.recordAnalysis(fileExtension, duration);
+
       const data = JSON.parse(stdout) as ReviewResult;
       let diagnostics = data.review.flatMap((reviewIssue) => reviewIssueToDiagnostics(reviewIssue, document));
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -16,6 +16,9 @@ export class StatsCollector {
   };
 
   recordAnalysis(language: string, time: number) {
+    // Skip record if time is negative or zero. Must be some kind of error.
+    if (time <= 0) return;
+
     const analysis = this.stats.analysis.find((a) => a.language === language);
     if (analysis) {
       analysis.runs++;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,37 @@
+export interface Stats {
+  analysis: AnalysisStats[];
+}
+
+export interface AnalysisStats {
+  language: string;
+  runs: number;
+  avgTime: number;
+  maxTime: number;
+}
+
+export class StatsCollector {
+  static readonly instance = new StatsCollector();
+  readonly stats: Stats = {
+    analysis: [],
+  };
+
+  recordAnalysis(language: string, time: number) {
+    const analysis = this.stats.analysis.find((a) => a.language === language);
+    if (analysis) {
+      analysis.runs++;
+      analysis.avgTime = (analysis.avgTime + time) / 2;
+      analysis.maxTime = Math.max(analysis.maxTime, time);
+    } else {
+      this.stats.analysis.push({
+        language,
+        runs: 1,
+        avgTime: time,
+        maxTime: time,
+      });
+    }
+  }
+
+  clear() {
+    this.stats.analysis = [];
+  }
+}

--- a/src/test/suite/stats.test.ts
+++ b/src/test/suite/stats.test.ts
@@ -1,0 +1,62 @@
+import * as assert from 'assert';
+
+import { StatsCollector } from '../../stats';
+
+suite('Stats Test Suite', () => {
+  // Create a new instance of StatsCollector before each test.
+  let statsCollector: StatsCollector;
+  setup(() => {
+    statsCollector = new StatsCollector();
+  });
+
+  test('empty to start', () => {
+    assert.ok(statsCollector.stats.analysis.length === 0);
+  });
+
+  test('handles one analysis', () => {
+    statsCollector.recordAnalysis('java', 100);
+    assert.ok(statsCollector.stats.analysis.length === 1);
+    assert.ok(statsCollector.stats.analysis[0].language === 'java');
+    assert.ok(statsCollector.stats.analysis[0].runs === 1);
+    assert.ok(statsCollector.stats.analysis[0].avgTime === 100);
+    assert.ok(statsCollector.stats.analysis[0].maxTime === 100);
+  });
+
+  test('handles averages', () => {
+    statsCollector.recordAnalysis('java', 100);
+    statsCollector.recordAnalysis('java', 200);
+    assert.ok(statsCollector.stats.analysis.length === 1);
+    assert.ok(statsCollector.stats.analysis[0].language === 'java');
+    assert.ok(statsCollector.stats.analysis[0].runs === 2);
+    assert.ok(statsCollector.stats.analysis[0].avgTime === 150);
+    assert.ok(statsCollector.stats.analysis[0].maxTime === 200);
+  });
+
+  test('handles multiple languages', () => {
+    statsCollector.recordAnalysis('java', 100);
+    statsCollector.recordAnalysis('java', 200);
+    statsCollector.recordAnalysis('python', 300);
+    assert.ok(statsCollector.stats.analysis.length === 2);
+    assert.ok(statsCollector.stats.analysis[0].language === 'java');
+    assert.ok(statsCollector.stats.analysis[0].runs === 2);
+    assert.ok(statsCollector.stats.analysis[0].avgTime === 150);
+    assert.ok(statsCollector.stats.analysis[0].maxTime === 200);
+    assert.ok(statsCollector.stats.analysis[1].language === 'python');
+    assert.ok(statsCollector.stats.analysis[1].runs === 1);
+    assert.ok(statsCollector.stats.analysis[1].avgTime === 300);
+    assert.ok(statsCollector.stats.analysis[1].maxTime === 300);
+  });
+
+  test('clear', () => {
+    statsCollector.recordAnalysis('java', 100);
+    statsCollector.recordAnalysis('java', 200);
+    statsCollector.recordAnalysis('python', 300);
+    statsCollector.clear();
+    assert.ok(statsCollector.stats.analysis.length === 0);
+  });
+
+  test('negative time', () => {
+    statsCollector.recordAnalysis('java', -100);
+    assert.ok(statsCollector.stats.analysis.length === 0);
+  });
+});


### PR DESCRIPTION
This will allow us to see which languages are used the most, and also if any of them are in need of being optimized.