### PR TITLE
Authorisation and API access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules
 ## Ignore executables and zips created (in the download process) when running the extension in dev mode
 cs
 cs.last-modified
-cs-*-*
+cs-*-x64
 cs-*.last-modified
 *.zip
 .idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "axios": "^1.3.4",
         "extract-zip": "^2.0.1",
         "follow-redirects": "^1.15.2",
-        "lodash.debounce": "^4.0.8"
+        "lodash.debounce": "^4.0.8",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@types/glob": "^8.0.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
+        "@types/uuid": "^9.0.1",
         "@types/vscode": "^1.75.1",
         "@typescript-eslint/eslint-plugin": "^5.51.0",
         "@typescript-eslint/parser": "^5.45.0",
@@ -319,6 +321,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -4488,6 +4496,14 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -4877,6 +4893,12 @@
       "version": "7.3.13",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/vscode": {
@@ -7957,6 +7979,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -105,13 +105,15 @@
       "scm": [
         {
           "id": "codescene.scmCouplingsView",
-          "name": "Change coupling"
+          "name": "Change coupling",
+          "when": "codescene.remoteFeaturesEnabled"
         }
       ],
       "explorer": [
         {
           "id": "codescene.explorerCouplingsView",
-          "name": "Change coupling"
+          "name": "Change coupling",
+          "when": "codescene.remoteFeaturesEnabled"
         }
       ]
     },
@@ -119,22 +121,22 @@
       {
         "view": "codescene.scmCouplingsView",
         "contents": "In order to see coupling data, you need to be logged in to the CodeScene server",
-        "when": "!codescene.isLoggedIn"
+        "when": "codescene.remoteFeaturesEnabled && !codescene.isLoggedIn"
       },
       {
         "view": "codescene.scmCouplingsView",
         "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
-        "when": "!codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        "when": "codescene.remoteFeaturesEnabled && !codescene.isWorkspaceAssociated && codescene.isLoggedIn"
       },
       {
         "view": "codescene.explorerCouplingsView",
         "contents": "In order to see coupling data, you need to be logged in to the CodeScene server",
-        "when": "!codescene.isLoggedIn"
+        "when": "codescene.remoteFeaturesEnabled && !codescene.isLoggedIn"
       },
       {
         "view": "codescene.explorerCouplingsView",
         "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
-        "when": "!codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        "when": "codescene.remoteFeaturesEnabled && !codescene.isWorkspaceAssociated && codescene.isLoggedIn"
       }
     ],
     "menus": {
@@ -213,27 +215,38 @@
         "codescene.enableCodeLenses": {
           "type": "boolean",
           "default": true,
-          "description": "Enable CodeScene code lenses"
+          "description": "Enable CodeScene code lenses",
+          "order": 1
         },
         "codescene.gitignore": {
           "type": "boolean",
           "default": true,
-          "description": "Exclude files in .gitignore from analysis"
+          "description": "Exclude files in .gitignore from analysis",
+          "order": 2
         },
         "codescene.excludeExternal": {
           "type": "boolean",
           "default": true,
-          "description": "Exclude files outside of the workspace from analysis"
+          "description": "Exclude files outside of the workspace from analysis",
+          "order": 3
+        },
+        "codescene.enableRemoteFeatures": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable remote features. This enables the use of pre-analyzed data on an existing CodeScene server. Requires codescene login. VS Code has to be restarted after changing this setting.",
+          "order": 4
         },
         "codescene.cloudUrl": {
           "type": "string",
           "default": "https://staging.codescene.io",
-          "description": "The URL to the CodeScene Cloud service"
+          "description": "The URL to the CodeScene Cloud service",
+          "order": 5
         },
         "codescene.cloudApiUrl": {
           "type": "string",
           "default": "https://api-staging.codescene.io",
-          "description": "The API URL of the CodeScene Cloud service"
+          "description": "The API URL of the CodeScene Cloud service",
+          "order": 6
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -60,13 +60,153 @@
     "commands": [
       {
         "command": "codescene.createRulesTemplate",
-        "title": "CodeScene: create rules template"
+        "title": "CodeScene: Create Rules Template"
       },
       {
         "command": "codescene.openCodeHealthDocs",
-        "title": "CodeScene: open code health documentation"
+        "title": "CodeScene: Open Code Health Documentation"
+      },
+      {
+        "command": "codescene.associateWithProject",
+        "title": "CodeScene: Associate Workspace with CodeScene Project"
+      },
+      {
+        "command": "codescene.scmCouplingsView.open",
+        "title": "Open File",
+        "icon": "$(preferences-open-settings)"
+      },
+      {
+        "command": "codescene.scmCouplingsView.refresh",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "codescene.openDashboard",
+        "title": "CodeScene: Open Project Dashboard"
+      },
+      {
+        "command": "codescene.openHotspots",
+        "title": "CodeScene: Open Hotspots Map"
+      },
+      {
+        "command": "codescene.openChangeCoupling",
+        "title": "CodeScene: Open Change Coupling"
+      },
+      {
+        "command": "codescene.openCodeReview",
+        "title": "CodeScene: Open Code Review"
+      },
+      {
+        "command": "codescene.openXRay",
+        "title": "CodeScene: Open X-Ray"
       }
     ],
+    "views": {
+      "scm": [
+        {
+          "id": "codescene.scmCouplingsView",
+          "name": "Change coupling"
+        }
+      ],
+      "explorer": [
+        {
+          "id": "codescene.explorerCouplingsView",
+          "name": "Change coupling"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "codescene.scmCouplingsView",
+        "contents": "In order to see coupling data, you need to be logged in to the CodeScene server",
+        "when": "!codescene.isLoggedIn"
+      },
+      {
+        "view": "codescene.scmCouplingsView",
+        "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
+        "when": "!codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+      },
+      {
+        "view": "codescene.explorerCouplingsView",
+        "contents": "In order to see coupling data, you need to be logged in to the CodeScene server",
+        "when": "!codescene.isLoggedIn"
+      },
+      {
+        "view": "codescene.explorerCouplingsView",
+        "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
+        "when": "!codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "codescene.scmCouplingsView.refresh",
+          "when": "view == codescene.scmCouplingsView",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "codescene.scmCouplingsView.open",
+          "when": "view == codescene.scmCouplingsView && viewItem == rootItem",
+          "group": "inline"
+        },
+        {
+          "command": "codescene.openXRay",
+          "when": "view == codescene.scmCouplingsView || view == codescene.explorerCouplingsView"
+        },
+        {
+          "command": "codescene.openCodeReview",
+          "when": "view == codescene.scmCouplingsView || view == codescene.explorerCouplingsView"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "codescene.openDashboard",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.openHotspots",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.openChangeCoupling",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.associateWithProject",
+          "when": "codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.openXRay",
+          "when": "false"
+        },
+        {
+          "command": "codescene.openCodeReview",
+          "when": "false"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "codescene.openCodeReview",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.openXRay",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "codescene.openCodeReview",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        },
+        {
+          "command": "codescene.openXRay",
+          "when": "codescene.isWorkspaceAssociated && codescene.isLoggedIn"
+        }
+      ]
+    },
     "configuration": {
       "title": "CodeScene",
       "properties": {
@@ -84,6 +224,16 @@
           "type": "boolean",
           "default": true,
           "description": "Exclude files outside of the workspace from analysis"
+        },
+        "codescene.cloudUrl": {
+          "type": "string",
+          "default": "https://staging.codescene.io",
+          "description": "The URL to the CodeScene Cloud service"
+        },
+        "codescene.cloudApiUrl": {
+          "type": "string",
+          "default": "https://api-staging.codescene.io",
+          "description": "The API URL of the CodeScene Cloud service"
         }
       }
     }
@@ -103,6 +253,7 @@
     "@types/glob": "^8.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "16.x",
+    "@types/uuid": "^9.0.1",
     "@types/vscode": "^1.75.1",
     "@typescript-eslint/eslint-plugin": "^5.51.0",
     "@typescript-eslint/parser": "^5.45.0",
@@ -116,9 +267,10 @@
   "dependencies": {
     "@types/follow-redirects": "^1.14.1",
     "@types/lodash.debounce": "^4.0.7",
+    "axios": "^1.3.4",
     "extract-zip": "^2.0.1",
     "follow-redirects": "^1.15.2",
     "lodash.debounce": "^4.0.8",
-    "axios": "^1.3.4"
+    "uuid": "^9.0.0"
   }
 }

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -1,0 +1,207 @@
+import {
+  authentication,
+  AuthenticationProvider,
+  AuthenticationProviderAuthenticationSessionsChangeEvent,
+  AuthenticationSession,
+  Disposable,
+  env,
+  EventEmitter,
+  ExtensionContext,
+  ProgressLocation,
+  Uri,
+  UriHandler,
+  window,
+} from 'vscode';
+import { v4 as uuid } from 'uuid';
+import { PromiseAdapter, promiseFromEvent } from './util';
+import { outputChannel } from '../log';
+import { getServerUrl } from '../configuration';
+import { CsWorkspace } from '../workspace';
+
+export const AUTH_TYPE = 'codescene';
+const SESSIONS_STORAGE_KEY = `${AUTH_TYPE}.sessions`;
+
+class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
+  public handleUri(uri: Uri) {
+    this.fire(uri);
+  }
+}
+
+interface LoginResponse {
+  name: string;
+  token: string;
+}
+
+export class CsAuthenticationProvider implements AuthenticationProvider, Disposable {
+  private sessionChangeEmitter = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+  private disposable: Disposable;
+  private uriHandler = new UriEventHandler();
+
+  constructor(private context: ExtensionContext, private csWorkspace: CsWorkspace) {
+    this.disposable = Disposable.from(
+      authentication.registerAuthenticationProvider(AUTH_TYPE, "CodeScene Cloud", this, { supportsMultipleAccounts: false }),
+      window.registerUriHandler(this.uriHandler)
+    );
+  }
+
+  get onDidChangeSessions() {
+    return this.sessionChangeEmitter.event;
+  }
+
+  get redirectUri() {
+    const publisher = this.context.extension.packageJSON.publisher;
+    const name = this.context.extension.packageJSON.name;
+    // E.g. vscode://codescene.codescene-vscode
+    return `${env.uriScheme}://${publisher}.${name}`;
+  }
+
+  /**
+   * Get the existing sessions.
+   * @param scopes
+   * @returns
+   */
+  public async getSessions(scopes?: string[]): Promise<readonly AuthenticationSession[]> {
+    const allSessions = await this.context.secrets.get(SESSIONS_STORAGE_KEY);
+
+    if (allSessions) {
+      return JSON.parse(allSessions) as AuthenticationSession[];
+    }
+
+    return [];
+  }
+
+  /**
+   * Create a new auth session
+   * @param scopes
+   * @returns
+   */
+  public async createSession(scopes: string[]): Promise<AuthenticationSession> {
+    try {
+      const loginResponse = await this.login();
+
+      if (!loginResponse) {
+        throw new Error("CodeScene login failure");
+      }
+
+      const session: AuthenticationSession = {
+        id: uuid(), // Do we need a "static" id here?
+        accessToken: loginResponse.token,
+        account: {
+          label: loginResponse.name,
+          id: uuid(), // Do we need a "static" id here?
+        },
+        scopes: [],
+      };
+
+      await this.context.secrets.store(SESSIONS_STORAGE_KEY, JSON.stringify([session]));
+
+      this.sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
+
+      outputChannel.appendLine(`Created session ${session.id} for ${session.account.label}`);
+      outputChannel.appendLine(`Secret token: ${session.accessToken}`);
+
+      if (this.csWorkspace.getProjectId() === undefined) {
+       const result = await window.showInformationMessage(`Signed in to CodeScene as ${session.account.label}`, "Associate workspace with project");
+       if (result === "Associate workspace with project") {
+         this.csWorkspace.associateWithProject();
+       }
+      } else {
+        window.showInformationMessage(`Signed in to CodeScene as ${session.account.label}`);
+      }
+
+      return session;
+    } catch (e) {
+      window.showErrorMessage(`Sign in failed: ${e}`);
+      throw e;
+    }
+  }
+
+  /**
+   * Remove an existing session
+   * @param sessionId
+   */
+  public async removeSession(sessionId: string): Promise<void> {
+    const allSessions = await this.context.secrets.get(SESSIONS_STORAGE_KEY);
+    if (allSessions) {
+      let sessions = JSON.parse(allSessions) as AuthenticationSession[];
+      const session = sessions.find((s) => s.id === sessionId);
+      if (session) {
+        await this.context.secrets.store(SESSIONS_STORAGE_KEY, "[]");
+        this.sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
+        this.csWorkspace.clearProjectAssociation();
+      }
+    }
+  }
+
+  /**
+   * Dispose the registered services
+   */
+  public async dispose() {
+    this.disposable.dispose();
+  }
+
+  /**
+   * Log in to CodeScene
+   */
+  private async login() {
+    return await window.withProgress<LoginResponse>(
+      {
+        location: ProgressLocation.Notification,
+        title: 'Signing in to CodeScene...',
+        cancellable: true,
+      },
+      async (_, cancel) => {
+        const searchParams = new URLSearchParams({
+          'redirect-url': this.redirectUri
+        });
+
+        const tokenPath = `/configuration/devtools-tokens/add?${searchParams.toString()}`;
+        const loginUrl = Uri.parse(`${getServerUrl()}/login?next=${tokenPath}`);
+
+        outputChannel.appendLine(`Opening ${loginUrl.toString()}`);
+
+        await env.openExternal(loginUrl);
+
+        let codeExchangePromise = promiseFromEvent(this.uriHandler.event, this.handleUri());
+
+        try {
+          return await Promise.race([
+            codeExchangePromise.promise,
+            new Promise<LoginResponse>((_, reject) => setTimeout(() => reject('Cancelled'), 60000)),
+            promiseFromEvent<any, any>(cancel.onCancellationRequested, (_, __, reject) => {
+              reject('User Cancelled');
+            }).promise,
+          ]);
+        } finally {
+          codeExchangePromise?.cancel.fire();
+        }
+      }
+    );
+  }
+
+  /**
+   * Handle the redirect to VS Code (after sign in from CodeScene)
+   * @param scopes
+   * @returns
+   */
+  private handleUri(): PromiseAdapter<Uri, LoginResponse> {
+    return async (uri, resolve, reject) => {
+      const query = new URLSearchParams(uri.query);
+
+      const name = query.get('name');
+      const token = query.get('token');
+
+      if (token === null) {
+        reject('No token found in redirect');
+        return;
+      }
+
+      if (name === null) {
+        reject('No name found in redirect');
+        return;
+      }
+
+      resolve({ name, token});
+    };
+  }
+}

--- a/src/auth/util.ts
+++ b/src/auth/util.ts
@@ -1,0 +1,52 @@
+import { Disposable, Event, EventEmitter } from 'vscode';
+
+export interface PromiseAdapter<T, U> {
+  (value: T, resolve: (value: U | PromiseLike<U>) => void, reject: (reason: any) => void): any;
+}
+
+const passthrough = (value: any, resolve: (value?: any) => void) => resolve(value);
+
+/**
+ * Return a promise that resolves with the next emitted event, or with some future
+ * event as decided by an adapter.
+ *
+ * If specified, the adapter is a function that will be called with
+ * `(event, resolve, reject)`. It will be called once per event until it resolves or
+ * rejects.
+ *
+ * The default adapter is the passthrough function `(value, resolve) => resolve(value)`.
+ *
+ * @param event the event
+ * @param adapter controls resolution of the returned promise
+ * @returns a promise that resolves or rejects as specified by the adapter
+ */
+export function promiseFromEvent<T, U>(
+  event: Event<T>,
+  adapter: PromiseAdapter<T, U> = passthrough
+): { promise: Promise<U>; cancel: EventEmitter<void> } {
+  let subscription: Disposable;
+  let cancel = new EventEmitter<void>();
+
+  return {
+    promise: new Promise<U>((resolve, reject) => {
+      cancel.event((_) => reject('Cancelled'));
+      subscription = event((value: T) => {
+        try {
+          Promise.resolve(adapter(value, resolve, reject)).catch(reject);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }).then(
+      (result: U) => {
+        subscription.dispose();
+        return result;
+      },
+      (error) => {
+        subscription.dispose();
+        throw error;
+      }
+    ),
+    cancel,
+  };
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export function getConfiguration<T>(key: string): T | undefined {
+  return vscode.workspace.getConfiguration('codescene').get<T>(key);
+}
+
+/**
+ * Get the configured URL of the CodeScene server.
+ *
+ * TODO: it should be able to adapt to the user's choice of cloud or on-premises server.
+ */
+export function getServerUrl() {
+  return getConfiguration<string>('cloudUrl');
+}
+
+/**
+ * Get the configured API URL of the CodeScene server.
+ *
+ * TODO: it should be able to adapt to the user's choice of cloud or on-premises server.
+ */
+export function getServerApiUrl() {
+  return getConfiguration<string>('cloudApiUrl');
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,15 @@
 import * as vscode from 'vscode';
 
-export function getConfiguration<T>(key: string): T | undefined {
-  return vscode.workspace.getConfiguration('codescene').get<T>(key);
+export function getConfiguration<T>(section: string): T | undefined {
+  return vscode.workspace.getConfiguration('codescene').get<T>(section);
+}
+
+export function onDidChangeConfiguration(section: string, listener: (e: vscode.ConfigurationChangeEvent) => any) {
+  vscode.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration('codescene.' + section)) {
+      listener(e);
+    }
+  });
 }
 
 /**

--- a/src/coupling/coupling-data-provider.ts
+++ b/src/coupling/coupling-data-provider.ts
@@ -1,0 +1,141 @@
+/**
+ * Provides coupling information for the views that display couplings.
+ *
+ * For now, this is the couplings view in the Explorer panel and in the SCM panel.
+ *
+ * The data is cached and can be retrieved with the getData() method, or fetched again
+ * with the fetch() method.
+ */
+import * as vscode from 'vscode';
+import { Coupling, CsRestApi } from '../cs-rest-api';
+import { CsWorkspace } from '../workspace';
+import { Git } from '../git';
+import { difference } from '../utils';
+import { outputChannel } from '../log';
+
+export interface CouplingWithUri extends Coupling {
+  entityUri?: vscode.Uri;
+  coupledUri?: vscode.Uri;
+}
+
+export class CouplingDataProvider {
+  private dataChangedEmitter = new vscode.EventEmitter<void>();
+  private cachedData: CouplingWithUri[] | undefined = undefined;
+  private suppressError = false;
+
+  constructor(private git: Git, private csRestApi: CsRestApi, private csWorkspace: CsWorkspace) {
+    this.csWorkspace.onDidChangeProjectAssociation(() => this.fetch());
+  }
+
+  get onDidChangeData() {
+    return this.dataChangedEmitter.event;
+  }
+
+  async getData() {
+    if (this.cachedData === undefined) {
+      await this.fetch({ silent: true });
+    }
+    return this.cachedData;
+  }
+
+  async fetch(opts = { silent: false }) {
+    const projectId = this.csWorkspace.getProjectId();
+    if (!projectId) {
+      this.cachedData = undefined;
+    } else {
+      try {
+        const couplings = await this.csRestApi.fetchCouplings(projectId);
+        await this.validateRemoteRepoRoots(couplings);
+        await this.processAndCacheData(couplings);
+      } catch (e: any) {
+        if (!this.suppressError) {
+          const msg = e.message || 'Unknown error';
+          vscode.window.showErrorMessage(`CodeScene failed to fetch couplings from server: ${msg}`);
+          this.suppressError = true;
+        }
+      }
+    }
+    if (!opts.silent) {
+      this.dataChangedEmitter.fire();
+    }
+  }
+
+  /**
+   * Check if there are remote repo roots that cannot be mapped to a local
+   * workspace folder. The paths in analysis data in prefixed with the repository name,
+   * and we need to know which workspace folder this corresponds to (if any!)
+   *
+   * Another complicating factor is that the workspace folders might
+   * be sub folders of the repository root. For example, you might have opened
+   * a single folder within a huge mono repo.
+   */
+  private async validateRemoteRepoRoots(data: Coupling[]) {
+    // Remote repo roots are gathered from the first component of the coupling paths.
+    const remoteRepoRoots = new Set(data.map((coupling) => coupling.entity.split('/')[0]));
+
+    // Local repo roots are gathered from the git repos that contain the local workspace folders.
+    const workspaceFolders = vscode.workspace.workspaceFolders || [];
+    const localRepoNames = workspaceFolders.map((folder) => this.git.repoRootNameFromDirectory(folder.uri.fsPath));
+    const localRepoRoots = new Set(await Promise.all(localRepoNames));
+
+    const unmappedLocalRepos = difference(localRepoRoots, remoteRepoRoots);
+    const unmappedRemoteRepos = difference(remoteRepoRoots, localRepoRoots);
+
+    if (unmappedLocalRepos.size > 0 && unmappedRemoteRepos.size > 0) {
+      outputChannel.appendLine('Warning: The following local workspace folders are not mapped to a repository in the CodeScene project:');
+      unmappedLocalRepos.forEach((workspace) => outputChannel.appendLine(`  ${workspace}`));
+      outputChannel.appendLine('These are the unmapped repositories in the remote CodeScene project:');
+      unmappedRemoteRepos.forEach((repository) => outputChannel.appendLine(`  ${repository}`));
+      outputChannel.appendLine('Please make sure that the workspace folders and repositories names match.');
+    }
+  }
+
+  private async processAndCacheData(couplings: Coupling[]) {
+    // Couplings from the server are only unidirectional, but we want them to
+    // be bidirectional in the UI. So we duplicate the couplings and swap the
+    // entity and coupled fields.
+    const swappedCouplings = couplings.map((coupling) => {
+      return {
+        ...coupling,
+        entity: coupling.coupled,
+        coupled: coupling.entity,
+      };
+    });
+    const bidirectionalCouplings = couplings.concat(swappedCouplings);
+
+    this.cachedData = await this.resolveAbsolutePaths(bidirectionalCouplings);
+    this.cachedData.sort((a, b) => b.degree - a.degree);
+  }
+
+  private async resolveAbsolutePaths(couplings: Coupling[]) {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+
+    if (!workspaceFolders) return couplings;
+
+    const repoRoots = new Map<string, string>();
+
+    // Gather up the local repos so we might find where the coupled files are
+    for (const folder of workspaceFolders) {
+      const repoRoot = await this.git.repoRootFromDirectory(folder.uri.fsPath);
+      if (repoRoot) {
+        const repoRootName = repoRoot.split('/').pop();
+        if (!repoRootName) continue;
+        repoRoots.set(repoRootName, repoRoot);
+      }
+    }
+
+    return couplings.map((coupling) => {
+      const entityUri = this.resolveAbsolutePath(repoRoots, coupling.entity);
+      const coupledUri = this.resolveAbsolutePath(repoRoots, coupling.coupled);
+      return { ...coupling, entityUri, coupledUri };
+    });
+  }
+
+  private resolveAbsolutePath(repoRoots: Map<string, string>, relativePath: string) {
+    const couplingRepoRoot = relativePath.split('/')[0];
+    const couplingPathWithoutRepoRoot = relativePath.split('/').slice(1).join('/');
+    const repoRoot = repoRoots.get(couplingRepoRoot);
+    if (!repoRoot) return undefined;
+    return vscode.Uri.file(repoRoot + '/' + couplingPathWithoutRepoRoot);
+  }
+}

--- a/src/coupling/explorer-couplings-view.ts
+++ b/src/coupling/explorer-couplings-view.ts
@@ -1,0 +1,117 @@
+/**
+ * Shows couplings in the Explorer panel.
+ *
+ * The purpose of this view is to show the user which files are related to the one that is
+ * currently active in the editor. The user can jump to these files by clicking on them.
+ */
+import * as vscode from 'vscode';
+import { CouplingDataProvider } from './coupling-data-provider';
+import { CoupledEntity } from './model';
+
+export class ExplorerCouplingsView implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private treeDataProvider: CouplingTreeProvider;
+
+  constructor(couplingDataProvider: CouplingDataProvider) {
+    this.treeDataProvider = new CouplingTreeProvider(couplingDataProvider);
+
+    const view = vscode.window.createTreeView('codescene.explorerCouplingsView', {
+      treeDataProvider: this.treeDataProvider,
+      showCollapseAll: true,
+    });
+    this.disposables.push(view);
+
+    this.disposables.push(this.treeDataProvider.onDidChangeTreeData(() => {
+      // Show the currently active file in the description
+      const entityFilename = this.treeDataProvider.activeFileName;
+      view.description = entityFilename;
+    }));
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+}
+
+export class CouplingTreeProvider implements vscode.TreeDataProvider<CoupledEntity> {
+  private treeDataChangedEmitter = new vscode.EventEmitter<CoupledEntity | undefined | null | void>();
+
+  constructor(private couplingDataProvider: CouplingDataProvider) {
+    this.couplingDataProvider.onDidChangeData(() => this.treeDataChangedEmitter.fire());
+    vscode.window.onDidChangeActiveTextEditor(() => this.treeDataChangedEmitter.fire());
+  }
+
+  get onDidChangeTreeData() {
+    return this.treeDataChangedEmitter.event;
+  }
+
+  /**
+   * Get the uri of the currently active file.
+   */
+  get activeFile(): vscode.Uri | undefined {
+    const activeDocument = vscode.window.activeTextEditor?.document;
+    if (!activeDocument || activeDocument.uri.scheme !== 'file') return undefined;
+
+    return activeDocument.uri;
+  }
+
+  /**
+   * Gets the filename part of the currently active file.
+   *
+   * Example: src/foo/bar.ts -> bar.ts
+   */
+  get activeFileName(): string | undefined {
+    return this.activeFile?.path.split('/').pop();
+  }
+
+  getTreeItem(element: CoupledEntity): vscode.TreeItem {
+    const item = new vscode.TreeItem(element.entityName);
+
+    if (element.resourceUri) {
+      item.resourceUri = element.resourceUri;
+      item.label = undefined;
+    }
+
+    item.description = `${element.degree}%`;
+
+    if (item.resourceUri) {
+      item.command = {
+        command: 'vscode.open',
+        title: 'Open File',
+        arguments: [item.resourceUri],
+      };
+    }
+
+    const entityFilename = element.entityName.split('/').pop();
+    const parentFilename = this.activeFileName;
+
+    item.tooltip = new vscode.MarkdownString(
+      `**${entityFilename}** is coupled to **${parentFilename}** with a coupling degree of \`${element.degree}%\``
+    );
+
+    return item;
+  }
+
+  async getChildren(element?: CoupledEntity): Promise<CoupledEntity[]> {
+    if (element) {
+      return [];
+    } else {
+      const couplings = await this.couplingDataProvider.getData();
+      if (couplings === undefined || couplings.length === 0) return [];
+
+      const activeAbsolutePath = this.activeFile?.fsPath;
+      if (!activeAbsolutePath) return [];
+
+      const couplingsFromActiveFile = couplings.filter((coupling) => activeAbsolutePath.endsWith(coupling.entity));
+
+      return couplingsFromActiveFile.map((coupling) => {
+        return {
+          entityName: coupling.coupled,
+          resourceUri: coupling.coupledUri,
+          couplings: [],
+          degree: coupling.degree
+        };
+      });
+    }
+  }
+}

--- a/src/coupling/model.ts
+++ b/src/coupling/model.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+
+/**
+ * Represents a node in the tree views for coupled files.
+ */
+export interface CoupledEntity {
+  entityName: string;
+  resourceUri?: vscode.Uri;
+  couplings: CoupledEntity[];
+  parent?: CoupledEntity;
+  degree?: number;
+}

--- a/src/coupling/scm-couplings-view.ts
+++ b/src/coupling/scm-couplings-view.ts
@@ -1,0 +1,158 @@
+/**
+ * Shows couplings in the SCM view.
+ *
+ * The purpose of the view is to show couplings to files in the current change set, to
+ * remind the user of other files that might need to be changed. Therefore, couplings might
+ * not be shown if the coupled file is already in the change set.
+ */
+import * as vscode from 'vscode';
+import { groupByProperty } from '../utils';
+import { Git } from '../git';
+import { outputChannel } from '../log';
+import { CouplingDataProvider, CouplingWithUri } from './coupling-data-provider';
+import { CoupledEntity } from './model';
+
+export class ScmCouplingsView implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private treeDataProvider: CouplingTreeProvider;
+
+  constructor(private git: Git, couplingDataProvider: CouplingDataProvider) {
+    this.treeDataProvider = new CouplingTreeProvider(git, couplingDataProvider);
+
+    const view = vscode.window.createTreeView('codescene.scmCouplingsView', {
+      treeDataProvider: this.treeDataProvider,
+      showCollapseAll: true,
+    });
+    this.disposables.push(view);
+
+    const openCmd = vscode.commands.registerCommand('codescene.scmCouplingsView.open', (item: CoupledEntity) => {
+      vscode.commands.executeCommand('vscode.open', item.resourceUri);
+    });
+    this.disposables.push(openCmd);
+
+    const refreshCmd = vscode.commands.registerCommand('codescene.scmCouplingsView.refresh', () => this.refresh());
+    this.disposables.push(refreshCmd);
+
+    // Refresh view on certain events
+    this.disposables.push(
+      this.git.onDidModifyChangeSet(() => {
+        outputChannel.appendLine('Change set modified, refreshing coupling tree view');
+        this.treeDataProvider.refresh();
+      })
+    );
+
+    view.description = 'Other files that are often changed';
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+
+  /**
+   * Refetch the couplings from the server and refresh the tree view.
+   */
+  async refresh() {
+    await this.treeDataProvider.refresh({ fetchFromServer: true });
+  }
+}
+
+export class CouplingTreeProvider implements vscode.TreeDataProvider<CoupledEntity> {
+  private treeDataChangedEmitter = new vscode.EventEmitter<CoupledEntity | undefined | null | void>();
+
+  constructor(private git: Git, private couplingDataProvider: CouplingDataProvider) {
+    this.couplingDataProvider.onDidChangeData(() => this.treeDataChangedEmitter.fire());
+  }
+
+  get onDidChangeTreeData() {
+    return this.treeDataChangedEmitter.event;
+  }
+
+  getTreeItem(element: CoupledEntity): vscode.TreeItem {
+    const item = new vscode.TreeItem(
+      element.entityName,
+      element.couplings?.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None
+    );
+
+    if (element.resourceUri) {
+      item.resourceUri = element.resourceUri;
+      item.label = undefined;
+    }
+
+    // Leaf node
+    if (element.couplings?.length === 0) {
+      item.description = `${element.degree}%`;
+
+      if (item.resourceUri) {
+        item.command = {
+          command: 'vscode.open',
+          title: 'Open File',
+          arguments: [item.resourceUri],
+        };
+      }
+
+      const entityFilename = element.entityName.split('/').pop();
+      const parentFilename = element.parent?.entityName.split('/').pop();
+
+      item.tooltip = new vscode.MarkdownString(
+        `**${entityFilename}** is coupled to **${parentFilename}** with a coupling degree of \`${element.degree}%\``
+      );
+    } else {
+      item.contextValue = 'rootItem';
+    }
+
+    return item;
+  }
+
+  async getChildren(element?: CoupledEntity): Promise<CoupledEntity[]> {
+    if (element) {
+      return element.couplings;
+    } else {
+      // No need to bother with executing git etc if there are no couplings
+      const couplings = await this.couplingDataProvider.getData();
+      if (couplings === undefined || couplings.length === 0) return [];
+
+      const changeSet = await this.git.changeSet();
+      const couplingsInChangeSet = couplings.filter(
+        // Because the purpose of the view is to show file you might have forgot to change
+        // we remove those couplings where the coupled file is already in the change set.
+        (coupling) => changeSet.has(coupling.entity) && !changeSet.has(coupling.coupled)
+      );
+      return buildTree(couplingsInChangeSet);
+    }
+  }
+
+  async refresh(opts = { fetchFromServer: false }) {
+    if (opts.fetchFromServer) {
+      // This will indirectly cause treeDataChangedEmitter.fire() to be called
+      await this.couplingDataProvider.fetch();
+    } else {
+      this.treeDataChangedEmitter.fire();
+    }
+  }
+}
+
+function buildTree(couplings: CouplingWithUri[]): CoupledEntity[] {
+  const grouped = groupByProperty(couplings, 'entity');
+
+  const entities = Object.keys(grouped).map((entityName) => {
+    const couplings = grouped[entityName].map((coupling) => {
+      const entity: CoupledEntity = {
+        entityName: coupling.coupled,
+        resourceUri: coupling.coupledUri,
+        couplings: [],
+        degree: coupling.degree,
+      };
+      return entity;
+    });
+    const resourceUri = grouped[entityName][0].entityUri;
+    const entity: CoupledEntity = {
+      entityName,
+      resourceUri,
+      couplings,
+    };
+    entity.couplings.forEach((coupling) => (coupling.parent = entity));
+    return entity;
+  });
+
+  return entities;
+}

--- a/src/cs-rest-api.ts
+++ b/src/cs-rest-api.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import axios, { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { AUTH_TYPE } from './auth/auth-provider';
+import { outputChannel } from './log';
+import { getServerApiUrl } from './configuration';
+
+export interface Coupling {
+  entity: string;
+  coupled: string;
+  degree: number;
+  averageRevs: number;
+}
+
+export class CsRestApi {
+  private axiosInstance: AxiosInstance;
+
+  constructor() {
+    this.axiosInstance = axios.create({
+      timeout: 5000,
+    });
+
+    const getToken = async () => {
+      const session = await vscode.authentication.getSession(AUTH_TYPE, [], { createIfNone: false });
+      if (session) {
+        return session.accessToken;
+      }
+    };
+
+    this.axiosInstance.interceptors.request.use(
+      async (config: InternalAxiosRequestConfig) => {
+        const token = await getToken();
+        const baseUrl = getServerApiUrl() + '/v2/devtools';
+        if (config.url && config.url.startsWith(baseUrl)) {
+          config.headers['Accept'] = 'application/json';
+          config.headers['Authorization'] = `Bearer ${token}`;
+        }
+
+        return config;
+      },
+      (error) => {
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  private async fetchJson<T>(url: string) {
+    const response = await this.axiosInstance.get(url);
+    outputChannel.appendLine(`GET ${url} ${response.status}`);
+    return response.data as T;
+  }
+
+
+  async fetchCouplings(projectId: number) {
+    const couplingsUrl = `${getServerApiUrl()}/v2/devtools/projects/${projectId}/couplings`;
+
+    const rawData = await this.fetchJson<{ [key: string]: any }[]>(couplingsUrl);
+
+    rawData.forEach((entity) => {
+      entity.averageRevs = entity['average_revs'];
+      delete entity['average_revs'];
+    });
+
+    const data = rawData as Coupling[];
+
+    return data;
+  }
+
+  async fetchProjects() {
+    const projectsUrl = getServerApiUrl() + '/v2/devtools/projects';
+    return await this.fetchJson<{ id: number; name: string }[]>(projectsUrl);
+  }
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,142 @@
+/**
+ * Interface to various git functions.
+ *
+ * It keeps track of changes to the git change set and emits an event when it changes. This
+ * is used to refresh e.g. the couplings view in the SCM panel.
+ */
+import * as vscode from 'vscode';
+import { SimpleExecutor } from './executor';
+import { dirname } from 'path';
+import debounce = require('lodash.debounce');
+
+export class Git implements vscode.Disposable {
+  private changeSetModifiedEmitter = new vscode.EventEmitter<void>();
+  private gitIgnoreCache = new Map<string, boolean>();
+  private disposables: vscode.Disposable[] = [];
+
+  constructor() {
+    const watcher = vscode.workspace.createFileSystemWatcher('**/.gitignore');
+    watcher.onDidChange(() => this.clearIgnoreCache());
+    watcher.onDidCreate(() => this.clearIgnoreCache());
+    watcher.onDidDelete(() => this.clearIgnoreCache());
+
+    const debouncedFire = debounce(() => this.changeSetModifiedEmitter.fire(), 2500);
+
+    const fileWatcherCallback = async (file: vscode.Uri) => {
+      if (await this.isIgnored(file, { throwOnFailure: true })) {
+        return;
+      }
+      debouncedFire();
+    };
+
+    // This can be a very noisy file watcher! We need to take care!
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher('**/*');
+    this.disposables.push(fileSystemWatcher.onDidChange(fileWatcherCallback));
+    this.disposables.push(fileSystemWatcher.onDidCreate(fileWatcherCallback));
+    this.disposables.push(fileSystemWatcher.onDidDelete(fileWatcherCallback));
+
+    const gitWatcher = vscode.workspace.createFileSystemWatcher('**/.git/index*');
+    this.disposables.push(gitWatcher.onDidCreate(debouncedFire));
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+
+  /**
+   * Fires when the files under git control have changed.
+   *
+   * This is somewhat of a best effort.
+   */
+  get onDidModifyChangeSet() {
+    return this.changeSetModifiedEmitter.event;
+  }
+
+  private clearIgnoreCache() {
+    this.gitIgnoreCache = new Map<string, boolean>();
+  }
+
+  async changeSet() {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    const changeSet = new Set<string>();
+
+    if (!workspaceFolders) return changeSet;
+
+    const executor = new SimpleExecutor();
+
+    for (const workspaceFolder of workspaceFolders) {
+      const workspacePath = workspaceFolder.uri.fsPath;
+
+      const result = await executor.execute(
+        { command: 'git', args: ['diff', '--name-only'], ignoreError: true },
+        { cwd: workspacePath }
+      );
+
+      if (result.exitCode !== 0) {
+        console.log(`git diff failed with exit code ${result.exitCode}`);
+        continue;
+      }
+
+      const files = result.stdout
+        .split('\n')
+        .map((f) => f.trim())
+        .filter((f) => f.length > 0);
+
+      const repoRootName = await this.repoRootNameFromDirectory(workspacePath);
+
+      for (const file of files) {
+        changeSet.add(`${repoRootName}/${file}`);
+      }
+    }
+
+    return changeSet;
+  }
+
+  async isIgnored(file: vscode.Uri | vscode.TextDocument, opts = { throwOnFailure: false }) {
+    const executor = new SimpleExecutor();
+
+    let filePath;
+    if (file instanceof vscode.Uri) {
+      filePath = file.fsPath;
+    } else {
+      filePath = file.uri.fsPath;
+    }
+
+    if (this.gitIgnoreCache.has(filePath)) {
+      return this.gitIgnoreCache.get(filePath);
+    }
+
+    const result = await executor.execute(
+      { command: 'git', args: ['check-ignore', filePath], ignoreError: true },
+      { cwd: dirname(filePath) }
+    );
+
+    // This happens when the file is not in a git repository.
+    if (opts.throwOnFailure && result.exitCode === 128) {
+      throw new Error(`git check-ignore failed with exit code ${result.exitCode}`);
+    }
+
+    const ignored = result.exitCode === 0;
+
+    this.gitIgnoreCache.set(filePath, ignored);
+
+    return ignored;
+  }
+
+  async repoRootFromDirectory(dir: string) {
+    const executor = new SimpleExecutor();
+
+    const result = await executor.execute({ command: 'git', args: ['rev-parse', '--show-toplevel'] }, { cwd: dir });
+
+    if (result.exitCode !== 0) {
+      throw new Error(`git rev-parse failed with exit code ${result.exitCode}`);
+    }
+
+    return result.stdout.trim();
+  }
+
+  async repoRootNameFromDirectory(dir: string) {
+    const repoRoot = await this.repoRootFromDirectory(dir);
+    return repoRoot.split('/').pop();
+  }
+}

--- a/src/links.ts
+++ b/src/links.ts
@@ -4,6 +4,9 @@ import { CsWorkspace } from './workspace';
 import { getServerUrl } from './configuration';
 import { CoupledEntity } from './coupling/model';
 
+/**
+ * Registers commands for opening CodeScene links in the browser.
+ */
 export class Links implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
 

--- a/src/links.ts
+++ b/src/links.ts
@@ -1,0 +1,90 @@
+import * as vscode from 'vscode';
+
+import { CsWorkspace } from './workspace';
+import { getServerUrl } from './configuration';
+import { CoupledEntity } from './coupling/model';
+
+export class Links implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+
+  constructor(private codeSceneWorkspace: CsWorkspace) {
+    this.disposables.push(
+      vscode.commands.registerCommand('codescene.openDashboard', () => {
+        this.openDashboard();
+      }),
+      vscode.commands.registerCommand('codescene.openHotspots', () => {
+        this.openHotspots();
+      }),
+      vscode.commands.registerCommand('codescene.openChangeCoupling', () => {
+        this.openChangeCoupling();
+      }),
+      vscode.commands.registerCommand('codescene.openCodeReview', async (file: vscode.Uri | CoupledEntity) => {
+        let uri = file instanceof vscode.Uri ? file : file.resourceUri;
+        if (!uri) return;
+
+        const csFilePath = await this.codeSceneWorkspace.getCsFilePath(uri);
+        if (!csFilePath) return;
+
+        this.openCodeReview(csFilePath);
+      }),
+      vscode.commands.registerCommand('codescene.openXRay', async (file: vscode.Uri | CoupledEntity) => {
+        let uri = file instanceof vscode.Uri ? file : file.resourceUri;
+        if (!uri) return;
+
+        const csFilePath = await this.codeSceneWorkspace.getCsFilePath(uri);
+        if (!csFilePath) return;
+
+        this.openXRay(csFilePath);
+      })
+    );
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+
+  private withProjectId(callback: (projectId: number) => void) {
+    const projectId = this.codeSceneWorkspace.getProjectId();
+
+    if (!projectId) {
+      return;
+    }
+
+    callback(projectId);
+  }
+
+  openDashboard() {
+    this.withProjectId((projectId) => {
+      const dashboardUrl = `${getServerUrl()}/projects/${projectId}`;
+      vscode.env.openExternal(vscode.Uri.parse(dashboardUrl));
+    });
+  }
+
+  openHotspots() {
+    this.withProjectId((projectId) => {
+      const hotspotsUrl = `${getServerUrl()}/projects/${projectId}/jobs/latest-successful/results/code/hotspots/system-map`;
+      vscode.env.openExternal(vscode.Uri.parse(hotspotsUrl));
+    });
+  }
+
+  openChangeCoupling() {
+    this.withProjectId((projectId) => {
+      const changeCouplingUrl = `${getServerUrl()}/projects/${projectId}/jobs/latest-successful/results/code/temporal-coupling/by-commits`;
+      vscode.env.openExternal(vscode.Uri.parse(changeCouplingUrl));
+    });
+  }
+
+  openCodeReview(filePathInRepo: string) {
+    this.withProjectId((projectId) => {
+      const codeReviewUrl = `${getServerUrl()}/projects/${projectId}/jobs/latest-successful/results/code/hotspots/biomarkers?name=${filePathInRepo}`;
+      vscode.env.openExternal(vscode.Uri.parse(codeReviewUrl));
+    });
+  }
+
+  openXRay(filePathInRepo: string) {
+    this.withProjectId((projectId) => {
+      const xrayUrl = `${getServerUrl()}/projects/${projectId}/jobs/latest-successful/results/files/hotspots?file-name=${filePathInRepo}`;
+      vscode.env.openExternal(vscode.Uri.parse(xrayUrl));
+    });
+  }
+}

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -95,7 +95,7 @@ export class CachingReviewer implements Reviewer {
  *
  * If git is not installed, or if the current document is not part of workspace
  * (i.e. it's opened as a standalone file), then this reviewer will basically be
- * downgraded to the injected reviewer.
+ * downgraded to the injected reviewer (which for normal use is the CachingReviewer)
  */
 export class FilteringReviewer implements Reviewer {
   private gitExecutor: SimpleExecutor | null = null;

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 
-import { getFileExtension, getFileNameWithoutExtension, getFunctionNameRange } from '../../utils';
+import { getFileExtension, getFileNameWithoutExtension, getFunctionNameRange, rankNamesBy } from '../../utils';
 
 suite('Utils Test Suite', () => {
   test('getFileExtension', () => {
@@ -26,5 +26,23 @@ suite('Utils Test Suite', () => {
     // If the actual line contains the full name including the period, we should match the full name.
     // Perhaps the language supports using periods in function names.
     assert.deepStrictEqual(getFunctionNameRange('    public weird.name() {', 'weird.name'), [11, 21]);
+  });
+
+  test('rankNamesBy - best match first', () => {
+    const names = ['foo', 'bar', 'baz', 'foobar', 'bazbar'];
+    const match = 'foo';
+    const expected = ['foo', 'foobar', 'bar', 'baz', 'bazbar'];
+    const actual = names.slice();
+    rankNamesBy(match, actual);
+    assert.deepStrictEqual(actual, expected);
+  });
+
+  test('rankNamesBy - case insensitive', () => {
+    const names = ['foo', 'bar', 'baz', 'foobar', 'bazbar'];
+    const match = 'FOO';
+    const expected = ['foo', 'foobar', 'bar', 'baz', 'bazbar'];
+    const actual = names.slice();
+    rankNamesBy(match, actual);
+    assert.deepStrictEqual(actual, expected);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,45 @@ export function getFileNameWithoutExtension(filename: string) {
 export function isDefined<T>(value: T | undefined): value is T {
   return value !== undefined;
 }
+
+export function groupByProperty<T>(arr: T[], property: keyof T): { [k: string]: T[] } {
+  const result: { [k: string]: T[] } = {};
+
+  for (const obj of arr) {
+    const key = String(obj[property]);
+
+    if (key in result) {
+      result[key].push(obj);
+    } else {
+      result[key] = [obj];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Rank name by how well they match the argument `match`.
+ */
+export function rankNamesBy(match: string, names: string[]): void {
+  let matchLower = match.toLowerCase();
+  names.sort((a: string, b: string) => {
+    const al = a.toLowerCase();
+    const bl = b.toLowerCase();
+
+    const isMatch = (match: string, s: string) => {
+      return match.includes(s) || s.includes(match);
+    };
+
+    if (isMatch(matchLower, al) && !isMatch(matchLower, bl)) {
+      return -1;
+    } else if (!isMatch(matchLower, al) && isMatch(matchLower, bl)) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
+export function difference<T>(a: Set<T>, b: Set<T>) {
+  return new Set([...a].filter((x) => !b.has(x)));
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,120 @@
+/**
+ * A workspace in vscode is the currently opened folder(s). You can also store settings in the workspace state.
+ * We store for example the project id for the corresponding project on the CodeScene server (if one is associated).
+ */
+import * as vscode from 'vscode';
+import { rankNamesBy } from './utils';
+import { CsRestApi } from './cs-rest-api';
+import { dirname } from 'path';
+import { SimpleExecutor } from './executor';
+
+export class CsWorkspace implements vscode.Disposable {
+  private disposables: vscode.Disposable[] = [];
+  private projectAssociationChangedEmitter = new vscode.EventEmitter<number | undefined>();
+
+  constructor(private context: vscode.ExtensionContext, private csRestApi: CsRestApi) {
+    const associateCmd = vscode.commands.registerCommand('codescene.associateWithProject', async () => {
+      await this.associateWithProject();
+    });
+    this.disposables.push(associateCmd);
+
+    const projectId = this.getProjectId();
+    this.updateIsWorkspaceAssociatedContext(projectId);
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+
+  /**
+   * Emitted when the user associates their vs code workspace with a project on the CodeScene server.
+   */
+  get onDidChangeProjectAssociation() {
+    return this.projectAssociationChangedEmitter.event;
+  }
+
+  getProjectId(): number | undefined {
+    return this.context.workspaceState.get('codescene.projectId');
+  }
+
+  async associateWithProject() {
+    const projects = await this.csRestApi.fetchProjects();
+
+    const quickPickList = projects.map((p) => p.name);
+
+    const workspaceName = vscode.workspace.name;
+    if (workspaceName) {
+      rankNamesBy(workspaceName, quickPickList);
+    }
+
+    const picked = await vscode.window.showQuickPick(quickPickList, {
+      placeHolder: 'Select a project to associate with',
+    });
+
+    if (!picked) {
+      return;
+    }
+
+    const project = projects.find((p) => p.name === picked);
+
+    if (!project) {
+      return;
+    }
+
+    // Store the project id in the workspace state (makes it retreivable via getProjectId())
+    this.updateIsWorkspaceAssociatedContext(project.id);
+  }
+
+  /**
+   * Updates the codescene.isWorkspaceAssociated context variable. This can be used in package.json to conditionally enable/disable views.
+   */
+  private updateIsWorkspaceAssociatedContext(projectId: number | undefined) {
+    this.context.workspaceState.update('codescene.projectId', projectId);
+    vscode.commands.executeCommand('setContext', 'codescene.isWorkspaceAssociated', projectId !== undefined);
+    this.projectAssociationChangedEmitter.fire(undefined);
+  }
+
+  clearProjectAssociation() {
+    this.updateIsWorkspaceAssociatedContext(undefined);
+  }
+
+  /**
+   * Updates the codescene.isLoggedIn context variable. This can be used in package.json to conditionally enable/disable views.
+   */
+  updateIsLoggedInContext(loggedIn: boolean) {
+    vscode.commands.executeCommand('setContext', 'codescene.isLoggedIn', loggedIn);
+  }
+
+  /**
+   * Project path here means the path used by the codescene server to denote the file.
+   *
+   * This is a relative file path with the repo name as the root. E.g. codescene-vscode/src/extension.ts.
+   */
+  async getCsFilePath(absoluteFilePath: vscode.Uri) {
+    const fileDir = dirname(absoluteFilePath.fsPath);
+    const executor = new SimpleExecutor();
+
+    const repoRoot = await executor.execute(
+      { command: 'git', args: ['rev-parse', '--show-toplevel'] },
+      { cwd: fileDir }
+    );
+
+    if (repoRoot.exitCode !== 0) {
+      return;
+    }
+
+    const repoRelativePath = await executor.execute(
+      { command: 'git', args: ['ls-files', '--full-name', '--', absoluteFilePath.fsPath] },
+      { cwd: fileDir }
+    );
+
+    if (repoRelativePath.exitCode !== 0) {
+      return;
+    }
+
+    const repoRootName = repoRoot.stdout.trim().split('/').pop();
+    const relativePath = repoRelativePath.stdout.trim();
+
+    return `${repoRootName}/${relativePath}`;
+  }
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -86,6 +86,13 @@ export class CsWorkspace implements vscode.Disposable {
   }
 
   /**
+   * Updates the codescene.remoteFeaturesEnabled context variable. This can be used in package.json to conditionally enable/disable views.
+   */
+  updateRemoteFeatureEnabledContext(enable: boolean) {
+    vscode.commands.executeCommand('setContext', 'codescene.remoteFeaturesEnabled', enable);
+  }
+
+  /**
    * Project path here means the path used by the codescene server to denote the file.
    *
    * This is a relative file path with the repo name as the root. E.g. codescene-vscode/src/extension.ts.


### PR DESCRIPTION
This is a work in progress for more advanced CodeScene integration. It adds the ability to log in (either on a free or paid account) and associate your VS code project to a project on the CodeScene server. This enables us to access already performed costly analyses that we can display in the editor. The first release is initially quite basic:

- Login to Cloud
- Fetch change coupling data and display in editor
- Maybe some shortcut commands to access certain pages in the web app 

Check before merge:

- [ ] Remove unnecessary prints to output channel
- [x] Squash and create good commit message for changelog