### PR TITLE
Change Coupling mapping improvement

### DIFF
--- a/src/coupling/coupling-data-provider.ts
+++ b/src/coupling/coupling-data-provider.ts
@@ -45,8 +45,9 @@ export class CouplingDataProvider {
     } else {
       try {
         const couplings = await this.csRestApi.fetchCouplings(projectId);
-        await this.validateRemoteRepoRoots(couplings);
-        await this.processAndCacheData(couplings);
+        const localRepoRoots = await this.localRepoRoots();
+        const repoNameAgnostic = await this.validateRepoRoots(couplings, localRepoRoots);
+        await this.processAndCacheData(couplings, localRepoRoots, repoNameAgnostic);
       } catch (e: any) {
         if (!this.suppressError) {
           const msg = e.message || 'Unknown error';
@@ -61,60 +62,13 @@ export class CouplingDataProvider {
   }
 
   /**
-   * Check if there are remote repo roots that cannot be mapped to a local
-   * workspace folder. The paths in analysis data in prefixed with the repository name,
-   * and we need to know which workspace folder this corresponds to (if any!)
-   *
-   * Another complicating factor is that the workspace folders might
-   * be sub folders of the repository root. For example, you might have opened
-   * a single folder within a huge mono repo.
+   * Local repo roots are gathered from the git repos that contain the local workspace folders.
+   * @returns 
    */
-  private async validateRemoteRepoRoots(data: Coupling[]) {
-    // Remote repo roots are gathered from the first component of the coupling paths.
-    const remoteRepoRoots = new Set(data.map((coupling) => coupling.entity.split('/')[0]));
-
-    // Local repo roots are gathered from the git repos that contain the local workspace folders.
+  private async localRepoRoots() {
     const workspaceFolders = vscode.workspace.workspaceFolders || [];
-    const localRepoNames = workspaceFolders.map((folder) => this.git.repoRootNameFromDirectory(folder.uri.fsPath));
-    const localRepoRoots = new Set(await Promise.all(localRepoNames));
-
-    const unmappedLocalRepos = difference(localRepoRoots, remoteRepoRoots);
-    const unmappedRemoteRepos = difference(remoteRepoRoots, localRepoRoots);
-
-    if (unmappedLocalRepos.size > 0 && unmappedRemoteRepos.size > 0) {
-      outputChannel.appendLine('Warning: The following local workspace folders are not mapped to a repository in the CodeScene project:');
-      unmappedLocalRepos.forEach((workspace) => outputChannel.appendLine(`  ${workspace}`));
-      outputChannel.appendLine('These are the unmapped repositories in the remote CodeScene project:');
-      unmappedRemoteRepos.forEach((repository) => outputChannel.appendLine(`  ${repository}`));
-      outputChannel.appendLine('Please make sure that the workspace folders and repositories names match.');
-    }
-  }
-
-  private async processAndCacheData(couplings: Coupling[]) {
-    // Couplings from the server are only unidirectional, but we want them to
-    // be bidirectional in the UI. So we duplicate the couplings and swap the
-    // entity and coupled fields.
-    const swappedCouplings = couplings.map((coupling) => {
-      return {
-        ...coupling,
-        entity: coupling.coupled,
-        coupled: coupling.entity,
-      };
-    });
-    const bidirectionalCouplings = couplings.concat(swappedCouplings);
-
-    this.cachedData = await this.resolveAbsolutePaths(bidirectionalCouplings);
-    this.cachedData.sort((a, b) => b.degree - a.degree);
-  }
-
-  private async resolveAbsolutePaths(couplings: Coupling[]) {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-
-    if (!workspaceFolders) return couplings;
-
     const repoRoots = new Map<string, string>();
 
-    // Gather up the local repos so we might find where the coupled files are
     for (const folder of workspaceFolders) {
       const repoRoot = await this.git.repoRootFromDirectory(folder.uri.fsPath);
       if (repoRoot) {
@@ -123,19 +77,121 @@ export class CouplingDataProvider {
         repoRoots.set(repoRootName, repoRoot);
       }
     }
+    return repoRoots;
+  }
+
+  /**
+   * Check if there are remote repo roots that cannot be mapped to a local
+   * workspace folder. The paths in analysis data in prefixed with the repository name,
+   * and we need to know which workspace folder this corresponds to (if any!)
+   *
+   * Another complicating factor is that the workspace folders might
+   * be sub folders of the repository root. For example, you might have opened
+   * a single folder within a huge mono repo.
+   * 
+   * In the special case there's a one-to-one mapping of remote repositories in the 
+   * CodeScene project to one local repo in the workspace this function returns true. 
+   * This indicates that we can match the change coupling paths without requiring that
+   * the workspace folder(s) matches the repository path(s).
+   */
+  private async validateRepoRoots(couplings: Coupling[], localRepoRoots: Map<string, string>) {
+    // Remote repo roots are gathered from the first component of the coupling entity paths.
+    const remoteRepoRootNames = new Set(couplings
+      .map(({ entity }) => this.splitCouplingPath(entity))
+      .map(({ root }) => root));
+    const localRepoRootNames = new Set(localRepoRoots.keys());
+
+    const unmappedLocalRepos = difference(localRepoRootNames, remoteRepoRootNames);
+    const unmappedRemoteRepos = difference(remoteRepoRootNames, localRepoRootNames);
+
+    if (remoteRepoRootNames.size === 1 && localRepoRootNames.size === 1) {
+      // When there's exactly one of both local and remote repo roots, we can assume it's intentional,
+      // even if the root names don't match. Will go down the simple path resolution code-path.
+      outputChannel.appendLine(`Info: Change Coupling assuming one-to-one mapping of remote CodeScene repo "
+      ${Array.from(remoteRepoRootNames)[0]}" and local git root "${Array.from(localRepoRootNames)[0]}".`);
+      return true;
+    }
+
+    if (unmappedLocalRepos.size > 0 && unmappedRemoteRepos.size > 0) {
+      outputChannel.appendLine('Warning: The following local workspace folders are not mapped to a repository in the CodeScene project:');
+      unmappedLocalRepos.forEach((workspace) => outputChannel.appendLine(`  ${workspace}`));
+      outputChannel.appendLine('These are the unmapped repositories in the remote CodeScene project:');
+      unmappedRemoteRepos.forEach((repository) => outputChannel.appendLine(`  ${repository}`));
+      outputChannel.appendLine('Please make sure that the workspace folders and repositories names match.');
+    }
+    return false;
+  }
+
+  private async processAndCacheData(couplings: Coupling[], localRepoRoots: Map<string, string>, repoNameAgnostic: boolean) {
+    const bidirectionalCouplings = this.createBidirectionalCouplings(couplings);
+    if (repoNameAgnostic) {
+      const repoNameAgnosticCouplings = bidirectionalCouplings.map((coupling) => {
+        const { path: entityPath } = this.splitCouplingPath(coupling.entity);
+        const { path: coupledPath } = this.splitCouplingPath(coupling.coupled);
+        return {
+          ...coupling,
+          entity: entityPath,
+          coupled: coupledPath,
+        };
+      });
+      this.cachedData = await this.resolveAbsolutePathsSimple(repoNameAgnosticCouplings, localRepoRoots);
+    } else {
+      this.cachedData = await this.resolveAbsolutePaths(bidirectionalCouplings, localRepoRoots);
+    }
+    this.cachedData.sort((a, b) => b.degree - a.degree);
+  }
+
+  /**
+   * Couplings from the server are only unidirectional, but we want them to
+   * be bidirectional in the UI. So we duplicate the couplings and swap the
+   * entity and coupled fields.
+   * @param couplings    
+   * @returns 
+   */
+  private createBidirectionalCouplings(couplings: Coupling[]) {
+    const swappedCouplings = couplings.map((coupling) => {
+      return {
+        ...coupling,
+        entity: coupling.coupled,
+        coupled: coupling.entity,
+      };
+    });
+    return couplings.concat(swappedCouplings);
+  }
+
+  private async resolveAbsolutePathsSimple(couplings: Coupling[], localRepoRoots: Map<string, string>) {
+    if (localRepoRoots.size === 0) return couplings;
+    const singleRepoRoot = Array.from(localRepoRoots.values())[0];
 
     return couplings.map((coupling) => {
-      const entityUri = this.resolveAbsolutePath(repoRoots, coupling.entity);
-      const coupledUri = this.resolveAbsolutePath(repoRoots, coupling.coupled);
+      const entityUri = vscode.Uri.file(singleRepoRoot + '/' + coupling.entity);
+      const coupledUri = vscode.Uri.file(singleRepoRoot + '/' + coupling.coupled);
       return { ...coupling, entityUri, coupledUri };
     });
   }
 
-  private resolveAbsolutePath(repoRoots: Map<string, string>, relativePath: string) {
-    const couplingRepoRoot = relativePath.split('/')[0];
-    const couplingPathWithoutRepoRoot = relativePath.split('/').slice(1).join('/');
-    const repoRoot = repoRoots.get(couplingRepoRoot);
+  private async resolveAbsolutePaths(couplings: Coupling[], localRepoRoots: Map<string, string>) {
+    if (localRepoRoots.size === 0) { return couplings; }
+
+    return couplings.map((coupling) => {
+      const entityUri = this.resolveAbsolutePath(localRepoRoots, coupling.entity);
+      const coupledUri = this.resolveAbsolutePath(localRepoRoots, coupling.coupled);
+      return { ...coupling, entityUri, coupledUri };
+    });
+  }
+
+  private resolveAbsolutePath(localRepoRoots: Map<string, string>, couplingPath: string) {
+    const { root, path } = this.splitCouplingPath(couplingPath);
+    const repoRoot = localRepoRoots.get(root);
     if (!repoRoot) return undefined;
-    return vscode.Uri.file(repoRoot + '/' + couplingPathWithoutRepoRoot);
+    return vscode.Uri.file(repoRoot + '/' + path);
+  }
+
+  private splitCouplingPath(couplingPath: string) {
+    return {
+      root: couplingPath.split('/')[0],
+      path: couplingPath.split('/').slice(1).join('/')
+    };
   }
 }
+


### PR DESCRIPTION
### Problem
The Change Coupling presentation currently depends on local git projects being checked out to their default directories - for example `codescene-vscode/`. Since both VSCode workspaces and CodeScene projects can contain multiple git repos, we effectively need to match many-to-many. To keep things fairly simple, we therefore require the repo root names to match.

With this in mind, having a project checked out to a custom directory - either manually or using git worktree - will cause this matching to fail, and no CC data will be presented.

### Solution
To somewhat remedy this, we implement a simpler code-path for projects/workspace combinations where a clear one-to-one mapping can be made. That is, when there's only one repository in the CodeScene project, and only one git root among
the VSCode workspace folders. In that (rather common) case we assume that all couplings returned correspond to files in the open VSCode workspace - allowing us to match regardless of local directory name.
