### PR TITLE
Bump to node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20
     - run: npm install
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'


### PR DESCRIPTION
Upgrading github actions to versions using Node 20.

Bump node-version to use Node 20 in both build, release and test scripts