### PR TITLE
chore: Add a telemetry log to examine refactor usage

### DIFF
--- a/src/refactoring/cs-refactoring-requests.ts
+++ b/src/refactoring/cs-refactoring-requests.ts
@@ -6,6 +6,7 @@ import { logOutputChannel } from '../log';
 import { isDefined, rangeStr } from '../utils';
 import { CsRefactorCodeLensProvider } from './codelens';
 import { FnToRefactor } from './command';
+import Telemetry from '../telemetry';
 
 export class CsRefactoringRequest {
   fnToRefactor: FnToRefactor;
@@ -24,6 +25,7 @@ export class CsRefactoringRequest {
   }
 
   post(csRestApi: CsRestApi, diagnostics: Diagnostic[]) {
+    Telemetry.instance.logUsage('codescene.vscode.refactor/request', { 'trace-id': this.traceId });
     logOutputChannel.debug(`Refactor request for ${this.logIdString(this.traceId, this.fnToRefactor)}`);
     this.refactorResponse = csRestApi
       .fetchRefactoring(diagnostics, this.fnToRefactor, this.traceId, this.abortController.signal)

--- a/src/refactoring/refactoring-panel.ts
+++ b/src/refactoring/refactoring-panel.ts
@@ -18,6 +18,7 @@ import { getLogoUrl } from '../utils';
 import { nonce } from '../webviews/utils';
 import { refactoringSymbol, toConfidenceSymbol } from './command';
 import { CsRefactoringRequest, CsRefactoringRequests } from './cs-refactoring-requests';
+import Telemetry from '../telemetry';
 
 interface CurrentRefactorState {
   request: CsRefactoringRequest;
@@ -60,6 +61,7 @@ export class RefactoringPanel {
         switch (message.command) {
           case 'apply':
             await this.applyRefactoring(refactoringState);
+            Telemetry.instance.logUsage('codescene.vscode.refactor/applied', {'trace-id': refactoringState.request.traceId});
             vscode.window.setStatusBarMessage(`$(sparkle) Successfully applied refactoring`, 3000);
             this.dispose();
             return;
@@ -73,6 +75,7 @@ export class RefactoringPanel {
             return;
           case 'show-diff':
             await this.showDiff(refactoringState);
+            Telemetry.instance.logUsage('codescene.vscode.refactor/diff-shown', {'trace-id': refactoringState.request.traceId});
             return;
         }
       },


### PR DESCRIPTION
To understand how our refactor functionality works, we are adding
minimal telemetry events on the user interactions around that
functionality:

- when a refactoring is attempted by the extension
- when a refactoring is applied by the user
- when the diff is shown by the user

Privacy notes:
- adds a per-request UUID trace-id to the current eventdata in
  ./src/telemetry.ts - no impact on privacy.

Co-authored-by: Johan Lindbergh <johan.lindbergh@codescene.com>
