### PR TITLE
feat!: Remove the Change Coupling feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,6 @@ This feature extends CodeScene's capabilities to not only identify code health i
 CodeScene Automated Code Engineering requires signing in to a CodeScene instance. Read more in the [docs](https://codescene.io/docs/auto-refactor/index.html).
 
 
-
-## <img src="assets/cs-logo-small.png" align="center" title="Requires signing in to CodeScene" width="20"/> Change Coupling
-
-Sign in to your CodeScene account to enable the Change Coupling analysis. Looking at the Change Coupling will help you understand how files change together over time. It can be useful for navigating between related files, and can also make it easier to pinpoint other files that might need updating when working on a certain file. See more about Change Coupling on [codescene.com](https://codescene.com/ide-extension).
-
 ## Example screenshots
 
 *Issues are displayed above the affected functions. Clicking on them shows an explanation.*
@@ -93,7 +88,6 @@ CodeScene supports most popular languages. Here is the full list:
 - Diagnostics for functions with code health issues.
 - Optionally show code issues as code lenses for the affected function.
 - Customizable code health rules via `.codescene/code-health-rules.json` ([format description](https://codescene.io/docs/guides/technical/code-health.html#advanced-override-the-low-level-code-health-thresholds)). You can create a template with the command `codescene.createRulesTemplate`.
-- Use an active CodeScene account to enable monitoring of Change Coupling.
 - Get automated refactoring suggestions with Automated Code Engineering.
 
 Note on custom code health rules: this is the same mechanism as the full CodeScene product.

--- a/package.json
+++ b/package.json
@@ -70,40 +70,6 @@
         "title": "CodeScene: Open Code Health Documentation"
       },
       {
-        "command": "codescene.associateWithProject",
-        "title": "CodeScene: Associate Workspace with CodeScene Project"
-      },
-      {
-        "command": "codescene.scmCouplingsView.open",
-        "title": "Open File",
-        "icon": "$(preferences-open-settings)"
-      },
-      {
-        "command": "codescene.scmCouplingsView.refresh",
-        "title": "Refresh",
-        "icon": "$(refresh)"
-      },
-      {
-        "command": "codescene.openDashboard",
-        "title": "CodeScene: Open Project Dashboard"
-      },
-      {
-        "command": "codescene.openHotspots",
-        "title": "CodeScene: Open Hotspots Map"
-      },
-      {
-        "command": "codescene.openChangeCoupling",
-        "title": "CodeScene: Open Change Coupling"
-      },
-      {
-        "command": "codescene.openCodeReview",
-        "title": "CodeScene: Open Code Review"
-      },
-      {
-        "command": "codescene.openXRay",
-        "title": "CodeScene: Open X-Ray"
-      },
-      {
         "command": "codescene.gotoAndPresentRefactoring",
         "title": "View in ACE panel"
       }
@@ -118,17 +84,7 @@
       ]
     },
     "views": {
-      "scm": [
-        {
-          "id": "codescene.scmCouplingsView",
-          "name": "Change coupling"
-        }
-      ],
       "explorer": [
-        {
-          "id": "codescene.explorerCouplingsView",
-          "name": "Change coupling"
-        },
         {
           "id": "codescene.explorerAutoRefactorView",
           "name": "Auto-refactor"
@@ -145,53 +101,13 @@
     },
     "viewsWelcome": [
       {
-        "view": "codescene.scmCouplingsView",
-        "contents": "In order to see coupling data, you need to sign in to a CodeScene server",
-        "when": "!codescene.isSignedIn"
-      },
-      {
-        "view": "codescene.scmCouplingsView",
-        "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
-        "when": "!codescene.isWorkspaceAssociated && codescene.isSignedIn"
-      },
-      {
-        "view": "codescene.explorerCouplingsView",
-        "contents": "In order to see coupling data, you need to sign in to a CodeScene server",
-        "when": "!codescene.isSignedIn"
-      },
-      {
-        "view": "codescene.explorerCouplingsView",
-        "contents": "In order to see coupling data, you need to have associated your workspace with a CodeScene project.\n[Associate workspace](command:codescene.associateWithProject)",
-        "when": "!codescene.isWorkspaceAssociated && codescene.isSignedIn"
-      },
-      {
         "view": "codescene.explorerAutoRefactorView",
         "contents": "To see Auto-refactoring suggestions, you need to sign in to a CodeScene server",
         "when": "!codescene.isSignedIn"
       }
     ],
     "menus": {
-      "view/title": [
-        {
-          "command": "codescene.scmCouplingsView.refresh",
-          "when": "view == codescene.scmCouplingsView",
-          "group": "navigation"
-        }
-      ],
       "view/item/context": [
-        {
-          "command": "codescene.scmCouplingsView.open",
-          "when": "view == codescene.scmCouplingsView && viewItem == rootItem",
-          "group": "inline"
-        },
-        {
-          "command": "codescene.openXRay",
-          "when": "view == codescene.scmCouplingsView || view == codescene.explorerCouplingsView"
-        },
-        {
-          "command": "codescene.openCodeReview",
-          "when": "view == codescene.scmCouplingsView || view == codescene.explorerCouplingsView"
-        },
         {
           "command": "codescene.gotoAndPresentRefactoring",
           "when": "view == codescene.explorerAutoRefactorView"
@@ -199,52 +115,8 @@
       ],
       "commandPalette": [
         {
-          "command": "codescene.openDashboard",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.openHotspots",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.openChangeCoupling",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.associateWithProject",
-          "when": "codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.openXRay",
-          "when": "false"
-        },
-        {
-          "command": "codescene.openCodeReview",
-          "when": "false"
-        },
-        {
           "command": "codescene.gotoAndPresentRefactoring",
           "when": "false"
-        }
-      ],
-      "explorer/context": [
-        {
-          "command": "codescene.openCodeReview",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.openXRay",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        }
-      ],
-      "editor/title/context": [
-        {
-          "command": "codescene.openCodeReview",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
-        },
-        {
-          "command": "codescene.openXRay",
-          "when": "codescene.isWorkspaceAssociated && codescene.isSignedIn"
         }
       ]
     },

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -96,20 +96,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
 
       outputChannel.appendLine(`Created session ${session.id} for ${session.account.label}`);
 
-      if (this.csWorkspace.getProjectId() === undefined) {
-        window
-          .showInformationMessage(
-            `Signed in to CodeScene as ${session.account.label}`,
-            'Associate workspace with project'
-          )
-          .then((result) => {
-            if (result === 'Associate workspace with project') {
-              this.csWorkspace.associateWithProject();
-            }
-          });
-      } else {
-        window.showInformationMessage(`Signed in to CodeScene as ${session.account.label}`);
-      }
+      window.showInformationMessage(`Signed in to CodeScene as ${session.account.label}`);
 
       return session;
     } catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,12 @@
 import * as vscode from 'vscode';
 import { AUTH_TYPE, CsAuthenticationProvider } from './auth/auth-provider';
 import { getConfiguration, onDidChangeConfiguration } from './configuration';
-import { CouplingDataProvider } from './coupling/coupling-data-provider';
-import { ExplorerCouplingsView } from './coupling/explorer-couplings-view';
-import { ScmCouplingsView } from './coupling/scm-couplings-view';
 import CsDiagnosticsCollection, { CsDiagnostics } from './cs-diagnostics';
 import { CsRestApi } from './cs-rest-api';
 import { CsStatusBar } from './cs-statusbar';
 import { categoryToDocsCode, registerCsDocProvider } from './csdoc';
 import { ensureLatestCompatibleCliExists } from './download';
-import { Git } from './git';
 import { toRefactoringDocumentSelector, toReviewDocumentSelector } from './language-support';
-import { Links } from './links';
 import { outputChannel } from './log';
 import { CsRefactorCodeAction } from './refactoring/codeaction';
 import { CsRefactorCodeLensProvider } from './refactoring/codelens';
@@ -225,23 +220,6 @@ function requireReloadWindowFn(message: string) {
  * Active functionality that requires a connection to a CodeScene server.
  */
 async function enableRemoteFeatures(context: vscode.ExtensionContext, csContext: CsContext) {
-  const { csWorkspace, csRestApi } = csContext;
-  const links = new Links(csWorkspace);
-  context.subscriptions.push(links);
-
-  const git = new Git();
-  const couplingDataProvider = new CouplingDataProvider(git, csRestApi, csWorkspace);
-
-  // Init tree view in scm container
-  const couplingView = new ScmCouplingsView(git, couplingDataProvider);
-  context.subscriptions.push(couplingView);
-
-  // Init tree view in explorer container
-  const explorerCouplingsView = new ExplorerCouplingsView(couplingDataProvider);
-  context.subscriptions.push(explorerCouplingsView);
-  outputChannel.appendLine('Change Coupling enabled');
-  csWorkspace.setChangeCouplingEnabled(true);
-
   // Refactoring features
   const enableACE = getConfiguration('enableAutomatedCodeEngineering');
   if (enableACE) {

--- a/src/refactoring/refactorings-view.ts
+++ b/src/refactoring/refactorings-view.ts
@@ -1,9 +1,3 @@
-/**
- * Shows couplings in the Explorer panel.
- *
- * The purpose of this view is to show the user which files are related to the one that is
- * currently active in the editor. The user can jump to these files by clicking on them.
- */
 import * as vscode from 'vscode';
 import { isDefined } from '../utils';
 import { pendingSymbol, presentRefactoringCmdName, toConfidenceSymbol } from './command';

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -42,9 +42,6 @@ export class StatusViewProvider implements WebviewViewProvider {
         case 'open-settings':
           vscode.commands.executeCommand('workbench.action.openWorkspaceSettings', 'codescene');
           return;
-        case 'focus-change-coupling-explorer-view':
-          vscode.commands.executeCommand('codescene.explorerCouplingsView.focus');
-          return;
         case 'focus-explorer-ace-view':
           vscode.commands.executeCommand('codescene.explorerAutoRefactorView.focus');
           return;
@@ -110,24 +107,6 @@ export class StatusViewProvider implements WebviewViewProvider {
     `;
   }
 
-  private changeCouplingContent(enabled?: boolean) {
-    let content = /*html*/ `<h3>Change Coupling</h3>`;
-    if (enabled) {
-      content += /*html*/ `
-        <p>Change coupling is enabled and available in the Explorer and Source Control views. If your workspace 
-        is associated with a CodeScene project, you will see which files are often changed together in the 
-        <a href="" id="change-coupling-link">Change Coupling</a> view.</p>
-        <p><span class="codicon codicon-question"></span> <a href="https://codescene.io/docs/guides/technical/change-coupling.html">Documentation on codescene.io</a></p>
-    `;
-    } else {
-      content += /*html*/ `
-        <p>Change coupling is enabled by signing in with CodeScene.</p>
-        <p><span class="codicon codicon-question"></span> <a href="https://codescene.io/docs/guides/technical/change-coupling.html">Documentation on codescene.io</a></p>
-      `;
-    }
-    return content;
-  }
-
   private aceContent(preflight?: PreFlightResponse) {
     let content = /*html*/ `<h3>Automated Code Engineering (ACE)</h3>`;
     if (isDefined(preflight)) {
@@ -179,7 +158,6 @@ export class StatusViewProvider implements WebviewViewProvider {
     const featureNames = {
       'Code health analysis': features.codeHealthAnalysis.cliPath,
       'Automated Code Engineering (ACE)': features.automatedCodeEngineering,
-      'Change Coupling': features.changeCoupling,
     };
 
     const signedInListItem = `<li><span class="codicon codicon-shield ${signedIn ? 'codicon-active' : ''}"></span> ${
@@ -209,7 +187,6 @@ export class StatusViewProvider implements WebviewViewProvider {
 
       ${this.cliStatusContent(features)}
       ${this.aceContent(features.automatedCodeEngineering)}
-      ${this.changeCouplingContent(features.changeCoupling)}
 
     `;
   }

--- a/src/webviews/status-webview-script.ts
+++ b/src/webviews/status-webview-script.ts
@@ -16,6 +16,5 @@ function sendMessage(command: string) {
 function main() {
   document.getElementById('open-settings-button')?.addEventListener('click', () => sendMessage('open-settings'));
   document.getElementById('open-settings-link')?.addEventListener('click', () => sendMessage('open-settings'));
-  document.getElementById('change-coupling-link')?.addEventListener('click', () => sendMessage('focus-change-coupling-explorer-view'));
   document.getElementById('auto-refactor-link')?.addEventListener('click', () => sendMessage('focus-explorer-ace-view'));
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -14,7 +14,6 @@ import { rankNamesBy } from './utils';
 export interface CsFeatures {
   codeHealthAnalysis: CliStatus;
   automatedCodeEngineering?: PreFlightResponse;
-  changeCoupling?: boolean;
 }
 
 export interface CsExtensionState {
@@ -106,10 +105,7 @@ export class CsWorkspace implements vscode.Disposable {
     vscode.commands.executeCommand('setContext', 'codescene.isSignedIn', signedIn);
 
     this.extensionState.signedIn = signedIn;
-    if (signedIn) {
-      this.extensionState.features.changeCoupling = true;
-    } else {
-      this.extensionState.features.changeCoupling = false;
+    if (!signedIn) {
       this.extensionState.features.automatedCodeEngineering = undefined;
     }
     this.extensionStateChangedEmitter.fire(this.extensionState);
@@ -117,11 +113,6 @@ export class CsWorkspace implements vscode.Disposable {
 
   setCliStatus(cliStatus: CliStatus) {
     this.extensionState.features.codeHealthAnalysis = cliStatus;
-    this.extensionStateChangedEmitter.fire(this.extensionState);
-  }
-
-  setChangeCouplingEnabled(enabled: boolean) {
-    this.extensionState.features.changeCoupling = enabled;
     this.extensionStateChangedEmitter.fire(this.extensionState);
   }
 


### PR DESCRIPTION
This feature is going to be reworked and might or might not get back into the extension in the future. If it does, it will be in a different form.

Keeping the code functionality for now, but all user facing commands and components are removed.