### PR TITLE
Get userId along with name and token from backend for use in Telemetry

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -32,6 +32,7 @@ class UriEventHandler extends EventEmitter<Uri> implements UriHandler {
 interface LoginResponse {
   name: string;
   token: string;
+  userId: string;
 }
 
 export class CsAuthenticationProvider implements AuthenticationProvider, Disposable {
@@ -85,7 +86,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
         accessToken: loginResponse.token,
         account: {
           label: loginResponse.name,
-          id: uuid(), // Do we need a "static" id here?
+          id: loginResponse.userId || uuid(), // Do we need a "static" id here?
         },
         scopes: [],
       };
@@ -176,6 +177,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
 
       const name = query.get('name');
       const token = query.get('token');
+      const userId = query.get('user-id');
 
       if (token === null) {
         reject('No token found in redirect');
@@ -187,7 +189,12 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
         return;
       }
 
-      resolve({ name, token });
+      if (userId === null) {
+        reject('No user-id found in redirect');
+        return;
+      }
+
+      resolve({ name, token, userId });
     };
   }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -11,6 +11,8 @@ export default class Telemetry {
 
   private telemetryLogger: vscode.TelemetryLogger;
 
+  private session?: vscode.AuthenticationSession;
+
   constructor(private cliPath: string) {
     const sender: vscode.TelemetrySender = {
       sendEventData: async (eventName, eventData) => {
@@ -46,7 +48,9 @@ export default class Telemetry {
       'process-platform': process.platform,
       'process-arch': process.arch,
     };
-
+    if (this.session) {
+      data['user-id'] = this.session.account.id;
+    }
     // To ensure we are sending exactly the same data to the sign command as we are sending in the body of the request,
     // we stringify the data manually.
     const jsonData = JSON.stringify(data);
@@ -61,5 +65,9 @@ export default class Telemetry {
     };
 
     axios.post('https://devtools.codescene.io/api/analytics/events/ide', jsonData, config).catch(logAxiosError);
+  }
+
+  setSession(session?: vscode.AuthenticationSession) {
+    this.session = session;
   }
 }

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -59,7 +59,7 @@ export class StatusViewProvider implements WebviewViewProvider {
     if (!this.view) return;
 
     const webView: Webview = this.view.webview;
-    if (!this.extensionState.signedIn) {
+    if (!this.extensionState.session) {
       this.view.badge = { tooltip: 'Not signed in', value: 1 };
     } else {
       this.view.badge = { tooltip: 'Signed in', value: 0 };
@@ -146,14 +146,14 @@ export class StatusViewProvider implements WebviewViewProvider {
   }
 
   private extensionStatusContent() {
-    const { signedIn, features } = this.extensionState;
+    const { session, features } = this.extensionState;
     const featureNames = {
       'Code health analysis': features.codeHealthAnalysis.cliPath,
       'Automated Code Engineering (ACE)': features.automatedCodeEngineering,
     };
 
-    const signedInListItem = `<li><span class="codicon codicon-shield ${signedIn ? 'codicon-active' : ''}"></span> ${
-      signedIn ? 'Signed in' : 'Not signed in'
+    const signedInListItem = `<li><span class="codicon codicon-shield ${session ? 'codicon-active' : ''}"></span> ${
+      session ? 'Signed in' : 'Not signed in'
     }</li>`;
     let featureListItems = '';
     Object.entries(featureNames).forEach(([featureName, value]) => {


### PR DESCRIPTION
Using the userId in the TelemetryLogger allows for a better user experience in our telemetry UI

chore: Use 'session' in place of 'signedIn' in the ExtensionState and make sure that the codescene.isSignedIn context is set (used in package.json for conditionally activating views or commands)