### PR TITLE
fix: Handle signing in/out without having to reload extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
           "description": "Enable CodeScene code lenses",
           "order": 1
         },
-        "codescene.enableAutomatedCodeEngineering": {
+        "codescene.enableAutoRefactor": {
           "type": "boolean",
           "default": true,
           "description": "Enable CodeScene ACE. This is currently only available for customers part of the ACE beta program.",

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -40,7 +40,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
   private disposable: Disposable;
   private uriHandler = new UriEventHandler();
 
-  constructor(private context: ExtensionContext, private csWorkspace: CsWorkspace) {
+  constructor(private context: ExtensionContext) {
     this.disposable = Disposable.from(
       authentication.registerAuthenticationProvider(AUTH_TYPE, 'CodeScene Cloud', this, {
         supportsMultipleAccounts: false,
@@ -118,7 +118,6 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
       if (session) {
         await this.context.secrets.store(SESSIONS_STORAGE_KEY, '[]');
         this.sessionChangeEmitter.fire({ added: [], removed: [session], changed: [] });
-        this.csWorkspace.clearProjectAssociation();
       }
     }
   }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -4,10 +4,13 @@ export function getConfiguration<T>(section: string): T | undefined {
   return vscode.workspace.getConfiguration('codescene').get<T>(section);
 }
 
-export function onDidChangeConfiguration(section: string, listener: (e: vscode.ConfigurationChangeEvent) => any) {
+export function onDidChangeConfiguration(
+  section: string,
+  listener: (e: { event: vscode.ConfigurationChangeEvent; value: any }) => any
+) {
   return vscode.workspace.onDidChangeConfiguration((e) => {
     if (e.affectsConfiguration('codescene.' + section)) {
-      listener(e);
+      listener({ event: e, value: getConfiguration(section) });
     }
   });
 }

--- a/src/cs-diagnostics.ts
+++ b/src/cs-diagnostics.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { requestRefactoringsCmdName } from './refactoring/command';
+import { requestRefactoringsCmdName } from './refactoring/commands';
 import Reviewer, { ReviewOpts, chScorePrefix } from './review/reviewer';
 import { reviewDocumentSelector } from './language-support';
 
@@ -25,7 +25,7 @@ export default class CsDiagnosticsCollection {
  */
 export class CsDiagnostics {
   private documentSelector: vscode.DocumentSelector;
-  
+
   constructor() {
     this.documentSelector = reviewDocumentSelector();
   }
@@ -48,15 +48,6 @@ export class CsDiagnostics {
   }
 
   private async preInitiateRefactoringRequests(document: vscode.TextDocument, diagnostics: vscode.Diagnostic[]) {
-    vscode.commands.executeCommand(requestRefactoringsCmdName, document, diagnostics).then(
-      () => {},
-      (err) => {
-        /**
-         * Command might not be registered. It only exists when extension.enableRefactoringCommand() has been run.
-         * If it doesn't exist we don't want to initiate any refactoring requests anyway, and if left unhandled
-         * we get "rejected promise not handled"-errors.
-         */
-      }
-    );
+    vscode.commands.executeCommand(requestRefactoringsCmdName, document, diagnostics);
   }
 }

--- a/src/cs-extension-state.ts
+++ b/src/cs-extension-state.ts
@@ -1,0 +1,84 @@
+import vscode from 'vscode';
+import { PreFlightResponse } from './cs-rest-api';
+import { CsStatusBar } from './cs-statusbar';
+import { CliStatus } from './download';
+import { CsRefactoringCommands } from './refactoring/commands';
+import Telemetry from './telemetry';
+import { isDefined } from './utils';
+import { StatusViewProvider } from './webviews/status-view-provider';
+
+export interface CsFeatures {
+  codeHealthAnalysis?: CliStatus;
+  automatedCodeEngineering?: PreFlightResponse;
+}
+
+export interface CsStateProperties {
+  session?: vscode.AuthenticationSession;
+  features?: CsFeatures;
+}
+
+/**
+ * This class is used to handle the state of the extension. One part is managing and presenting
+ * the state properties, the other part is to handle the state of components that are registered
+ * when the user signs in and out of CodeScene.
+ */
+export class CsExtensionState {
+  private stateProperties: CsStateProperties = {};
+  private statusViewProvider: StatusViewProvider;
+  private statusBar: CsStatusBar;
+
+  private refactoringCommand: CsRefactoringCommands | undefined;
+  private onlineFeatureDisposables: vscode.Disposable[] = [];
+
+  constructor(statusViewProvider: StatusViewProvider) {
+    this.statusViewProvider = statusViewProvider;
+    this.statusBar = new CsStatusBar();
+  }
+
+  updateStatusViews() {
+    this.statusViewProvider.update(this.stateProperties);
+    this.statusBar.setOnline(isDefined(this.stateProperties.session));
+  }
+
+  /**
+   * Sets session state and updates the codescene.isSignedIn context variable.
+   * This can be used in package.json to conditionally enable/disable views.
+   */
+  setSession(session?: vscode.AuthenticationSession) {
+    const signedIn = isDefined(session);
+    vscode.commands.executeCommand('setContext', 'codescene.isSignedIn', signedIn);
+    Telemetry.instance.setSession(session);
+    this.stateProperties.session = session;
+    if (!signedIn) {
+      // this.csWorkspace.clearProjectAssociation(); <- when re-working Change Coupling...
+      this.setACEEnabled(undefined); // Ace cannot be active if not signed in
+      return;
+    }
+
+    this.updateStatusViews();
+  }
+
+  setCliStatus(cliStatus: CliStatus) {
+    this.stateProperties.features = { ...this.stateProperties.features, codeHealthAnalysis: cliStatus };
+    this.updateStatusViews();
+  }
+
+  setACEEnabled(preflight: PreFlightResponse | undefined) {
+    this.stateProperties.features = { ...this.stateProperties.features, automatedCodeEngineering: preflight };
+    if (isDefined(preflight)) {
+      this.refactoringCommand?.enableRequestRefactoringsCmd(preflight);
+    } else {
+      this.refactoringCommand?.disableRequestRefactoringsCmd();
+      this.onlineFeatureDisposables.forEach((d) => d.dispose());
+    }
+    this.updateStatusViews();
+  }
+
+  addOnlineFeatureDisposable(...disposables: vscode.Disposable[]) {
+    this.onlineFeatureDisposables.push(...disposables);
+  }
+
+  setRefactoringCommand(refactoringCommand: CsRefactoringCommands) {
+    this.refactoringCommand = refactoringCommand;
+  }
+}

--- a/src/cs-rest-api.ts
+++ b/src/cs-rest-api.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { AUTH_TYPE } from './auth/auth-provider';
 import { getServerApiUrl } from './configuration';
 import { logOutputChannel, outputChannel } from './log';
-import { FnToRefactor } from './refactoring/command';
+import { FnToRefactor } from './refactoring/commands';
 
 export interface Coupling {
   entity: string;

--- a/src/refactoring/codeaction.ts
+++ b/src/refactoring/codeaction.ts
@@ -1,12 +1,12 @@
 import vscode, { CodeActionKind } from 'vscode';
-import { isDefined } from '../utils';
-import { commandFromRequest, toConfidenceSymbol } from './command';
+import { DiagnosticFilter, isDefined } from '../utils';
+import { commandFromRequest, toConfidenceSymbol } from './commands';
 import { CsRefactoringRequest, CsRefactoringRequests } from './cs-refactoring-requests';
 
 export class CsRefactorCodeAction implements vscode.CodeActionProvider {
   public static readonly providedCodeActionKinds = [CodeActionKind.QuickFix, CodeActionKind.Empty];
 
-  public constructor(private codeSmellFilter: (d: vscode.Diagnostic) => boolean) {}
+  public constructor(private codeSmellFilter: DiagnosticFilter) {}
 
   provideCodeActions(
     document: vscode.TextDocument,

--- a/src/refactoring/codelens.ts
+++ b/src/refactoring/codelens.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
 import { getConfiguration } from '../configuration';
 import { logOutputChannel, outputChannel } from '../log';
-import { isDefined, rangeStr } from '../utils';
-import { commandFromRequest, pendingSymbol } from './command';
+import { DiagnosticFilter, isDefined, rangeStr } from '../utils';
+import { commandFromRequest, pendingSymbol } from './commands';
 import { CsRefactoringRequest, CsRefactoringRequests } from './cs-refactoring-requests';
 
 export class CsRefactorCodeLens extends vscode.CodeLens {
@@ -25,7 +25,7 @@ export class CsRefactorCodeLensProvider implements vscode.CodeLensProvider<CsRef
   private onDidChangeCodeLensesEmitter = new vscode.EventEmitter<void>();
   private disposables: vscode.Disposable[] = [];
 
-  constructor(private codeSmellFilter: (d: vscode.Diagnostic) => boolean) {
+  constructor(private codeSmellFilter: DiagnosticFilter) {
     outputChannel.appendLine('Creating Auto-refactor CodeLens provider');
     this.disposables.push(
       CsRefactoringRequests.onDidChangeRequests(() => {

--- a/src/refactoring/cs-refactoring-requests.ts
+++ b/src/refactoring/cs-refactoring-requests.ts
@@ -3,10 +3,9 @@ import { v4 as uuidv4 } from 'uuid';
 import vscode, { Diagnostic, EventEmitter, Range, TextDocument } from 'vscode';
 import { CsRestApi, RefactorConfidence, RefactorResponse } from '../cs-rest-api';
 import { logOutputChannel } from '../log';
-import { isDefined, rangeStr } from '../utils';
-import { CsRefactorCodeLensProvider } from './codelens';
-import { FnToRefactor } from './command';
 import Telemetry from '../telemetry';
+import { isDefined, rangeStr } from '../utils';
+import { FnToRefactor } from './commands';
 
 export class CsRefactoringRequest {
   fnToRefactor: FnToRefactor;
@@ -61,11 +60,11 @@ export class CsRefactoringRequest {
 
   /**
    * Indicate that we should present the refactoring state in the UI
-   * Rules at the moment is to basically always present it, unless the 
+   * Rules at the moment is to basically always present it, unless the
    * confidence level is invalid.
-   * 
+   *
    * @param request
-   * @returns 
+   * @returns
    */
   shouldPresent() {
     const level = this.resolvedResponse?.confidence.level;
@@ -125,7 +124,7 @@ export class CsRefactoringRequests {
   static readonly onDidChangeRequests = CsRefactoringRequests.requestsEmitter.event;
 
   static initiate(
-    context: { csRestApi: CsRestApi; document: TextDocument; codeLensProvider: CsRefactorCodeLensProvider },
+    context: { csRestApi: CsRestApi; document: TextDocument },
     fnsToRefactor: FnToRefactor[],
     diagnostics: Diagnostic[]
   ) {

--- a/src/refactoring/refactoring-panel.ts
+++ b/src/refactoring/refactoring-panel.ts
@@ -17,7 +17,7 @@ import { logOutputChannel } from '../log';
 import Telemetry from '../telemetry';
 import { getLogoUrl } from '../utils';
 import { nonce } from '../webviews/utils';
-import { FnToRefactor, refactoringSymbol, toConfidenceSymbol } from './command';
+import { FnToRefactor, refactoringSymbol, toConfidenceSymbol } from './commands';
 import { CsRefactoringRequest, CsRefactoringRequests } from './cs-refactoring-requests';
 import { decorateCode } from './utils';
 

--- a/src/refactoring/utils.ts
+++ b/src/refactoring/utils.ts
@@ -1,5 +1,6 @@
-import { ReasonsWithDetails } from '../cs-rest-api';
-import { isDefined } from '../utils';
+import { Diagnostic } from 'vscode';
+import { PreFlightResponse, ReasonsWithDetails } from '../cs-rest-api';
+import { DiagnosticFilter, isDefined } from '../utils';
 
 function singleLineCommentSeparator(languageId: string) {
   switch (languageId) {
@@ -28,4 +29,9 @@ export function decorateCode(code: string, languageId: string, reasonsWithDetail
     commentsAdded += commentLines.length;
   });
   return codeLines.join('\n');
+}
+
+export function createCodeSmellsFilter(refactorCapabilities: PreFlightResponse): DiagnosticFilter {
+  return (d: Diagnostic) =>
+    d.code instanceof Object && refactorCapabilities.supported['code-smells'].includes(d.code.value.toString());
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,8 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { Diagnostic, Range } from 'vscode';
 
+export type DiagnosticFilter = (d: Diagnostic) => boolean;
+
 export function getFileExtension(filename: string) {
   return filename.slice(((filename.lastIndexOf('.') - 1) >>> 0) + 2);
 }

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -6,10 +6,10 @@ import vscode, {
   WebviewViewProvider,
   WebviewViewResolveContext,
 } from 'vscode';
+import { CsFeatures, CsStateProperties } from '../cs-extension-state';
 import { PreFlightResponse } from '../cs-rest-api';
 import { toDistinctLanguageIds } from '../language-support';
 import { isDefined } from '../utils';
-import { CsExtensionState, CsFeatures } from '../workspace';
 import { nonce } from './utils';
 
 export function registerStatusViewProvider(context: vscode.ExtensionContext) {
@@ -21,11 +21,11 @@ export function registerStatusViewProvider(context: vscode.ExtensionContext) {
 export class StatusViewProvider implements WebviewViewProvider {
   public static readonly viewId = 'codescene.statusView';
 
-  private extensionState: CsExtensionState;
+  private stateProperties: CsStateProperties;
   private view?: vscode.WebviewView;
 
   constructor(private readonly extensionUri: vscode.Uri) {
-    this.extensionState = {};
+    this.stateProperties = {};
   }
 
   resolveWebviewView(
@@ -51,15 +51,15 @@ export class StatusViewProvider implements WebviewViewProvider {
           return;
       }
     });
-    this.update(this.extensionState);
+    this.update(this.stateProperties);
   }
 
-  update(csExtensionState: CsExtensionState) {
-    this.extensionState = csExtensionState;
+  update(stateProperties: CsStateProperties) {
+    this.stateProperties = stateProperties;
     if (!this.view) return;
 
     const webView: Webview = this.view.webview;
-    if (!this.extensionState.session) {
+    if (!this.stateProperties.session) {
       this.view.badge = { tooltip: 'Not signed in', value: 1 };
     } else {
       this.view.badge = { tooltip: 'Signed in', value: 0 };
@@ -153,7 +153,7 @@ export class StatusViewProvider implements WebviewViewProvider {
   }
 
   private extensionStatusContent() {
-    const { session, features } = this.extensionState;
+    const { session, features } = this.stateProperties;
     const featureNames = {
       'Code health analysis': features?.codeHealthAnalysis?.cliPath,
       'Automated Code Engineering (ACE)': features?.automatedCodeEngineering,

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,43 +1,15 @@
 /**
  * A workspace in vscode is the currently opened folder(s). You can also store settings in the workspace state.
  * We store for example the project id for the corresponding project on the CodeScene server (if one is associated).
- *
- * We also use this as a container for lightweight state management, such as sign in and feature availability.
  */
-import { dirname } from 'path';
 import * as vscode from 'vscode';
-import { CsRestApi, PreFlightResponse } from './cs-rest-api';
-import { CliStatus } from './download';
-import { SimpleExecutor } from './executor';
-import { rankNamesBy } from './utils';
-import Telemetry from './telemetry';
 
-export interface CsFeatures {
-  codeHealthAnalysis?: CliStatus;
-  automatedCodeEngineering?: PreFlightResponse;
-}
-
-export interface CsExtensionState {
-  session?: vscode.AuthenticationSession;
-  features?: CsFeatures;
-}
-
-export class CsWorkspace implements vscode.Disposable {
-  private disposables: vscode.Disposable[] = [];
+export class CsWorkspace {
   private projectAssociationChangedEmitter = new vscode.EventEmitter<number | undefined>();
-
-  private extensionStateChangedEmitter = new vscode.EventEmitter<CsExtensionState>();
-  readonly onDidExtensionStateChange = this.extensionStateChangedEmitter.event;
-
-  extensionState: CsExtensionState = {};
 
   constructor(private context: vscode.ExtensionContext) {
     const projectId = this.getProjectId();
     this.updateIsWorkspaceAssociatedContext(projectId);
-  }
-
-  dispose() {
-    this.disposables.forEach((d) => d.dispose());
   }
 
   /**
@@ -62,72 +34,5 @@ export class CsWorkspace implements vscode.Disposable {
 
   clearProjectAssociation() {
     this.updateIsWorkspaceAssociatedContext(undefined);
-  }
-
-  /**
-   * Sets session state and updates the codescene.isSignedIn context variable.
-   * This can be used in package.json to conditionally enable/disable views.
-   */
-  setSession(session: vscode.AuthenticationSession) {
-    vscode.commands.executeCommand('setContext', 'codescene.isSignedIn', true);
-    Telemetry.instance.setSession(session);
-    this.extensionState.session = session;
-    this.extensionStateChangedEmitter.fire(this.extensionState);
-  }
-
-  /**
-   * Unsets session state and updates the codescene.isSignedIn context variable.
-   * Also updates feature availability state (ACE) and fires an event to notify listeners.
-   * (ACE cannot be available when signed out)
-   */
-  unsetSession() {
-    vscode.commands.executeCommand('setContext', 'codescene.isSignedIn', false);
-    Telemetry.instance.setSession();
-    delete this.extensionState['session'];
-    delete this.extensionState.features?.automatedCodeEngineering;
-    this.extensionStateChangedEmitter.fire(this.extensionState);
-  }
-
-  setCliStatus(cliStatus: CliStatus) {
-    this.extensionState.features = { ...this.extensionState.features, codeHealthAnalysis: cliStatus };
-    this.extensionStateChangedEmitter.fire(this.extensionState);
-  }
-
-  setACEEnabled(preflight: PreFlightResponse | undefined) {
-    this.extensionState.features = { ...this.extensionState.features, automatedCodeEngineering: preflight };
-    this.extensionStateChangedEmitter.fire(this.extensionState);
-  }
-
-  /**
-   * Project path here means the path used by the codescene server to denote the file.
-   *
-   * This is a relative file path with the repo name as the root. E.g. codescene-vscode/src/extension.ts.
-   */
-  async getCsFilePath(absoluteFilePath: vscode.Uri) {
-    const fileDir = dirname(absoluteFilePath.fsPath);
-    const executor = new SimpleExecutor();
-
-    const repoRoot = await executor.execute(
-      { command: 'git', args: ['rev-parse', '--show-toplevel'] },
-      { cwd: fileDir }
-    );
-
-    if (repoRoot.exitCode !== 0) {
-      return;
-    }
-
-    const repoRelativePath = await executor.execute(
-      { command: 'git', args: ['ls-files', '--full-name', '--', absoluteFilePath.fsPath] },
-      { cwd: fileDir }
-    );
-
-    if (repoRelativePath.exitCode !== 0) {
-      return;
-    }
-
-    const repoRootName = repoRoot.stdout.trim().split('/').pop();
-    const relativePath = repoRelativePath.stdout.trim();
-
-    return `${repoRootName}/${relativePath}`;
   }
 }


### PR DESCRIPTION
To get around relying on users to reload the extension manually when signing out we're doing a bit of a rewrite to be able to handle consecutive sign in/out calls.

The same goes for checking or unchecking the ACE configuration option, this no longer pops up the "You need to reload CodeScene to enable/disable this feature"