### PR TITLE
UX updates in error handling

### DIFF
--- a/assets/status-view.css
+++ b/assets/status-view.css
@@ -18,12 +18,16 @@ code.preflight-error {
   vertical-align: text-bottom;
 }
 
-.codicon-active {
+.color-active {
   color: rgb(29, 139, 29);
 }
 
-.codicon-inactive {
+.color-inactive {
   color: var(--vscode-notificationsErrorIcon-foreground);
+}
+
+.color-warning {
+  color: var(--vscode-notificationsWarningIcon-foreground);
 }
 
 .features-list {

--- a/src/coupling/command.ts
+++ b/src/coupling/command.ts
@@ -3,9 +3,9 @@ import { CsRestApi } from '../cs-rest-api';
 import { rankNamesBy } from '../utils';
 import { CsWorkspace } from '../workspace';
 
-export function registerCommand(context: vscode.ExtensionContext, csRestApi: CsRestApi, csWorkspace: CsWorkspace) {
+export function registerCommand(context: vscode.ExtensionContext, csWorkspace: CsWorkspace) {
   const associateCmd = vscode.commands.registerCommand('codescene.associateWithProject', async () => {
-    const projects = await csRestApi.fetchProjects();
+    const projects = await CsRestApi.instance.fetchProjects();
 
     const quickPickList = projects.map((p) => p.name);
 

--- a/src/coupling/scm-couplings-view.ts
+++ b/src/coupling/scm-couplings-view.ts
@@ -25,7 +25,7 @@ export class ScmCouplingsView implements vscode.Disposable {
     this.disposables.push(view);
 
     const openCmd = vscode.commands.registerCommand('codescene.scmCouplingsView.open', (item: CoupledEntity) => {
-      vscode.commands.executeCommand('vscode.open', item.resourceUri);
+      void vscode.commands.executeCommand('vscode.open', item.resourceUri);
     });
     this.disposables.push(openCmd);
 
@@ -35,7 +35,7 @@ export class ScmCouplingsView implements vscode.Disposable {
     // Refresh view on certain events
     this.disposables.push(
       this.git.onDidModifyChangeSet(() => {
-        this.treeDataProvider.refresh();
+        void this.treeDataProvider.refresh();
       })
     );
 

--- a/src/cs-extension-state.ts
+++ b/src/cs-extension-state.ts
@@ -1,5 +1,5 @@
 import vscode from 'vscode';
-import { PreFlightResponse } from './cs-rest-api';
+import { CsRestApi, PreFlightResponse } from './cs-rest-api';
 import { CsStatusBar } from './cs-statusbar';
 import { CsRefactoringCommands } from './refactoring/commands';
 import { CsRefactoringRequests } from './refactoring/cs-refactoring-requests';
@@ -58,6 +58,7 @@ export class CsExtensionState implements vscode.Disposable {
   setSession(session?: vscode.AuthenticationSession) {
     const signedIn = isDefined(session);
     void vscode.commands.executeCommand('setContext', 'codescene.isSignedIn', signedIn);
+    CsRestApi.instance.setSession(session);
     Telemetry.instance.setSession(session);
     this.stateProperties.session = session;
     if (!signedIn) {

--- a/src/cs-rest-api.ts
+++ b/src/cs-rest-api.ts
@@ -85,6 +85,7 @@ export class CsRestApi {
     });
 
     // TODO - maybe do this once in constructor and resetting the header if session is removed?
+    //  -> Need to have a way to reset the header if the session is removed
     const addAccessToken = async (config: InternalAxiosRequestConfig) => {
       const session = await vscode.authentication.getSession(AUTH_TYPE, [], { createIfNone: false });
       if (session) {

--- a/src/cs-statusbar.ts
+++ b/src/cs-statusbar.ts
@@ -1,7 +1,10 @@
 import vscode from 'vscode';
+import { CsStateProperties } from './cs-extension-state';
+import { isDefined } from './utils';
 
 export class CsStatusBar {
   private readonly statusBarItem: vscode.StatusBarItem;
+  private isOnline?: boolean;
 
   constructor() {
     this.statusBarItem = vscode.window.createStatusBarItem(
@@ -9,13 +12,48 @@ export class CsStatusBar {
       vscode.StatusBarAlignment.Right,
       -1
     );
-    this.statusBarItem.name = 'CodeScene status bar';
-    this.statusBarItem.text = '$(cs-logo)';
-    this.statusBarItem.command = 'codescene.statusView.focus';
+    this.defaultState();
     this.statusBarItem.show();
   }
 
-  setOnline(online?: boolean) {
-    this.statusBarItem.text = `$(cs-logo) ${online ? 'Signed in' : ''}`;
+  update(stateProperties: CsStateProperties) {
+    this.setOnline(isDefined(stateProperties.session));
+    this.indicateErrors(stateProperties);
+  }
+
+  private defaultState() {
+    this.statusBarItem.name = 'CodeScene status bar';
+    this.statusBarItem.text = this.textContent();
+    this.statusBarItem.tooltip = this.tooltipContent();
+    this.statusBarItem.command = 'codescene.statusView.focus';
+    this.statusBarItem.backgroundColor = undefined;
+  }
+
+  private textContent() {
+    return `$(cs-logo) ${this.isOnline ? 'Signed in' : ''}`;
+  }
+  private tooltipContent() {
+    return `${this.isOnline ? 'CodeScene extension active, user signed in' : 'CodeScene extension active'}`;
+  }
+
+  private setOnline(online?: boolean) {
+    this.isOnline = online;
+    this.defaultState();
+  }
+
+  private indicateErrors(stateProperties: CsStateProperties) {
+    if (stateProperties.features?.codeHealthAnalysis instanceof Error) {
+      // Indicates an error in d/l or verifying the CLI
+      this.statusBarItem.text = `$(cs-logo) Error`;
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+      this.statusBarItem.tooltip = 'Click to open the status view.';
+    } else if (isDefined(stateProperties.serviceErrors) && stateProperties.serviceErrors.length > 0) {
+      // Indicates a service error
+      this.statusBarItem.text = `$(cs-logo) Service error`;
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+      this.statusBarItem.tooltip = 'Click to open the status view.';
+    } else {
+      this.defaultState();
+    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { getConfiguration, onDidChangeConfiguration } from './configuration';
 import CsDiagnosticsCollection, { CsDiagnostics } from './cs-diagnostics';
 import { CsExtensionState } from './cs-extension-state';
 import { CsRestApi } from './cs-rest-api';
+import { CsStatusBar } from './cs-statusbar';
 import { categoryToDocsCode, registerCsDocProvider } from './csdoc';
 import { ensureLatestCompatibleCliExists } from './download';
 import { reviewDocumentSelector, toRefactoringDocumentSelector } from './language-support';
@@ -38,7 +39,8 @@ interface CsContext {
 export async function activate(context: vscode.ExtensionContext) {
   outputChannel.appendLine('Activating extension...');
 
-  const csExtensionState = new CsExtensionState(registerStatusViewProvider(context));
+  const csExtensionState = new CsExtensionState(registerStatusViewProvider(context), new CsStatusBar());
+  context.subscriptions.push(csExtensionState);
 
   ensureLatestCompatibleCliExists(context.extensionPath)
     .then((cliPath) => {
@@ -291,7 +293,7 @@ function createAuthProvider(context: vscode.ExtensionContext, csContext: CsConte
   const { csExtensionState } = csContext;
   const authProvider = new CsAuthenticationProvider(context);
 
-  // If there's already a session we enable the remote features, otherwise a badge will appear in the 
+  // If there's already a session we enable the remote features, otherwise a badge will appear in the
   // accounts menu - see AuthenticationGetSessionOptions.createIfNone?: boolean
   vscode.authentication
     .getSession(AUTH_TYPE, [])

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,7 +67,7 @@ function startExtension(context: vscode.ExtensionContext, cliPath: string, csExt
     csRestApi: new CsRestApi(context.extension),
   };
   Reviewer.init(cliPath);
-  setupTelemetry(cliPath);
+  setupTelemetry(context, cliPath);
 
   // The DiagnosticCollection provides the squigglies and also form the basis for the CodeLenses.
   CsDiagnosticsCollection.init(context);
@@ -172,8 +172,8 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
   csExtensionState.setRefactoringCommand(refactoringCommand);
 }
 
-function setupTelemetry(cliPath: string) {
-  Telemetry.init(cliPath);
+function setupTelemetry(context: vscode.ExtensionContext, cliPath: string) {
+  Telemetry.init(context.extension, cliPath);
 
   // send telemetry on activation (gives us basic usage stats)
   Telemetry.instance.logUsage('onActivateExtension');

--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -1,13 +1,12 @@
 import vscode, { TextDocument } from 'vscode';
 import { findEnclosingFunction } from '../codescene-interop';
-import { CsRestApi, PreFlightResponse, RefactorResponse } from '../cs-rest-api';
+import { PreFlightResponse } from '../cs-rest-api';
 import { logOutputChannel } from '../log';
 import { DiagnosticFilter, isDefined } from '../utils';
 import {
-  CsRefactoringRequest,
   CsRefactoringRequests,
   ResolvedRefactoring,
-  validConfidenceLevel,
+  validConfidenceLevel
 } from './cs-refactoring-requests';
 import { RefactoringPanel } from './refactoring-panel';
 import { createCodeSmellsFilter } from './utils';
@@ -26,7 +25,6 @@ export interface FnToRefactor {
 
 export interface CsRefactoringCommandParams {
   context: vscode.ExtensionContext;
-  csRestApi: CsRestApi;
   cliPath: string;
   codeSmellFilter: DiagnosticFilter;
   maxInputLoc: number;
@@ -36,7 +34,6 @@ export class CsRefactoringCommands {
   private extensionUri: vscode.Uri;
   constructor(
     context: vscode.ExtensionContext,
-    private csRestApi: CsRestApi,
     private cliPath: string,
     private codeSmellFilter?: DiagnosticFilter,
     private maxInputLoc?: number
@@ -89,11 +86,7 @@ export class CsRefactoringCommands {
     ).then((fns) => fns.filter(isDefined));
 
     const distinctFns = fnsToRefactor.filter((fn, i, fns) => fns.findIndex((f) => f.range.isEqual(fn.range)) === i);
-    CsRefactoringRequests.initiate(
-      { csRestApi: this.csRestApi, document: document },
-      distinctFns,
-      supportedDiagnostics
-    );
+    CsRefactoringRequests.initiate(document, distinctFns, supportedDiagnostics);
   }
 }
 

--- a/src/refactoring/utils.ts
+++ b/src/refactoring/utils.ts
@@ -1,4 +1,4 @@
-import { Diagnostic } from 'vscode';
+import { Diagnostic, TextDocument, window } from 'vscode';
 import { PreFlightResponse, ReasonsWithDetails } from '../cs-rest-api';
 import { DiagnosticFilter, isDefined } from '../utils';
 
@@ -34,4 +34,22 @@ export function decorateCode(code: string, languageId: string, reasonsWithDetail
 export function createCodeSmellsFilter(refactorCapabilities: PreFlightResponse): DiagnosticFilter {
   return (d: Diagnostic) =>
     d.code instanceof Object && refactorCapabilities.supported['code-smells'].includes(d.code.value.toString());
+}
+
+/**
+ * Finds the editor associated with the request document.
+ *
+ * Primarily this is the activeTextEditor, but that might be out of focus. If so, we will
+ * target the first editor in the list of visibleTextEditors matching the request document.
+ */
+export function targetEditor(document: TextDocument) {
+  if (window.activeTextEditor?.document === document) {
+    return window.activeTextEditor;
+  } else {
+    for (const e of window.visibleTextEditors) {
+      if (e.document === document) {
+        return e;
+      }
+    }
+  }
 }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,5 +1,5 @@
 // This module provides a global interface to the CodeScene telemetry singleton.
-import axios, { AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import * as vscode from 'vscode';
 import { sign } from './codescene-interop';
 import { logAxiosError } from './cs-rest-api';
@@ -10,25 +10,34 @@ export default class Telemetry {
   private static _instance: Telemetry;
 
   private telemetryLogger: vscode.TelemetryLogger;
+  private axiosInstance: AxiosInstance;
 
   private session?: vscode.AuthenticationSession;
 
-  constructor(private cliPath: string) {
+  constructor(extension: vscode.Extension<any>, private cliPath: string) {
     const sender: vscode.TelemetrySender = {
       sendEventData: (eventName, eventData) => {
-        void this.postTelemetry(eventName, eventData);
+        this.postTelemetry(eventName, eventData).catch(() => {}); // post but ignore errors (logged using logAxiosError in interceptor instead)
       },
       sendErrorData: (error) => {
         logOutputChannel.error(error);
       },
     };
+    this.axiosInstance = axios.create({
+      timeout: 5000,
+      headers: {
+        'content-type': 'application/json',
+        'User-Agent': `${extension.id}/${extension.packageJSON.version} axios/${axios.VERSION}`,
+      },
+    });
+    this.axiosInstance.interceptors.response.use(undefined, logAxiosError);
 
-    this.telemetryLogger = vscode.env.createTelemetryLogger(sender);
+    this.telemetryLogger = vscode.env.createTelemetryLogger(sender, { ignoreUnhandledErrors: true });
   }
 
-  static init(cliPath: string): void {
+  static init(extension: vscode.Extension<any>, cliPath: string): void {
     outputChannel.appendLine('Initializing telemetry logger');
-    Telemetry._instance = new Telemetry(cliPath);
+    Telemetry._instance = new Telemetry(extension, cliPath);
   }
 
   static get instance(): Telemetry {
@@ -58,13 +67,11 @@ export default class Telemetry {
 
     const config: AxiosRequestConfig = {
       headers: {
-        'content-type': 'application/json',
         'x-codescene-signature': signResult.stdout,
       },
-      timeout: 5000, //milliseconds
     };
 
-    axios.post('https://devtools.codescene.io/api/analytics/events/ide', jsonData, config).catch(logAxiosError);
+    return this.axiosInstance.post('https://devtools.codescene.io/api/analytics/events/ide', jsonData, config);
   }
 
   setSession(session?: vscode.AuthenticationSession) {

--- a/src/test/suite/cs-rest-api.test.ts
+++ b/src/test/suite/cs-rest-api.test.ts
@@ -1,0 +1,9 @@
+import * as assert from 'assert';
+import { CsRestApi } from '../../cs-rest-api';
+
+suite('Cs Rest Api test', () => {
+  test('Get Rest API instance ', () => {
+    // Will fail creating an instance if we change the extension id
+    assert.ok(CsRestApi.instance);
+  });
+});

--- a/src/webviews/status-webview-script.ts
+++ b/src/webviews/status-webview-script.ts
@@ -16,4 +16,8 @@ function main() {
   document
     .getElementById('auto-refactor-link')
     ?.addEventListener('click', () => sendMessage('focus-explorer-ace-view'));
+  document.getElementById('clear-errors-button')?.addEventListener('click', () => sendMessage('clear-errors'));
+  document
+    .getElementById('show-codescene-log-link')
+    ?.addEventListener('click', () => sendMessage('show-codescene-log-output'));
 }


### PR DESCRIPTION
We should not present individual errors for refactoring requests, rather show them in a more general manner.

This PR uses the statusView panel and statusBar item for that. We also include links to the CodeScene Log output for more info, and an option to clear the error state.

<img width="369" alt="Screenshot 2024-03-11 at 16 06 37" src="https://github.com/codescene-oss/codescene-vscode/assets/238111/d1560133-545a-4b16-a009-b27bfa84ed4d">
<img width="375" alt="Screenshot 2024-03-11 at 16 06 07" src="https://github.com/codescene-oss/codescene-vscode/assets/238111/e039c72f-72b6-4dbc-825b-e8e30f4d1ac8">
