### PR TITLE
Code health rules debugger in vscode

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
         "title": "CodeScene: Create Rules Template"
       },
       {
+        "command": "codescene.showVerboseReview",
+        "title": "CodeScene: Show review with verbose logging"
+      },
+      {
         "command": "codescene.openCodeHealthDocs",
         "title": "CodeScene: Open Code Health Documentation"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,9 +139,7 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
   context.subscriptions.push(createRulesTemplateCmd);
 
   const createShowVerboseReview = vscode.commands.registerCommand('codescene.showVerboseReview', () => {
-    showVerboseReview(cliPath).catch((error: Error) => {
-      void vscode.window.showErrorMessage(error.message);
-    });
+    showVerboseReview();
   });
   context.subscriptions.push(createShowVerboseReview);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { createCodeSmellsFilter } from './refactoring/utils';
 import { CsReviewCodeLensProvider } from './review/codelens';
 import Reviewer from './review/reviewer';
 import { createRulesTemplate } from './rules-template';
+import { showVerboseReview } from './verbose-review';
 import { StatsCollector } from './stats';
 import Telemetry from './telemetry';
 import { registerStatusViewProvider } from './webviews/status-view-provider';
@@ -136,6 +137,13 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
     });
   });
   context.subscriptions.push(createRulesTemplateCmd);
+
+  const createShowVerboseReview = vscode.commands.registerCommand('codescene.showVerboseReview', () => {
+    showVerboseReview(cliPath).catch((error: Error) => {
+      void vscode.window.showErrorMessage(error.message);
+    });
+  });
+  context.subscriptions.push(createShowVerboseReview);
 
   // This command tries to get a "codescene" session. The createIfNone option causes a dialog to pop up,
   // asking the user to log in. (Currently unused)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,9 +18,9 @@ import { createCodeSmellsFilter } from './refactoring/utils';
 import { CsReviewCodeLensProvider } from './review/codelens';
 import Reviewer from './review/reviewer';
 import { createRulesTemplate } from './rules-template';
-import { showVerboseReview } from './verbose-review';
 import { StatsCollector } from './stats';
 import Telemetry from './telemetry';
+import { registerCommand as registerVerboseReviewCmd } from './verbose-review';
 import { registerStatusViewProvider } from './webviews/status-view-provider';
 import { CsWorkspace } from './workspace';
 import debounce = require('lodash.debounce');
@@ -138,11 +138,8 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
   });
   context.subscriptions.push(createRulesTemplateCmd);
 
-  const createShowVerboseReview = vscode.commands.registerCommand('codescene.showVerboseReview', () => {
-    showVerboseReview();
-  });
-  context.subscriptions.push(createShowVerboseReview);
-
+  registerVerboseReviewCmd(context, reviewDocumentSelector());
+  
   // This command tries to get a "codescene" session. The createIfNone option causes a dialog to pop up,
   // asking the user to log in. (Currently unused)
   const loginCommand = vscode.commands.registerCommand('codescene.signInWithCodeScene', () => {

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -2,7 +2,7 @@ import { dirname } from 'path';
 import * as vscode from 'vscode';
 import { getConfiguration } from '../configuration';
 import { LimitingExecutor, SimpleExecutor } from '../executor';
-import { logOutputChannel, outputChannel } from '../log';
+import { outputChannel } from '../log';
 import { StatsCollector } from '../stats';
 import { getFileExtension } from '../utils';
 import { ReviewResult } from './model';
@@ -73,8 +73,9 @@ class SimpleReviewer implements IReviewer {
       .then(({ stdout, stderr, duration }) => {
         StatsCollector.instance.recordAnalysis(extension, duration);
         if (reviewOpts.verbose) {
-          logOutputChannel.info(`Review stdout: ${stdout}`);
-          logOutputChannel.info(`Review verbose: ${stderr}`);
+          outputChannel.append(`Review stdout: ${stdout}`);
+          outputChannel.append(`Review verbose: ${stderr}`);
+          outputChannel.show();
         }
 
         const data = JSON.parse(stdout) as ReviewResult;

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -70,11 +70,10 @@ class SimpleReviewer implements IReviewer {
     const result = this.executor.execute(cmd, { cwd: documentDirectory }, document.getText());
 
     const diagnostics = result
-      .then(({ stdout, stderr, duration }) => {
+      .then(({ stderr, stdout, duration }) => {
         StatsCollector.instance.recordAnalysis(extension, duration);
         if (reviewOpts.verbose) {
-          outputChannel.append(`Review stdout: ${stdout}`);
-          outputChannel.append(`Review verbose: ${stderr}`);
+          outputChannel.appendLine(`Review verbose: ${stderr}`);
           outputChannel.show();
         }
 

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -49,6 +49,13 @@ class SimpleReviewer implements IReviewer {
 
   constructor(private cliPath: string) {}
 
+  private codeHealthRulesInfo(verboseOutput: string) {
+    return verboseOutput
+      .split('\n')
+      .filter((line) => line.startsWith('Overriding code health') || line.startsWith('Using custom code health'))
+      .join('\n');
+  }
+
   review(document: vscode.TextDocument, reviewOpts: ReviewOpts = {}): Promise<vscode.Diagnostic[]> {
     const extension = getFileExtension(document.fileName);
 
@@ -73,7 +80,9 @@ class SimpleReviewer implements IReviewer {
       .then(({ stderr, stdout, duration }) => {
         StatsCollector.instance.recordAnalysis(extension, duration);
         if (reviewOpts.verbose) {
-          outputChannel.appendLine(`Review verbose: ${stderr}`);
+          outputChannel.appendLine('');
+          outputChannel.appendLine('Custom code health rules info:');
+          outputChannel.appendLine(this.codeHealthRulesInfo(stderr));
           outputChannel.show();
         }
 
@@ -94,7 +103,7 @@ class SimpleReviewer implements IReviewer {
       })
       .catch((e) => {
         this.errorEmitter.fire(e);
-        return [];
+        return [] as vscode.Diagnostic[];
       })
       .finally(() => {
         this.reviewEmitter.fire('idle');

--- a/src/verbose-review.ts
+++ b/src/verbose-review.ts
@@ -1,0 +1,19 @@
+import { window } from 'vscode';
+import Reviewer from "./review/reviewer";
+
+/**
+ * Function to show verbose response for review command in current file. This will help users understand if the rules file is configured properly. 
+ * @param cliPath path to the CodeScene binary
+ * @returns void
+ */
+export async function showVerboseReview(cliPath: string) {
+    const editor = window.activeTextEditor;
+    if (editor && editor.document) {
+        const uri = editor.document.uri;
+        const filePath = uri.fsPath;
+        const res = await Reviewer.instance.review(editor.document, {skipCache: true, verbose: true});
+        void window.showInformationMessage("Check log output for result");
+    } else {
+        void window.showErrorMessage('No file is currently selected.');
+    }
+  }

--- a/src/verbose-review.ts
+++ b/src/verbose-review.ts
@@ -1,15 +1,21 @@
-import { window } from 'vscode';
-import Reviewer from "./review/reviewer";
+import vscode, { window } from 'vscode';
+import Reviewer from './review/reviewer';
 
 /**
- * Function to show verbose response for review command in current file. This will help users understand if the rules file is configured properly. 
+ * Command to show verbose response for review command in current file. This will help users understand if the rules file is configured properly.
  * @returns void
  */
-export function showVerboseReview() {
-    const editor = window.activeTextEditor;
-    if (editor && editor.document) {
-        void Reviewer.instance.review(editor.document, {skipCache: true, verbose: true});
-    } else {
-        void window.showErrorMessage('No file is currently selected.');
+export function registerCommand(context: vscode.ExtensionContext, documentSelector: vscode.DocumentSelector) {
+  const disposable = vscode.commands.registerCommand('codescene.showVerboseReview', () => {
+    const document = window.activeTextEditor?.document;
+
+    if (!document || vscode.languages.match(documentSelector, document) === 0) {
+      void window.showErrorMessage('No valid file selected.');
+      return;
     }
-  }
+
+    void Reviewer.instance.review(document, { skipCache: true, verbose: true });
+  });
+
+  context.subscriptions.push(disposable);
+}

--- a/src/verbose-review.ts
+++ b/src/verbose-review.ts
@@ -3,15 +3,12 @@ import Reviewer from "./review/reviewer";
 
 /**
  * Function to show verbose response for review command in current file. This will help users understand if the rules file is configured properly. 
- * @param cliPath path to the CodeScene binary
  * @returns void
  */
-export async function showVerboseReview(cliPath: string) {
+export function showVerboseReview() {
     const editor = window.activeTextEditor;
     if (editor && editor.document) {
-        const uri = editor.document.uri;
-        const filePath = uri.fsPath;
-        const res = await Reviewer.instance.review(editor.document, {skipCache: true, verbose: true});
+        void Reviewer.instance.review(editor.document, {skipCache: true, verbose: true});
     } else {
         void window.showErrorMessage('No file is currently selected.');
     }

--- a/src/verbose-review.ts
+++ b/src/verbose-review.ts
@@ -12,7 +12,6 @@ export async function showVerboseReview(cliPath: string) {
         const uri = editor.document.uri;
         const filePath = uri.fsPath;
         const res = await Reviewer.instance.review(editor.document, {skipCache: true, verbose: true});
-        void window.showInformationMessage("Check log output for result");
     } else {
         void window.showErrorMessage('No file is currently selected.');
     }


### PR DESCRIPTION
Write verbose output from CLI to output to enable users to understand which rules in code-health-rules.json applies to current file.