### PR TITLE
UX improvements, present review state

### DIFF
--- a/src/cs-diagnostics.ts
+++ b/src/cs-diagnostics.ts
@@ -27,19 +27,14 @@ export default class CsDiagnostics {
       return;
     }
 
-    Reviewer.instance
-      .review(document, reviewOpts)
-      .then((diagnostics) => {
-        // Remove the diagnostics that are for file level issues. These are only shown as code lenses
-        const importantDiagnostics = diagnostics.filter((d) => !d.message.startsWith(chScorePrefix));
-        CsDiagnostics.set(document.uri, importantDiagnostics);
+    void Reviewer.instance.review(document, reviewOpts).then((diagnostics) => {
+      // Remove the diagnostics that are for file level issues. These are only shown as code lenses
+      const importantDiagnostics = diagnostics.filter((d) => !d.message.startsWith(chScorePrefix));
+      CsDiagnostics.set(document.uri, importantDiagnostics);
 
-        // Try to request refactorings for the important diagnostics
-        void vscode.commands.executeCommand(requestRefactoringsCmdName, document, importantDiagnostics);
-      })
-      .catch((e) => {
-        logOutputChannel.error(`Review error ${e}`);
-      });
+      // Try to request refactorings for the important diagnostics
+      void vscode.commands.executeCommand(requestRefactoringsCmdName, document, importantDiagnostics);
+    });
   }
 
   static abort(document: vscode.TextDocument) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,11 +61,14 @@ function startExtension(context: vscode.ExtensionContext, cliPath: string, csExt
     csWorkspace: new CsWorkspace(context),
     csExtensionState,
   };
-  // CsRestApi.init(context.extension);
   Reviewer.init(cliPath);
   Telemetry.init(context.extension, cliPath);
   // send telemetry on activation (gives us basic usage stats)
   Telemetry.instance.logUsage('onActivateExtension');
+
+  csExtensionState.addErrorListener(Reviewer.instance.onDidReviewFail);
+  csExtensionState.addReviewStatusListener(Reviewer.instance.onDidReview);
+  csExtensionState.addErrorListener(CsRefactoringRequests.onDidRequestFail);
 
   // The DiagnosticCollection provides the squigglies and also form the basis for the CodeLenses.
   CsDiagnostics.init(context);

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -50,6 +50,9 @@ export class StatusViewProvider implements WebviewViewProvider {
         case 'focus-explorer-ace-view':
           void vscode.commands.executeCommand('codescene.explorerAutoRefactorView.focus');
           return;
+        case 'focus-problems-view':
+          void vscode.commands.executeCommand('workbench.action.problems.focus');
+          return;
         case 'clear-errors':
           void vscode.commands.executeCommand('codescene.extensionState.clearErrors');
           logOutputChannel.clear();
@@ -109,7 +112,8 @@ export class StatusViewProvider implements WebviewViewProvider {
       return /*html*/ `
         <h3>Code Health Analysis</h3>
         <p>Live <a href="https://codescene.io/docs/terminology/codescene-terminology.html#code-health">Code Health</a> 
-        Analysis is enabled. Code health metrics and issues are available as a CodeLenses and in the Problems panel.
+        Analysis is enabled. Code health metrics and issues are available as a CodeLenses and in the 
+        <a href="" id="problems-panel-link">Problems panel</a>.
         </p>
       `;
     }

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -217,8 +217,8 @@ export class StatusViewProvider implements WebviewViewProvider {
   private errorContent(serviceErrors: any[]) {
     return /*html*/ `
       <hr>
-      <h3><span class="codicon codicon-warning color-warning"></span> Service errors</h3>
-      <p>There was an error when communicating with the CodeScene service.</p>
+      <h3><span class="codicon codicon-warning color-warning"></span> Errors</h3>
+      <p>The CodeScene extension has encountered an error.</p>
       ${this.checkLogsContent()}
       <vscode-button id="clear-errors-button" aria-label="Clear errors" 
       title="Ignore and continue using the CodeScene extension">

--- a/src/webviews/status-webview-script.ts
+++ b/src/webviews/status-webview-script.ts
@@ -16,6 +16,7 @@ function main() {
   document
     .getElementById('auto-refactor-link')
     ?.addEventListener('click', () => sendMessage('focus-explorer-ace-view'));
+  document.getElementById('problems-panel-link')?.addEventListener('click', () => sendMessage('focus-problems-view'));
   document.getElementById('clear-errors-button')?.addEventListener('click', () => sendMessage('clear-errors'));
   document
     .getElementById('show-codescene-log-link')


### PR DESCRIPTION
### Problem
As a user of the extension it's sometimes hard to know when to expect to see the code health analysis results, especially when working with larger files where the review can take a bit longer.

### Solution
Show a loading indication in the status bar item when a review is running. Also, the review state is used to show that a code review is pending in the Auto-refactoring view.

![Screenshot 2024-04-16 at 11 19 29](https://github.com/codescene-oss/codescene-vscode/assets/238111/b7939857-8ebc-4476-a22a-df69adfe890e) ![Screenshot 2024-04-16 at 11 19 39](https://github.com/codescene-oss/codescene-vscode/assets/238111/81d33325-8ebe-4aab-8055-a9e7c0a2db28)
