### PR TITLE
Fix max-input-loc vs Large Method discrepancy

### DIFF
--- a/src/codescene-interop.ts
+++ b/src/codescene-interop.ts
@@ -30,6 +30,7 @@ export interface EnclosingFn {
   'function-type': string;
   'start-column': number;
   'end-column': number;
+  'active-code-size': number;
 }
 /**
  * Executes the command for getting function coordinates for a list of line numbers.

--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -4,9 +4,9 @@ import { toRefactoringDocumentSelector } from '../language-support';
 import { logOutputChannel } from '../log';
 import { DiagnosticFilter, getFileExtension, isDefined } from '../utils';
 import { CsRefactoringRequests, ResolvedRefactoring, validConfidenceLevel } from './cs-refactoring-requests';
+import { PreFlightResponse } from './model';
 import { RefactoringPanel } from './refactoring-panel';
 import { createCodeSmellsFilter } from './utils';
-import { PreFlightResponse } from './model';
 
 export const requestRefactoringsCmdName = 'codescene.requestRefactorings';
 export const presentRefactoringCmdName = 'codescene.presentRefactoring';
@@ -121,9 +121,12 @@ function toFnToRefactor(
   extension: string,
   maxInputLoc: number
 ) {
-  const { range, loc } = rangeAndLocFromEnclosingFn(enclosingFn);
-  if (loc > maxInputLoc) {
-    logOutputChannel.debug(`Function "${enclosingFn.name}" exceeds max-input-loc (${loc} > ${maxInputLoc}) - ignoring`);
+  const activeLoc = enclosingFn['active-code-size'];
+  const range = rangeFromEnclosingFn(enclosingFn);
+  if (activeLoc > maxInputLoc) {
+    logOutputChannel.debug(
+      `Function "${enclosingFn.name}" exceeds max-input-loc (${activeLoc} > ${maxInputLoc}) - ignoring`
+    );
     return;
   }
 
@@ -137,14 +140,13 @@ function toFnToRefactor(
 }
 
 // Note that vscode.Range line numbers are zero-based, while the CodeScene API uses 1-based line numbers
-export function rangeAndLocFromEnclosingFn(enclosingFn: EnclosingFn) {
-  const range = new vscode.Range(
+export function rangeFromEnclosingFn(enclosingFn: EnclosingFn) {
+  return new vscode.Range(
     enclosingFn['start-line'] - 1,
     enclosingFn['start-column'],
     enclosingFn['end-line'] - 1,
     enclosingFn['end-column']
   );
-  return { range, loc: loc(range) };
 }
 
 export const refactoringSymbol = '✨';

--- a/src/test/suite/refactor-commands.test.ts
+++ b/src/test/suite/refactor-commands.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { Range } from 'vscode';
 import { EnclosingFn } from '../../codescene-interop';
-import { rangeAndLocFromEnclosingFn } from '../../refactoring/commands';
+import { rangeFromEnclosingFn } from '../../refactoring/commands';
 
 const enclosingFn1: EnclosingFn = {
   name: 'anon',
@@ -11,6 +11,7 @@ const enclosingFn1: EnclosingFn = {
   'function-type': 'FatArrrowFn',
   'start-column': 0,
   'end-column': 19,
+  'active-code-size': 1,
 };
 
 const enclosingFn2: EnclosingFn = {
@@ -21,18 +22,17 @@ const enclosingFn2: EnclosingFn = {
   'function-type': 'StandaloneFn',
   'start-column': 0,
   'end-column': 1,
+  'active-code-size': 54,
 };
 
 suite('Refactor commands Test Suite', () => {
   test('Handle output from findEnclosingFunction call', async () => {
-    const { range, loc } = rangeAndLocFromEnclosingFn(enclosingFn1);
+    const range = rangeFromEnclosingFn(enclosingFn1);
     assert.ok(range.isEqual(new Range(0, 0, 0, 19)));
-    assert.equal(loc, 1);
   });
 
   test('Handle output from findEnclosingFunction call', async () => {
-    const { range, loc } = rangeAndLocFromEnclosingFn(enclosingFn2);
+    const range = rangeFromEnclosingFn(enclosingFn2);
     assert.ok(range.isEqual(new Range(47, 0, 100, 1)));
-    assert.equal(loc, 54);
   });
 });

--- a/src/webviews/status-view-provider.ts
+++ b/src/webviews/status-view-provider.ts
@@ -172,7 +172,7 @@ export class StatusViewProvider implements WebviewViewProvider {
         <ul>${languageIdList}</ul>
         Supported code smells:
         <ul>${codeSmellList}</ul>
-        Also, only functions under ${preflight['max-input-loc']} lines of code will be considered for refactoring.
+        Also, only functions under ${preflight['max-input-loc']} lines of code will be considered for refactoring (ignoring commented lines).
         </p>
         <p><span class="codicon codicon-question"></span> <a href="https://codescene.io/docs/auto-refactor/index.html">Documentation on codescene.io</a><br/>
         <span class="codicon codicon-verified"></span> <a href="https://codescene.com/product/ace/principles">Privacy Principles for CodeScene AI Based Services</a></p>


### PR DESCRIPTION
The Large Method code smell is displayed in the vscode extension with details of the actual lines-of-code (LoC) count. This LoC is calculated by the scoring as the active code count - i.e. ignoring comments.

Worth noting is that this count is also used when checking against `function_lines_of_code_warning` in the optional `code-health-rules.json`.

The max-loc-check before requesting a refactoring via ACE is done by just counting the actual lines in the editor. As a user it is hard to understand why for example a function with LoC = 125 - which is below the number reported by the ACE preflight (130) - cannot be refactored.

This PR updates the function info with "active code size" and uses that when comparing against the ACE service preflight response.