### PR TITLE
Add Bright[er]Script languageId support

### DIFF
--- a/src/code-health-gate/analyser.ts
+++ b/src/code-health-gate/analyser.ts
@@ -61,10 +61,11 @@ export class DeltaAnalyser {
     const newJson = JSON.stringify(newScore);
     if (oldJson === newJson) return;
 
-    if (isDefined(newScore)) {
-      return `{"old-score": ${oldJson}, "new-score": ${newJson}}`;
+    // The devtools binary handles either being undef, but not both
+    if (isDefined(oldScore) || isDefined(newScore)) {
+      // Make sure not to put "undefined" in the json string - it is an invalid json token while null is
+      return `{"old-score": ${oldJson || null}, "new-score": ${newJson || null}}`;
     }
-    return `{"old-score": ${oldJson}}`;
   }
 
   async deltaForScores(document: vscode.TextDocument, oldScore: any, newScore: any) {
@@ -72,6 +73,7 @@ export class DeltaAnalyser {
 
     const inputJsonString = this.jsonForScores(oldScore, newScore);
     if (!inputJsonString) {
+      this.endAnalysisEvent(document);
       return;
     }
 

--- a/src/language-support.ts
+++ b/src/language-support.ts
@@ -11,6 +11,9 @@ const extToLanguageId = new Map<string, string | string[]>([
   ['ts', 'typescript'],
   ['tsx', 'typescriptreact'],
 
+  ['brs', 'brightscript'],
+  ['bs', 'brighterscript'],
+
   ['cls', 'apex'],
   ['tgr', 'apex'],
   ['trigger', 'apex'],

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -159,6 +159,7 @@ class CachingReviewer {
       switch (e.exitCode) {
         case 2:
           logOutputChannel.warn(e.message);
+          void vscode.window.showWarningMessage(e.message);
           return;
         case 'ABORT_ERR':
           // Delete the cache entry for this document if the review was aborted (document closed)


### PR DESCRIPTION
The `brightscript` and `brighterscript` languageIds are provided by the [RokuCommunity.brightscript](https://marketplace.visualstudio.com/items?itemName=RokuCommunity.brightscript) extension and were not in the original [list of vscode languageIds](https://code.visualstudio.com/docs/languages/identifiers). Because of this, brightscript files were not picked up by our review DocumentSelector.

Fixed by adding the mapping in `language-support.ts`