### PR TITLE
feat(codelens): Implement a menu codelens for code health monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,13 +93,6 @@
       }
     ],
     "menus": {
-      "view/item/context": [
-        {
-          "command": "codescene.chMonitorTreeContext.presentRefactoring",
-          "when": "view == codescene.codeHealthMonitorView && viewItem === 'delta-refactorableFunction'",
-          "group": "inline@1"
-        }
-      ],
       "view/title": [
         {
           "command": "codescene.codeHealthMonitorHelp",

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -3,6 +3,7 @@ import { Branch, GitExtension, Repository } from '../../types/git';
 import { AceAPI } from '../refactoring/addon';
 import Reviewer from '../review/reviewer';
 import { registerCommandWithTelemetry } from '../utils';
+import { register as registerCodeLens } from './codelens';
 import { CodeHealthMonitorView } from './tree-view';
 
 export function activate(context: vscode.ExtensionContext, aceApi?: AceAPI) {
@@ -16,6 +17,7 @@ export function activate(context: vscode.ExtensionContext, aceApi?: AceAPI) {
 
   const gitApi = gitExtension.getAPI(1);
   const repoStateListeners = gitApi.repositories.map((repo) => repo.state.onDidChange(() => onRepoStateChange(repo)));
+  registerCodeLens(context);
 
   context.subscriptions.push(
     codeHealthMonitorView,

--- a/src/code-health-monitor/codelens.ts
+++ b/src/code-health-monitor/codelens.ts
@@ -1,0 +1,107 @@
+import * as vscode from 'vscode';
+import { InteractiveDocsParams } from '../documentation/csdoc-provider';
+import { reviewDocumentSelector } from '../language-support';
+import { DeltaFunctionInfo } from './tree-model';
+
+export function register(context: vscode.ExtensionContext) {
+  const codeLensProvider = new CodeHealthMonitorCodeLens();
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(reviewDocumentSelector(), codeLensProvider),
+    vscode.commands.registerCommand('codescene.monitorCodeLens.showFunction', (functionInfo: DeltaFunctionInfo) => {
+      const uri = functionInfo.parent.uri;
+      const location = new vscode.Location(uri, functionInfo.position);
+      codeLensProvider.showFor(functionInfo);
+      void vscode.commands.executeCommand('editor.action.goToLocations', uri, functionInfo.position, [location]);
+    }),
+    vscode.commands.registerCommand('codescene.monitorCodeLens.dismiss', () => {
+      codeLensProvider.dismiss();
+    })
+  );
+}
+
+export class CodeHealthMonitorCodeLens implements vscode.CodeLensProvider<vscode.CodeLens> {
+  private changeCodeLensesEmitter = new vscode.EventEmitter<void>();
+  onDidChangeCodeLenses = this.changeCodeLensesEmitter.event;
+
+  codeLenses: vscode.CodeLens[] = [];
+
+  // Listeners to dismiss the menu code lenses when the document is changed or closed
+  private disposables: vscode.Disposable[] = [];
+
+  provideCodeLenses(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.CodeLens[]> {
+    return this.codeLenses;
+  }
+
+  update() {
+    this.changeCodeLensesEmitter.fire();
+  }
+
+  showFor(functionInfo: DeltaFunctionInfo) {
+    this.clear();
+    const documentUri = functionInfo.parent.uri;
+    this.disposables = [
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        if (e.document.uri !== documentUri) return;
+        this.dismiss();
+      }),
+      vscode.workspace.onDidCloseTextDocument((doc) => {
+        if (doc.uri !== documentUri) return;
+        this.dismiss();
+      }),
+    ];
+
+    const fnRange = new vscode.Range(functionInfo.position, functionInfo.position);
+    if (functionInfo.refactoring) {
+      this.codeLenses.push(
+        new vscode.CodeLens(fnRange, {
+          title: '$(sparkle) CodeScene ACE',
+          command: 'codescene.presentRefactoring',
+          arguments: [functionInfo.refactoring.resolvedRefactoring()],
+        })
+      );
+    }
+
+    functionInfo.children.forEach((issue) => {
+      const issueRange = new vscode.Range(issue.position, issue.position);
+
+      const params: InteractiveDocsParams = {
+        codeSmell: {
+          category: issue.category,
+          position: issue.position,
+        },
+        documentUri: issue.parentUri,
+      };
+
+      this.codeLenses.push(
+        new vscode.CodeLens(issueRange, {
+          title: `$(warning) ${issue.category}`,
+          command: 'codescene.openInteractiveDocsPanel',
+          arguments: [params],
+        })
+      );
+    });
+
+    this.codeLenses.push(
+      new vscode.CodeLens(fnRange, {
+        title: '$(circle-slash) Dismiss',
+        command: 'codescene.monitorCodeLens.dismiss',
+        arguments: [documentUri],
+      })
+    );
+
+    this.update();
+  }
+
+  private clear() {
+    this.disposables.forEach((l) => l.dispose());
+    this.codeLenses = [];
+  }
+
+  dismiss() {
+    this.clear();
+    this.update();
+  }
+}

--- a/src/code-health-monitor/tree-model.ts
+++ b/src/code-health-monitor/tree-model.ts
@@ -134,7 +134,7 @@ export class FileWithIssues implements DeltaTreeViewItem {
 export class DeltaFunctionInfo implements DeltaTreeViewItem {
   readonly fnName: string;
   readonly position: vscode.Position;
-  readonly children: Array<DeltaTreeViewItem> = [];
+  readonly children: Array<DeltaIssue> = [];
 
   constructor(readonly parent: FileWithIssues, readonly location: Location, public refactoring?: CsRefactoringRequest) {
     this.fnName = location.function;
@@ -161,12 +161,10 @@ export class DeltaFunctionInfo implements DeltaTreeViewItem {
   }
 
   private get command() {
-    const uri = this.parent.uri;
-    const location = new vscode.Location(uri, this.position);
     return {
-      command: 'editor.action.goToLocations',
-      title: 'Go to location',
-      arguments: [uri, this.position, [location]],
+      command: 'codescene.monitorCodeLens.showFunction',
+      title: 'Show function with code lens menu',
+      arguments: [this],
     };
   }
 
@@ -191,7 +189,6 @@ export class DeltaFunctionInfo implements DeltaTreeViewItem {
 
   private presentAsRefactorable(item: vscode.TreeItem) {
     item.tooltip = this.tooltip(true);
-    item.contextValue = 'delta-refactorableFunction';
     item.iconPath = new vscode.ThemeIcon('sparkle');
   }
 }

--- a/src/refactoring/cs-refactoring-requests.ts
+++ b/src/refactoring/cs-refactoring-requests.ts
@@ -84,10 +84,6 @@ function validConfidenceLevel(level: number) {
   return level > 0;
 }
 
-/**
- * Map of diagnostics to refactoring requests - per document.
- * Used to get the proper requests when presenting the refactoring codelenses and codeactions.
- */
 export class CsRefactoringRequests {
   private static readonly requestsChangedEmitter = new EventEmitter<AceRequestEvent>();
   static readonly onDidChangeRequests = CsRefactoringRequests.requestsChangedEmitter.event;


### PR DESCRIPTION
This menu code lens is activated when clicking functions in the code health monitor, showing CodeScene ACE if available, along with code smells affecting this function.

Note - this changes the previous behaviour for showing code smells as code lenses. The review diagnostics are still visible in the regular vscode squiggly line fashion along with showing them in the problems view. 