### PR TITLE
feat: Add code action for ACE and interactive docs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,7 @@ import Telemetry from './telemetry';
 import { registerCommandWithTelemetry } from './utils';
 import { CsWorkspace } from './workspace';
 import debounce = require('lodash.debounce');
+import { register as registerCodeActionProvider } from './review/codeaction';
 
 interface CsContext {
   csWorkspace: CsWorkspace;
@@ -79,6 +80,8 @@ function startExtension(context: vscode.ExtensionContext) {
   const codeLensProvider = new CsReviewCodeLensProvider();
   context.subscriptions.push(codeLensProvider);
   context.subscriptions.push(vscode.languages.registerCodeLensProvider(reviewDocumentSelector(), codeLensProvider));
+
+  registerCodeActionProvider(context, csContext.aceApi);
 
   // If configuration option is changed, en/disable ACE capabilities accordingly - debounce to handle rapid changes
   const debouncedEnableOrDisableACECapabilities = debounce(enableOrDisableACECapabilities, 500);

--- a/src/review/codeaction.ts
+++ b/src/review/codeaction.ts
@@ -1,0 +1,92 @@
+import * as vscode from 'vscode';
+import { InteractiveDocsParams } from '../documentation/csdoc-provider';
+import { reviewDocumentSelector } from '../language-support';
+import { AceAPI } from '../refactoring/addon';
+import { isDefined } from '../utils';
+import Reviewer from './reviewer';
+import { getCsDiagnosticCode } from './utils';
+import { CsRefactoringRequest } from '../refactoring/cs-refactoring-requests';
+
+export function register(context: vscode.ExtensionContext, aceApi?: AceAPI) {
+  const codeActionProvider = new ReviewCodeActionProvider(aceApi);
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(reviewDocumentSelector(), codeActionProvider),
+    codeActionProvider
+  );
+}
+
+class ReviewCodeActionProvider implements vscode.CodeActionProvider, vscode.Disposable {
+  readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix, vscode.CodeActionKind.Empty];
+  private disposables: vscode.Disposable[] = [];
+
+  private requestsForDocument = new Map<string, CsRefactoringRequest[]>();
+
+  constructor(aceApi?: AceAPI) {
+    if (aceApi) {
+      this.disposables.push(
+        aceApi.onDidChangeRequests((event) => {
+          if (event.requests) {
+            this.requestsForDocument.set(event.document.uri.toString(), event.requests);
+          }
+        })
+      );
+    }
+  }
+
+  async provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+    context: vscode.CodeActionContext,
+    token: vscode.CancellationToken
+  ) {
+    const review = Reviewer.instance.reviewCache.get(document);
+    if (!review) return;
+
+    const diagnostics: vscode.Diagnostic[] = await review.review.diagnostics;
+
+    const actions = diagnostics
+      .filter((diagnostic) => diagnostic.range.contains(range))
+      .map((diagnostic) => {
+        const category = getCsDiagnosticCode(diagnostic.code);
+        if (!category) return;
+
+        const params: InteractiveDocsParams = {
+          codeSmell: {
+            category,
+            position: diagnostic.range.start,
+          },
+          documentUri: document.uri,
+        };
+        const title = `Explain ${category}`;
+        const action = new vscode.CodeAction(title, vscode.CodeActionKind.Empty);
+        action.diagnostics = [diagnostic];
+        action.command = {
+          command: 'codescene.openInteractiveDocsPanel',
+          title,
+          arguments: [params],
+        };
+        return action;
+      })
+      .filter(isDefined);
+
+    if (actions.length === 0) return;
+
+    const refactoringRequests = this.requestsForDocument.get(document.uri.toString());
+    const matchingRequest = refactoringRequests?.find((request) => request.fnToRefactor.range.contains(range));
+    if (matchingRequest) {
+      const refactorAction = new vscode.CodeAction('Refactor using CodeScene ACE', vscode.CodeActionKind.QuickFix);
+      refactorAction.command = {
+        command: 'codescene.presentRefactoring',
+        title: 'Refactor using CodeScene ACE',
+        arguments: [matchingRequest],
+      };
+      actions.unshift(refactorAction);
+    }
+
+    return actions;
+  }
+
+  dispose() {
+    this.disposables.forEach((d) => d.dispose());
+  }
+}


### PR DESCRIPTION
Clicking on 💡 or using the quick fix menu should add actions for explaining code-smells or viewing ACE refactorings if applicable:

<img width="410" alt="image" src="https://github.com/user-attachments/assets/913c51fa-2aa8-4f3f-a3ec-d086efc8114f">
