### PR TITLE
Log and startup chores

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,3 +1,4 @@
+const { error } = require('console');
 const { build, context } = require('esbuild');
 const { copy } = require('esbuild-plugin-copy');
 
@@ -13,9 +14,8 @@ function buildCounter(counterName) {
     setup: (build) => {
       let count = 0;
       build.onEnd((result) => {
-        console.log(`${new Date().toLocaleTimeString()} [${counterName}] build #${count}`);
-        result.errors.length > 0 && console.log(`   Warnings ${result.errors}`);
-        result.warnings.length > 0 && console.log(`   Errors ${result.warnings}`);
+        const warningOrError = result.errors.length > 0 || result.warnings.length > 0 ? '❌' : '';
+        console.log(`${new Date().toLocaleTimeString()} [${counterName}] build #${count} ${warningOrError}`);
         count++;
       });
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
       },
       {
         "command": "codescene.checkRules",
-        "title": "CodeScene: Check code health rule match for selected file"
+        "title": "CodeScene: Check code health rule match for selected file",
+        "when": "codescene.asyncActivationFinished"
       },
       {
         "command": "codescene.codeHealthMonitorHelp",
@@ -73,14 +74,14 @@
           "id": "codescene.codeHealthMonitorView",
           "name": "Code Health Monitoring [beta]",
           "icon": "$(cs-logo)",
-          "when": "config.codescene.previewCodeHealthMonitoring"
+          "when": "config.codescene.previewCodeHealthMonitoring && codescene.asyncActivationFinished"
         },
         {
           "id": "codescene.codeHealthDetailsView",
           "name": "Code Health Details [beta]",
           "icon": "$(cs-logo)",
           "type": "webview",
-          "when": "config.codescene.previewCodeHealthMonitoring"
+          "when": "config.codescene.previewCodeHealthMonitoring && codescene.asyncActivationFinished"
         }
       ]
     },

--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -15,7 +15,7 @@ import {
   window,
 } from 'vscode';
 import { getServerUrl } from '../configuration';
-import { outputChannel } from '../log';
+import { logOutputChannel } from '../log';
 import { CsServerVersion, ServerVersion } from '../server-version';
 import Telemetry from '../telemetry';
 import { PromiseAdapter, promiseFromEvent } from './util';
@@ -106,7 +106,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
 
     this.sessionChangeEmitter.fire({ added: [session], removed: [], changed: [] });
 
-    outputChannel.appendLine(`Created session ${session.id} for ${session.account.label}`);
+    logOutputChannel.info(`Created session ${session.id} for ${session.account.label}`);
 
     void window.showInformationMessage(`Signed in to CodeScene as ${session.account.label}`);
 
@@ -165,7 +165,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
       },
       async (_, cancelButtonToken) => {
         const loginUrl = await this.loginUrl();
-        outputChannel.appendLine(`Opening ${loginUrl.toString()}`);
+        logOutputChannel.debug(`Opening ${loginUrl.toString()}`);
 
         await env.openExternal(loginUrl);
 

--- a/src/check-rules.ts
+++ b/src/check-rules.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { window } from 'vscode';
 import { codeHealthRulesCheck } from './codescene-interop';
-import { outputChannel } from './log';
 
 /**
  * Function to show matching code health rule for currently opened file.
@@ -14,15 +13,15 @@ export async function checkCodeHealthRules() {
     const fileName = path.basename(absoluteFilePath);
     const folder = path.dirname(absoluteFilePath);
     const result = await codeHealthRulesCheck(folder, fileName);
-    const msg = result.stdout;
-    const error = result.stderr;
-    outputChannel.appendLine('----------');
-    if (error.trim() !== '') {
-      outputChannel.append(error);
+    const error = result.stderr.trim();
+    if (error !== '') {
+      void window.showErrorMessage(error);
     }
-    outputChannel.append(msg);
-    outputChannel.appendLine('----------');
-    outputChannel.show();
+    const msgParts = result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line !== '');
+    void window.showInformationMessage('Code Health Rules', { modal: true, detail: msgParts.join('\n\n') });
   } else {
     void window.showErrorMessage('No file is currently selected.');
   }

--- a/src/code-health-rules/check-rules.ts
+++ b/src/code-health-rules/check-rules.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { window } from 'vscode';
-import { codeHealthRulesCheck } from './codescene-interop';
+import { codeHealthRulesCheck } from '../codescene-interop';
 
 /**
  * Function to show matching code health rule for currently opened file.

--- a/src/code-health-rules/index.ts
+++ b/src/code-health-rules/index.ts
@@ -1,0 +1,24 @@
+import { window, ExtensionContext } from 'vscode';
+import { registerCommandWithTelemetry } from '../utils';
+import { checkCodeHealthRules } from './check-rules';
+import { createRulesTemplate } from './rules-template';
+
+export function register(context: ExtensionContext) {
+  const createRulesTemplateCmd = registerCommandWithTelemetry({
+    commandId: 'codescene.createRulesTemplate',
+    handler: () => {
+      createRulesTemplate().catch((error: Error) => {
+        void window.showErrorMessage(error.message);
+      });
+    },
+  });
+  context.subscriptions.push(createRulesTemplateCmd);
+
+  const createCheckRules = registerCommandWithTelemetry({
+    commandId: 'codescene.checkRules',
+    handler: () => {
+      void checkCodeHealthRules();
+    },
+  });
+  context.subscriptions.push(createCheckRules);
+}

--- a/src/code-health-rules/rules-template.ts
+++ b/src/code-health-rules/rules-template.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { QuickPickItem, Uri, WorkspaceFolder, window, workspace } from 'vscode';
-import { codeHealthRulesJson } from './codescene-interop';
+import { codeHealthRulesJson } from '../codescene-interop';
 
 const rulesPathAndFile: string = '.codescene/code-health-rules.json';
 

--- a/src/coupling/coupling-data-provider.ts
+++ b/src/coupling/coupling-data-provider.ts
@@ -9,7 +9,7 @@
 import * as vscode from 'vscode';
 import { CsRestApi } from '../cs-rest-api';
 import { Git } from '../git';
-import { outputChannel } from '../log';
+import { logOutputChannel } from '../log';
 import { CsWorkspace } from '../workspace';
 import { Coupling } from './model';
 import { difference } from './utils';
@@ -108,19 +108,19 @@ export class CouplingDataProvider {
     if (remoteRepoRootNames.size === 1 && localRepoRootNames.size === 1) {
       // When there's exactly one of both local and remote repo roots, we can assume it's intentional,
       // even if the root names don't match. Will go down the simple path resolution code-path.
-      outputChannel.appendLine(`Info: Change Coupling assuming one-to-one mapping of remote CodeScene repo "
+      logOutputChannel.info(`Change Coupling assuming one-to-one mapping of remote CodeScene repo "
       ${Array.from(remoteRepoRootNames)[0]}" and local git root "${Array.from(localRepoRootNames)[0]}".`);
       return true;
     }
 
     if (unmappedLocalRepos.size > 0 && unmappedRemoteRepos.size > 0) {
-      outputChannel.appendLine(
+      logOutputChannel.warn(
         'Warning: The following local workspace folders are not mapped to a repository in the CodeScene project:'
       );
-      unmappedLocalRepos.forEach((workspace) => outputChannel.appendLine(`  ${workspace}`));
-      outputChannel.appendLine('These are the unmapped repositories in the remote CodeScene project:');
-      unmappedRemoteRepos.forEach((repository) => outputChannel.appendLine(`  ${repository}`));
-      outputChannel.appendLine('Please make sure that the workspace folders and repositories names match.');
+      unmappedLocalRepos.forEach((workspace) => logOutputChannel.info(`  ${workspace}`));
+      logOutputChannel.info('These are the unmapped repositories in the remote CodeScene project:');
+      unmappedRemoteRepos.forEach((repository) => logOutputChannel.info(`  ${repository}`));
+      logOutputChannel.info('Please make sure that the workspace folders and repositories names match.');
     }
     return false;
   }

--- a/src/cs-rest-api.ts
+++ b/src/cs-rest-api.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosR
 import vscode from 'vscode';
 import { CodeSceneAuthenticationSession } from './auth/auth-provider';
 import { Coupling } from './coupling/model';
-import { logOutputChannel, outputChannel } from './log';
+import { logOutputChannel } from './log';
 import { FnToRefactor } from './refactoring/commands';
 import { CsServerVersion } from './server-version';
 import { PreFlightResponse, RefactorRequest, RefactorResponse } from './refactoring/model';
@@ -48,10 +48,9 @@ export class CsRestApi {
       const extension = vscode.extensions.getExtension('codescene.codescene-vscode');
       if (!extension) {
         const msg = 'Could not initiate Rest API!';
-        outputChannel.appendLine(msg);
+        logOutputChannel.error(msg);
         throw new Error(msg);
       }
-      outputChannel.appendLine('Initializing Rest API');
       CsRestApi._instance = new CsRestApi(extension);
     }
     return CsRestApi._instance;

--- a/src/download.ts
+++ b/src/download.ts
@@ -10,7 +10,7 @@ import { https } from 'follow-redirects';
 import * as fs from 'fs';
 import * as path from 'path';
 import { SimpleExecutor } from './executor';
-import { logOutputChannel, outputChannel } from './log';
+import { logOutputChannel } from './log';
 
 export class DownloadError extends Error {
   constructor(message: string, readonly url: URL, readonly expectedCliPath: string) {
@@ -77,7 +77,7 @@ async function ensureExecutable(filePath: string) {
 
 function download({ artifactName: artifactDownloadName, absoluteDownloadPath, absoluteBinaryPath }: ArtifactInfo) {
   const url = new URL(`https://downloads.codescene.io/enterprise/cli/${artifactDownloadName}`);
-  outputChannel.appendLine(`Downloading ${url}`);
+  logOutputChannel.info(`Downloading ${url}`);
 
   return new Promise<void>((resolve, reject) => {
     https
@@ -136,14 +136,14 @@ async function verifyBinaryVersion({
  * Download the CodeScene devtools artifact for the current platform and architecture.
  */
 export async function ensureCompatibleBinary(extensionPath: string): Promise<string> {
-  outputChannel.appendLine('Ensuring we have the current CodeScene devtools binary working on your system...');
+  logOutputChannel.info('Ensuring we have the current CodeScene devtools binary working on your system...');
 
   const artifactInfo = new ArtifactInfo(extensionPath);
   const binaryPath = artifactInfo.absoluteBinaryPath;
 
   if (await verifyBinaryVersion({ binaryPath })) return binaryPath;
 
-  outputChannel.appendLine('Failed verifying CodeScene devtools binary, re-downloading...');
+  logOutputChannel.info('Failed verifying CodeScene devtools binary, re-downloading...');
 
   await download(artifactInfo);
   await unzipFile(artifactInfo);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { ensureCompatibleBinary } from './download';
 import { reviewDocumentSelector } from './language-support';
 import { logOutputChannel } from './log';
 import { AceAPI, activate as activateAce } from './refactoring/addon';
+import { register as registerCodeActionProvider } from './review/codeaction';
 import { CsReviewCodeLensProvider } from './review/codelens';
 import Reviewer from './review/reviewer';
 import { CsServerVersion } from './server-version';
@@ -19,7 +20,6 @@ import Telemetry from './telemetry';
 import { registerCommandWithTelemetry } from './utils';
 import { CsWorkspace } from './workspace';
 import debounce = require('lodash.debounce');
-import { register as registerCodeActionProvider } from './review/codeaction';
 
 interface CsContext {
   csWorkspace: CsWorkspace;
@@ -87,6 +87,17 @@ function startExtension(context: vscode.ExtensionContext) {
       debouncedEnableOrDisableACECapabilities(context, csContext);
     })
   );
+
+  finalizeActivation();
+}
+
+/**
+ * This function finalizes the activation of the extension by setting a context variable.
+ * The context variable is used in package.json to conditionally enable/disable views that could
+ * point to commands that haven't been fully initialized.
+ */
+function finalizeActivation() {
+  void vscode.commands.executeCommand('setContext', 'codescene.asyncActivationFinished', true);
 }
 
 // Use this scheme for the virtual documents when diffing the refactoring

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
 import vscode from 'vscode';
 import { AUTH_TYPE, CsAuthenticationProvider } from './auth/auth-provider';
-import { checkCodeHealthRules } from './check-rules';
 import { activate as activateCHMonitor } from './code-health-monitor/addon';
 import { DeltaAnalyser } from './code-health-monitor/analyser';
+import { register as registerCHRulesCommands } from './code-health-rules';
 import { onDidChangeConfiguration } from './configuration';
 import { CsExtensionState } from './cs-extension-state';
 import CsDiagnostics from './diagnostics/cs-diagnostics';
@@ -13,7 +13,6 @@ import { logOutputChannel } from './log';
 import { AceAPI, activate as activateAce } from './refactoring/addon';
 import { CsReviewCodeLensProvider } from './review/codelens';
 import Reviewer from './review/reviewer';
-import { createRulesTemplate } from './rules-template';
 import { CsServerVersion } from './server-version';
 import { StatsCollector } from './stats';
 import Telemetry from './telemetry';
@@ -128,23 +127,7 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
   });
   context.subscriptions.push(openCodeHealthDocsCmd);
 
-  const createRulesTemplateCmd = registerCommandWithTelemetry({
-    commandId: 'codescene.createRulesTemplate',
-    handler: () => {
-      createRulesTemplate().catch((error: Error) => {
-        void vscode.window.showErrorMessage(error.message);
-      });
-    },
-  });
-  context.subscriptions.push(createRulesTemplateCmd);
-
-  const createCheckRules = registerCommandWithTelemetry({
-    commandId: 'codescene.checkRules',
-    handler: () => {
-      void checkCodeHealthRules();
-    },
-  });
-  context.subscriptions.push(createCheckRules);
+  registerCHRulesCommands(context);
 }
 
 /**

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,6 @@
 // This module provides a global interface to the CodeScene output channel.
 import * as vscode from 'vscode';
 
-const outputChannel = vscode.window.createOutputChannel('CodeScene');
 const logOutputChannel = vscode.window.createOutputChannel('CodeScene Log', { log: true });
 
-export { logOutputChannel, outputChannel };
+export { logOutputChannel };

--- a/src/review/codelens.ts
+++ b/src/review/codelens.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { getConfiguration, onDidChangeConfiguration } from '../configuration';
 import { toDocsParams } from '../documentation/csdoc-provider';
-import { logOutputChannel, outputChannel } from '../log';
+import { logOutputChannel } from '../log';
 import { isDefined } from '../utils';
 import Reviewer, { ReviewCacheItem } from './reviewer';
 import { getCsDiagnosticCode, isGeneralDiagnostic, removeDetails, roundScore } from './utils';
@@ -11,7 +11,6 @@ export class CsReviewCodeLensProvider implements vscode.CodeLensProvider<vscode.
   private disposables: vscode.Disposable[] = [];
 
   constructor() {
-    outputChannel.appendLine('Creating Review CodeLens provider');
     this.disposables.push(onDidChangeConfiguration('enableCodeLenses', () => this.onDidChangeCodeLensesEmitter.fire()));
     this.disposables.push(
       Reviewer.instance.onDidReview((event) => {

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -6,7 +6,7 @@ import { DeltaForFile } from '../code-health-monitor/model';
 import { getConfiguration } from '../configuration';
 import { CsExtensionState } from '../cs-extension-state';
 import { LimitingExecutor, SimpleExecutor } from '../executor';
-import { logOutputChannel, outputChannel } from '../log';
+import { logOutputChannel } from '../log';
 import { StatsCollector } from '../stats';
 import { ReviewResult } from './model';
 import { formatScore, reviewResultToDiagnostics } from './utils';
@@ -17,8 +17,8 @@ export default class Reviewer {
   private static _instance: CachingReviewer;
 
   static init(): void {
-    outputChannel.appendLine('Initializing code Reviewer');
     Reviewer._instance = new CachingReviewer(new FilteringReviewer(new SimpleReviewer(CsExtensionState.cliPath)));
+    logOutputChannel.info('Code reviewer initialized');
   }
 
   static get instance(): CachingReviewer {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { sign } from './codescene-interop';
 import { logAxiosError } from './cs-rest-api';
 import { ExecResult } from './executor';
-import { logOutputChannel, outputChannel } from './log';
+import { logOutputChannel } from './log';
 
 export default class Telemetry {
   private static _instance: Telemetry;
@@ -36,7 +36,7 @@ export default class Telemetry {
   }
 
   static init(extension: vscode.Extension<any>): void {
-    outputChannel.appendLine('Initializing telemetry logger');
+    logOutputChannel.info('Initializing telemetry logger');
     Telemetry._instance = new Telemetry(extension);
   }
 


### PR DESCRIPTION
Chore: Removing the old "CodeScene" output channel and migrate logging to either the "CodeScene Log" output channel.
The "Check Code Health rule match" command result is presented in a modal window instead of the old output channel.

Fix: The StatsCollector was initialized with a `setTimeout` was never disposed, which could possibly cause problems in long-running instances.

This PR also makes sure to not enable any views or commands that depend on the ide binary being fully initialized, which should hopefully get rid of any "Actual command not found, wanted to execute..." messages.