### PR TITLE
chore(codelens): Restore default to showing diagnostics as CodeLenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
       {
         "command": "codescene.openCodeHealthDocs",
         "title": "CodeScene: Open Code Health Documentation"
+      },
+      {
+        "command": "codescene.toggleReviewCodeLenses",
+        "title": "CodeScene: Toggle Review CodeLenses"
       }
     ],
     "viewsContainers": {
@@ -104,10 +108,10 @@
     "configuration": {
       "title": "CodeScene",
       "properties": {
-        "codescene.enableCodeLenses": {
+        "codescene.enableReviewCodeLenses": {
           "type": "boolean",
           "default": true,
-          "description": "Enable CodeScene code lenses",
+          "description": "Show CodeLenses for review diagnostics",
           "order": 1
         },
         "codescene.previewCodeHealthMonitoring": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,7 +1,18 @@
 import * as vscode from 'vscode';
+import { logOutputChannel } from './log';
 
 export function getConfiguration<T>(section: string): T | undefined {
   return vscode.workspace.getConfiguration('codescene').get<T>(section);
+}
+
+export function setConfiguration(section: string, value: any) {
+  const codesceneConfig = vscode.workspace.getConfiguration('codescene');
+  codesceneConfig.update(section, value).then(
+    () => {},
+    (err) => {
+      logOutputChannel.error(`setConfiguration(${section}) failed: ${err}`);
+    }
+  );
 }
 
 export function onDidChangeConfiguration(
@@ -20,4 +31,13 @@ export function onDidChangeConfiguration(
  */
 export function getServerUrl() {
   return getConfiguration<string>('serverUrl');
+}
+
+export function reviewCodeLensesEnabled() {
+  return getConfiguration<boolean>('enableReviewCodeLenses');
+}
+
+export function toggleReviewCodeLenses() {
+  const state = reviewCodeLensesEnabled();
+  setConfiguration('enableReviewCodeLenses', !state);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { AUTH_TYPE, CsAuthenticationProvider } from './auth/auth-provider';
 import { activate as activateCHMonitor } from './code-health-monitor/addon';
 import { DeltaAnalyser } from './code-health-monitor/analyser';
 import { register as registerCHRulesCommands } from './code-health-rules';
-import { onDidChangeConfiguration } from './configuration';
+import { onDidChangeConfiguration, toggleReviewCodeLenses } from './configuration';
 import { CsExtensionState } from './cs-extension-state';
 import CsDiagnostics from './diagnostics/cs-diagnostics';
 import { register as registerCsDoc } from './documentation/csdoc-provider';
@@ -117,7 +117,11 @@ function registerCommands(context: vscode.ExtensionContext, csContext: CsContext
       void vscode.env.openExternal(vscode.Uri.parse('https://codescene.io/docs/guides/technical/code-health.html'));
     },
   });
-  context.subscriptions.push(openCodeHealthDocsCmd);
+
+  const toggleReviewCodeLensesCmd = vscode.commands.registerCommand('codescene.toggleReviewCodeLenses', () => {
+    toggleReviewCodeLenses();
+  });
+  context.subscriptions.push(openCodeHealthDocsCmd, toggleReviewCodeLensesCmd);
 
   registerCHRulesCommands(context);
 }


### PR DESCRIPTION
After further discussions about the UX we've decided to restore the behaviour of the diagnostics codelenses. Now they're showing by default, and when selecting a decline in the code health monitor we're just adding the refactoring commands if available.
If they're not showing, the code health monitor will add Code Lenses for the introduced issues along with the optional refactoring lenses.

<img width="313" alt="image" src="https://github.com/user-attachments/assets/12db2a24-900a-47ac-8885-60a8ef91a97b">

This PR also adds the command "CodeScene: Toggle Review CodeLenses" to make it easier to change the behaviour.
<img width="475" alt="image" src="https://github.com/user-attachments/assets/2544e2f7-1cc2-4220-adc6-566674eee50b">
