### PR TITLE
fix(code-health-monitor): Stable handling of multiple subsequent refactorings

### DIFF
--- a/src/refactoring/addon.ts
+++ b/src/refactoring/addon.ts
@@ -9,6 +9,7 @@ import { toDistinctLanguageIds } from '../language-support';
 import { CsRefactoringCommands } from './commands';
 import { CsRefactoringRequest, CsRefactoringRequests } from './cs-refactoring-requests';
 import { PreFlightResponse } from './model';
+import { createTmpDiffUriScheme } from './utils';
 
 /**
  * Work in progress API just to keep us from creating too many contact points between
@@ -68,6 +69,7 @@ async function enableACE(context: vscode.ExtensionContext) {
   return CsRestApi.instance.fetchRefactorPreflight().then((preflightResponse) => {
     const commandDisposable = new CsRefactoringCommands(context.extensionUri, preflightResponse);
     aceDisposables.push(commandDisposable);
+    aceDisposables.push(createTmpDiffUriScheme());
 
     /* Add disposables to both subscription context and the extension state list
      * of disposables. This is to ensure they're disposed either when the extension

--- a/src/test/suite/refactor-utils.test.ts
+++ b/src/test/suite/refactor-utils.test.ts
@@ -1,32 +1,43 @@
 import * as assert from 'assert';
+import { RefactorResponse } from '../../refactoring/model';
 import { decorateCode } from '../../refactoring/utils';
 
 const originalCode = 'const a = 1;\nconst b = 2;\nconst c = 3;\n';
 
 suite('Refactor utils Test Suite', () => {
+  const refactorResponse: RefactorResponse = {
+    code: originalCode,
+    'reasons-with-details': [],
+    'refactoring-properties': { 'added-code-smells': [], 'removed-code-smells': [] },
+    confidence: { level: 3, 'recommended-action': { description: '', details: '' }, description: '', title: '' },
+  };
+
   test("Return code as is if there's no reasons-with-details", async () => {
-    const code = decorateCode(originalCode, 'javascript', []);
+    const code = decorateCode(refactorResponse, 'javascript');
     assert.equal(code, originalCode);
   });
 
   test('Return code with decorations if there are reasons-with-details containing linter info', async () => {
-    let code = decorateCode(originalCode, 'javascript', [
+    refactorResponse['reasons-with-details'] = [
       { summary: 'Issue 1', details: [{ message: 'Issue 1', lines: [1], columns: [1] }] },
-    ]);
+    ];
+    let code = decorateCode(refactorResponse, 'javascript');
     assert.equal(code, 'const a = 1;\n// ⚠️ Issue 1\nconst b = 2;\nconst c = 3;\n');
-
-    code = decorateCode(originalCode, 'javascript', [
+    refactorResponse['reasons-with-details'] = [
       { summary: 'Issue 1', details: [{ message: 'Issue 1', lines: [0], columns: [1] }] },
       { summary: 'Issue 2', details: [{ message: 'Issue 2', lines: [2], columns: [1] }] },
-    ]);
+    ];
+
+    code = decorateCode(refactorResponse, 'javascript');
     assert.equal(code, '// ⚠️ Issue 1\nconst a = 1;\nconst b = 2;\n// ⚠️ Issue 2\nconst c = 3;\n');
   });
 
   test('Handle reason-with-details with multiline messages', async () => {
-    let code = decorateCode(originalCode, 'javascript', [
+    refactorResponse['reasons-with-details'] = [
       { summary: 'Issue 1', details: [{ message: 'Issue 1\nThis is weird', lines: [1], columns: [1] }] },
       { summary: 'Issue 2', details: [{ message: 'Issue 2', lines: [2], columns: [1] }] },
-    ]);
+    ];
+    let code = decorateCode(refactorResponse, 'javascript');
     assert.equal(code, 'const a = 1;\n// ⚠️ Issue 1\n// This is weird\nconst b = 2;\n// ⚠️ Issue 2\nconst c = 3;\n');
   });
 });


### PR DESCRIPTION
### Problem
When applying a refactoring we want to make sure that that same refactoring isn't still usable.

### Solution
Make sure to invalidate current refactorings for a file when applying a refactoring.

This is to prevent accidentally applying the same refactoring twice. Instead it makes sense to invalidate and await a new review+delta analysis of the updated file to get the code-health-monitor re-populated with other possible refactoring suggestions.

This commit also moves some of the functionality used by the refactoring panel into the refactoring/commands module.