### PR TITLE
feat(terms-and-conditions): Add agreement popup on extension activation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,19 @@
 Copyright CodeScene AB
 
-The following license applies only to files located in this repository, and not to other utilities
-used by this software to perform code analysis. These utilities are only for use in the
-codescene-oss/codescene-vscode open source project.
+This extension ("IDE Plugin") includes both Open-Source and Closed-Source software components.
 
-MIT License
+Usage of the IDE Plugin requires acceptance of the CodeScene Plugin Terms, and is governed by those terms. The Plugin Terms are available at https://codescene.com/policies
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Subject to your compliance with the Plugin Terms and payment of any applicable fees, CodeScene grants rights to this IDE Plugin as follows:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Open-Source Components
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+The Open-Source Components relate to the user interface and are published in a public, open-source git repository, located at https://github.com/codescene-oss/codescene-vscode
+CodeScene grants a GNU Lesser General Public License ('LGPL') to these software components, based on the license to be found at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+Closed-Source Components
+
+The Closed-Source Components relate to extension libraries, analysis libraries and other services, and are held in a private git repository.
+CodeScene grants a non-exclusive, non-transferable, non-sub-licensable, limited license to use the Closed-Source Components in object code format as described in the Plugin Terms.
+
+The Closed-Source Components shall under no circumstances be considered as sold and, other than any license granted pursuant to the Plugin Terms, CodeScene reserves all rights to the software components not expressly granted herein.

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       {
         "command": "codescene.signIn",
         "title": "CodeScene: Sign in to CodeScene (see Server Url setting)"
+      },
+      {
+        "command": "codescene.revokeTerms",
+        "title": "CodeScene: Revoke Terms and Policies agreement"
       }
     ],
     "viewsContainers": {

--- a/src/control-center/view-provider.ts
+++ b/src/control-center/view-provider.ts
@@ -57,7 +57,10 @@ export class ControlCenterViewProvider implements WebviewViewProvider /* , Dispo
       case 'open-documentation':
         void vscode.env.openExternal(vscode.Uri.parse('https://codescene.io/docs'));
         return;
-      case 'open-privacy-principles':
+        case 'open-terms-and-policies':
+          void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/policies'));
+          return;  
+      case 'open-ai-privacy-principles':
         void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/product/ace/principles'));
         return;
       case 'open-contact-codescene':
@@ -264,7 +267,10 @@ export class ControlCenterViewProvider implements WebviewViewProvider /* , Dispo
             <div class="icon-and-text clickable" id="documentation"><span class="codicon codicon-question"></span><span>Documentation</span></div>
         </div>
         <div class="row">
-            <div class="icon-and-text clickable" id="privacy-principles"><span class="codicon codicon-file"></span><span>Privacy Principles</span></div>
+            <div class="icon-and-text clickable" id="terms-and-policies"><span class="codicon codicon-file"></span><span>Terms & Policies</span></div>
+        </div>
+        <div class="row">
+            <div class="icon-and-text clickable" id="privacy-principles"><span class="codicon codicon-file"></span><span>AI Privacy Principles</span></div>
         </div>
         <div class="row">
             <div class="icon-and-text clickable" id="contact-codescene"><span class="codicon codicon-comment-discussion"></span><span>Contact CodeScene</span></div>

--- a/src/control-center/webview-script.ts
+++ b/src/control-center/webview-script.ts
@@ -16,8 +16,12 @@ function main() {
   document.getElementById('codescene-settings')?.addEventListener('click', () => sendMessage('open-settings'));
   document.getElementById('documentation')?.addEventListener('click', () => sendMessage('open-documentation'));
   document
+    .getElementById('terms-and-policies')
+    ?.addEventListener('click', () => sendMessage('open-terms-and-policies'));
+
+  document
     .getElementById('privacy-principles')
-    ?.addEventListener('click', () => sendMessage('open-privacy-principles'));
+    ?.addEventListener('click', () => sendMessage('open-ai-privacy-principles'));
   document.getElementById('contact-codescene')?.addEventListener('click', () => sendMessage('open-contact-codescene'));
 
   document.getElementById('machine-id')?.addEventListener('click', () => sendMessage('copy-machine-id'));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import Telemetry from './telemetry';
 import { isError } from './utils';
 import { CsWorkspace } from './workspace';
 import debounce = require('lodash.debounce');
+import { acceptTermsAndPolicies, registerTermsAndPoliciesCmds } from './terms-conditions';
 
 interface CsContext {
   csWorkspace: CsWorkspace;
@@ -33,10 +34,13 @@ interface CsContext {
  */
 export async function activate(context: vscode.ExtensionContext) {
   logOutputChannel.info('⚙️ Activating extension...');
+  Telemetry.init(context.extension);
+
+  registerShowLogCommand(context);
+  registerTermsAndPoliciesCmds(context);
+  await acceptTermsAndPolicies(context);
 
   CsExtensionState.init(context);
-  Telemetry.init(context.extension);
-  registerShowLogCommand(context);
 
   try {
     const binaryPath = await ensureCompatibleBinary(context.extensionPath);

--- a/src/terms-conditions.ts
+++ b/src/terms-conditions.ts
@@ -1,4 +1,4 @@
-import { env, ExtensionContext, Uri, window } from 'vscode';
+import { commands, env, ExtensionContext, Uri, window } from 'vscode';
 import Telemetry from './telemetry';
 import { registerCommandWithTelemetry } from './utils';
 

--- a/src/terms-conditions.ts
+++ b/src/terms-conditions.ts
@@ -1,0 +1,42 @@
+import { env, ExtensionContext, Uri, window } from 'vscode';
+import Telemetry from './telemetry';
+import { registerCommandWithTelemetry } from './utils';
+
+const acceptedTermsAndPoliciesKey = 'termsAndPoliciesAccepted';
+export function registerTermsAndPoliciesCmds(context: ExtensionContext) {
+  context.globalState.setKeysForSync([acceptedTermsAndPoliciesKey]);
+  context.subscriptions.push(
+    registerCommandWithTelemetry({
+      commandId: 'codescene.revokeTerms',
+      handler: async () => {
+        await context.globalState.update(acceptedTermsAndPoliciesKey, undefined);
+        void window.showInformationMessage('Terms and Privacy Policy agreement has now been revoked');
+      },
+    })
+  );
+}
+
+export async function acceptTermsAndPolicies(context: ExtensionContext) {
+  const hasAcceptedTerms = context.globalState.get<boolean>(acceptedTermsAndPoliciesKey);
+  if (hasAcceptedTerms === true) return hasAcceptedTerms;
+
+  const selection = await window.showInformationMessage(
+    "By using this extension you agree to CodeScene's Terms and Privacy Policy",
+    'Accept',
+    'Decline',
+    'View Terms & Policies'
+  );
+
+  Telemetry.instance.logUsage('termsAgreement', { selection });
+
+  switch (selection) {
+    case 'Accept':
+      await context.globalState.update(acceptedTermsAndPoliciesKey, true);
+      return true;
+    case 'View Terms & Policies':
+      void env.openExternal(Uri.parse('https://codescene.com/policies'));
+      return await acceptTermsAndPolicies(context);
+    default:
+      throw new Error('You need to accept the terms to use this extension.');
+  }
+}


### PR DESCRIPTION
Notification popup for accepting on first use:
![image](https://github.com/user-attachments/assets/6a826bff-91d7-4b79-906e-e58f6e7f8396)

Updated control-center-panel:
![image](https://github.com/user-attachments/assets/81d6ff8f-6927-454a-b80a-17cd77103793)

Command for revoking agreement:
![image](https://github.com/user-attachments/assets/fa7d6b26-b45d-4f6f-9b05-06f723817ce5)
