### PR TITLE
fix(statusbar): Analysis keeps running on startup

### DIFF
--- a/src/cs-statusbar.ts
+++ b/src/cs-statusbar.ts
@@ -34,7 +34,7 @@ export class CsStatusBar {
   }
 
   private isAnalysing(stateProperties: CsStateProperties) {
-    return stateProperties.features.analysis.analysisState !== 'idle';
+    return stateProperties.features.analysis.analysisState === 'running';
   }
 
   private textContent(stateProperties: CsStateProperties) {


### PR DESCRIPTION
This happens on startup when no supported file is open. Fix by not implicitly assume analysis is running when state isn't 'idle'.