### PR TITLE
chore(web-ui): Remove @vscode/webview-ui-toolkit dependency

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -1,4 +1,3 @@
-const { error } = require('console');
 const { build, context } = require('esbuild');
 const { copy } = require('esbuild-plugin-copy');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "codescene-vscode",
-  "version": "0.9.0",
+  "version": "0.9.1-beta-241107-2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codescene-vscode",
-      "version": "0.9.0",
+      "version": "0.9.1-beta-241107-2",
       "license": "MIT",
       "dependencies": {
         "@types/follow-redirects": "^1.14.1",
         "@types/lodash.debounce": "^4.0.7",
         "@types/vscode-webview": "^1.57.4",
+        "@vscode-elements/elements": "^1.8.0",
         "@vscode/codicons": "^0.0.35",
-        "@vscode/webview-ui-toolkit": "^1.4.0",
         "axios": "^1.7.4",
         "extract-zip": "^2.0.1",
         "follow-redirects": "^1.15.6",
@@ -564,40 +564,17 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
-    "node_modules/@microsoft/fast-foundation": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.4.tgz",
-      "integrity": "sha512-5I2tSPo6bnOfVAIX7XzX+LhilahwvD7h+yzl3jW0t5IYmMX9Lci9VUVyx5f8hHdb1O9a8Y9Atb7Asw7yFO/u+w==",
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
       "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "node_modules/@microsoft/fast-react-wrapper": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.22.tgz",
-      "integrity": "sha512-XhlX4m6znh7XW92oPvlKoG9USUn9JtF9rP1qtUoIbkaDaFtUS+H8o1Jn6/oK/rS44LbBLJXrvRkInmSWlDiGFw==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "dependencies": {
-        "exenv-es6": "^1.1.1"
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -715,6 +692,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/uuid": {
       "version": "9.0.1",
@@ -1108,6 +1090,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vscode-elements/elements": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.8.0.tgz",
+      "integrity": "sha512-iTZGDCqMOW8vuwoUbf5+Nla9L+qILsANcki8w5GMVADLqjtYBXz1G1YaaJn4C2U788oV7Y4DCIsjN5UhcUs7Ow==",
+      "dependencies": {
+        "lit": "^3.2.0"
+      }
+    },
     "node_modules/@vscode/codicons": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.35.tgz",
@@ -1127,25 +1117,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "dependencies": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0"
-      }
-    },
-    "node_modules/@vscode/webview-ui-toolkit/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -2331,11 +2302,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
-    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -3113,7 +3079,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3243,6 +3210,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -3319,18 +3314,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -4066,18 +4049,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -4741,11 +4712,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -4814,7 +4780,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -5360,37 +5327,17 @@
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
       "dev": true
     },
-    "@microsoft/fast-element": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.12.0.tgz",
-      "integrity": "sha512-gQutuDHPKNxUEcQ4pypZT4Wmrbapus+P9s3bR/SEOLsMbNqNoXigGImITygI5zhb+aA5rzflM6O8YWkmRbGkPA=="
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
-    "@microsoft/fast-foundation": {
-      "version": "2.49.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.49.4.tgz",
-      "integrity": "sha512-5I2tSPo6bnOfVAIX7XzX+LhilahwvD7h+yzl3jW0t5IYmMX9Lci9VUVyx5f8hHdb1O9a8Y9Atb7Asw7yFO/u+w==",
+    "@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
       "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-web-utilities": "^5.4.1",
-        "tabbable": "^5.2.0",
-        "tslib": "^1.13.0"
-      }
-    },
-    "@microsoft/fast-react-wrapper": {
-      "version": "0.3.22",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.3.22.tgz",
-      "integrity": "sha512-XhlX4m6znh7XW92oPvlKoG9USUn9JtF9rP1qtUoIbkaDaFtUS+H8o1Jn6/oK/rS44LbBLJXrvRkInmSWlDiGFw==",
-      "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4"
-      }
-    },
-    "@microsoft/fast-web-utilities": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-      "integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-      "requires": {
-        "exenv-es6": "^1.1.1"
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -5496,6 +5443,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "@types/uuid": {
       "version": "9.0.1",
@@ -5726,6 +5678,14 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@vscode-elements/elements": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode-elements/elements/-/elements-1.8.0.tgz",
+      "integrity": "sha512-iTZGDCqMOW8vuwoUbf5+Nla9L+qILsANcki8w5GMVADLqjtYBXz1G1YaaJn4C2U788oV7Y4DCIsjN5UhcUs7Ow==",
+      "requires": {
+        "lit": "^3.2.0"
+      }
+    },
     "@vscode/codicons": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.35.tgz",
@@ -5741,24 +5701,6 @@
         "https-proxy-agent": "^5.0.0",
         "jszip": "^3.10.1",
         "semver": "^7.5.2"
-      }
-    },
-    "@vscode/webview-ui-toolkit": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.4.0.tgz",
-      "integrity": "sha512-modXVHQkZLsxgmd5yoP3ptRC/G8NBDD+ob+ngPiWNQdlrH6H1xR/qgOBD85bfU3BhOB5sZzFWBwwhp9/SfoHww==",
-      "requires": {
-        "@microsoft/fast-element": "^1.12.0",
-        "@microsoft/fast-foundation": "^2.49.4",
-        "@microsoft/fast-react-wrapper": "^0.3.22",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-          "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
       }
     },
     "acorn": {
@@ -6661,11 +6603,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "exenv-es6": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-      "integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
-    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -7244,7 +7181,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -7354,6 +7292,34 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "requires": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "requires": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7414,15 +7380,6 @@
       "requires": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
-      }
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "peer": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "lru-cache": {
@@ -7969,15 +7926,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -8481,11 +8429,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
-    "tabbable": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-    },
     "text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -8544,7 +8487,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "CodeScene AB",
   "publisher": "codescene",
   "description": "Integrates CodeScene analysis into VS Code. Keeps your code clean and maintainable.",
-  "version": "0.9.0",
+  "version": "0.9.1-beta-241107-2",
   "license": "MIT",
   "engines": {
     "vscode": "^1.75.1"
@@ -213,8 +213,8 @@
     "@types/follow-redirects": "^1.14.1",
     "@types/lodash.debounce": "^4.0.7",
     "@types/vscode-webview": "^1.57.4",
+    "@vscode-elements/elements": "^1.8.0",
     "@vscode/codicons": "^0.0.35",
-    "@vscode/webview-ui-toolkit": "^1.4.0",
     "axios": "^1.7.4",
     "extract-zip": "^2.0.1",
     "follow-redirects": "^1.15.6",

--- a/src/code-health-monitor/details/webview-script.ts
+++ b/src/code-health-monitor/details/webview-script.ts
@@ -1,6 +1,5 @@
-import { provideVSCodeDesignSystem, vsCodeButton } from '@vscode/webview-ui-toolkit';
-
-provideVSCodeDesignSystem().register(vsCodeButton());
+import '@vscode-elements/elements/dist/vscode-button';
+import { VscodeButton } from '@vscode-elements/elements/dist/vscode-button';
 
 window.addEventListener('load', main);
 
@@ -15,7 +14,7 @@ function main() {
   refactoringButton?.addEventListener('click', () => sendMessage('auto-refactor'));
 
   if (refactoringButton) {
-    window.addEventListener('message', refactoringButtonHandler(refactoringButton));
+    window.addEventListener('message', refactoringButtonHandler(refactoringButton as VscodeButton));
   }
   for (const link of Array.from(document.getElementsByClassName('issue-icon-link'))) {
     link.addEventListener('click', (e) => issueClickHandler(e));
@@ -27,17 +26,16 @@ function issueClickHandler(event: Event) {
   sendMessage('interactive-docs', { issueIndex });
 }
 
-function refactoringButtonHandler(refactoringButton: HTMLElement) {
+function refactoringButtonHandler(refactoringButton: VscodeButton) {
   return (event: MessageEvent<any>) => {
     const { command } = event.data;
-    const iconSpan = refactoringButton.querySelector('span');
-    if (!iconSpan) return;
-    iconSpan.classList.remove('codicon-loading', 'codicon-modifier-spin');
+    refactoringButton.iconSpin = false;
     if (command === 'refactoring-ok') {
-      iconSpan.classList.add('codicon-sparkle');
+      refactoringButton.icon = 'sparkle';
     } else if (command === 'refactoring-failed') {
-      iconSpan.classList.add('codicon-circle-slash');
-      refactoringButton.setAttribute('disabled', 'true');
+      refactoringButton.secondary = true;
+      refactoringButton.disabled = true;
+      refactoringButton.icon = 'circle-slash';
     }
   };
 }

--- a/src/codescene-tab/webview/documentation-components.ts
+++ b/src/codescene-tab/webview/documentation-components.ts
@@ -4,9 +4,9 @@ import { readRawMarkdownDocs } from './utils';
 export function optionalRefactoringButton(hidden: boolean) {
   return /*html*/ `
     <div class="button-container">
-      <vscode-button id="refactoring-button" class="${hidden ? 'hidden' : ''}">
-        <span slot="start" class="codicon codicon-loading codicon-modifier-spin"></span>
-        Auto-refactor
+      <vscode-button id="refactoring-button" icon="loading" icon-spin="true"
+        ${hidden ? 'hidden' : ''}>
+          Auto-refactor
       </vscode-button>
     </div>
   `;

--- a/src/codescene-tab/webview/documentation-script.ts
+++ b/src/codescene-tab/webview/documentation-script.ts
@@ -1,6 +1,5 @@
-import { provideVSCodeDesignSystem, vsCodeButton } from '@vscode/webview-ui-toolkit';
-
-provideVSCodeDesignSystem().register(vsCodeButton());
+import '@vscode-elements/elements/dist/vscode-button';
+import { VscodeButton } from '@vscode-elements/elements/dist/vscode-button';
 
 window.addEventListener('load', main);
 
@@ -17,21 +16,20 @@ function main() {
   refactoringButton?.addEventListener('click', () => sendMessage('show-refactoring'));
 
   if (refactoringButton) {
-    window.addEventListener('message', refactoringButtonHandler(refactoringButton));
+    window.addEventListener('message', refactoringButtonHandler(refactoringButton as VscodeButton));
   }
 }
 
-function refactoringButtonHandler(refactoringButton: HTMLElement) {
+function refactoringButtonHandler(refactoringButton: VscodeButton) {
   return (event: MessageEvent<any>) => {
     const { command } = event.data;
-    const iconSpan = refactoringButton.querySelector('span');
-    if (!iconSpan) return;
-    iconSpan.classList.remove('codicon-loading', 'codicon-modifier-spin');
+    refactoringButton.iconSpin = false;
     if (command === 'refactoring-ok') {
-      iconSpan.classList.add('codicon-sparkle');
+      refactoringButton.icon = 'sparkle';
     } else if (command === 'refactoring-failed') {
-      iconSpan.classList.add('codicon-circle-slash');
-      refactoringButton.setAttribute('disabled', 'true');
+      refactoringButton.secondary = true;
+      refactoringButton.disabled = true;
+      refactoringButton.icon = 'circle-slash';
     }
   };
 }

--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -1,5 +1,4 @@
 import { commands } from 'vscode';
-import { CsExtensionState } from '../../cs-extension-state';
 import { RefactorConfidence, RefactorResponse } from '../../refactoring/model';
 import { CodeWithLangId, decorateCode } from '../../refactoring/utils';
 import { collapsibleContent, markdownAsCollapsible } from './components';
@@ -93,12 +92,10 @@ function reasonsContent(response: RefactorResponse) {
 function acceptAndRejectButtons() {
   return /* html */ `
       <div class="button-container">
-        <vscode-button id="apply-button" appearance="primary" aria-label="Accept Auto-Refactor" title="Accept Auto-Refactor">
-          <span slot="start" class="codicon codicon-check"></span>
+        <vscode-button id="apply-button" icon="check" primary aria-label="Accept Auto-Refactor" title="Accept Auto-Refactor">
           Accept Auto-Refactor
         </vscode-button>
-        <vscode-button id="reject-button" appearance="secondary" aria-label="Reject" title="Reject">
-          <span slot="start" class="codicon codicon-circle-slash"></span>
+        <vscode-button id="reject-button" icon="circle-slash" secondary aria-label="Reject" title="Reject">
           Reject
         </vscode-button>
       </div>
@@ -114,8 +111,7 @@ async function codeContainerContent(code: CodeWithLangId, showDiff = true) {
 
   const diffButton = showDiff
     ? /*html*/ `
-          <vscode-button id="diff-button" appearance="secondary" aria-label="Show diff">
-            <span slot="start" class="codicon codicon-diff"></span>
+          <vscode-button id="diff-button" icon="diff" secondary aria-label="Show diff">
             Show diff
           </vscode-button>
         `
@@ -126,8 +122,7 @@ async function codeContainerContent(code: CodeWithLangId, showDiff = true) {
         <div class="code-container-buttons">
           ${diffButton}
         <!-- slot="start" ? -->
-          <vscode-button id="copy-to-clipboard-button" appearance="secondary" aria-label="Copy code" title="Copy code">
-            <span slot="start" class="codicon codicon-clippy"></span>
+          <vscode-button id="copy-to-clipboard-button" icon="clippy" secondary aria-label="Copy code" title="Copy code">
             Copy
           </vscode-button>
         </div>      

--- a/src/codescene-tab/webview/refactoring-script.ts
+++ b/src/codescene-tab/webview/refactoring-script.ts
@@ -1,6 +1,5 @@
-import { provideVSCodeDesignSystem, vsCodeButton, vsCodeProgressRing } from '@vscode/webview-ui-toolkit';
-
-provideVSCodeDesignSystem().register(vsCodeButton(), vsCodeProgressRing());
+import '@vscode-elements/elements/dist/vscode-button';
+import '@vscode-elements/elements/dist/vscode-progress-ring';
 
 window.addEventListener('load', main);
 

--- a/src/codescene-tab/webview/utils.ts
+++ b/src/codescene-tab/webview/utils.ts
@@ -29,7 +29,7 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
     cssTag(webView, ['out', 'codescene-tab', 'webview', 'styles.css']),
     cssTag(webView, ['assets', 'markdown-languages.css']),
     cssTag(webView, ['assets', 'highlight.css']),
-    cssTag(webView, ['out', 'codicons', 'codicon.css'])
+    cssTag(webView, ['out', 'codicons', 'codicon.css'], 'vscode-codicon-stylesheet') // NOTE - vscode-elements needs an id for the stylesheet tag ¯\_(ツ)_/¯
   );
 
   cssPaths?.forEach((path) => cssTags.push(cssTag(webView, path)));
@@ -65,10 +65,10 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
   webView.html = html;
 }
 
-function cssTag(webView: Webview, pathComponents: string[]) {
+function cssTag(webView: Webview, pathComponents: string[], id?: string) {
   const uri = getUri(webView, ...pathComponents);
   return /*html*/ `
-        <link href="${uri}" type="text/css" rel="stylesheet" />
+        <link href="${uri}" type="text/css" rel="stylesheet" ${id ? 'id="' + id + '"' : ''}/>
     `;
 }
 


### PR DESCRIPTION
The [webview-ui-toolkit will be deprecated](https://github.com/microsoft/vscode-webview-ui-toolkit/issues/561) at the end of this year. Replace with [VSCode Elements](https://github.com/vscode-elements/elements).
