### PR TITLE
Update components on ace state change

### DIFF
--- a/src/code-health-monitor/details/view.ts
+++ b/src/code-health-monitor/details/view.ts
@@ -10,7 +10,7 @@ export function register(context: ExtensionContext) {
   const viewProvider = new CodeHealthDetailsView();
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider('codescene.codeHealthDetailsView', viewProvider),
-    vscode.commands.registerCommand('codescene.codeHealthDetailsView.showDetails', (functionInfo: DeltaFunctionInfo) =>
+    vscode.commands.registerCommand('codescene.codeHealthDetailsView.showDetails', (functionInfo?: DeltaFunctionInfo) =>
       viewProvider.update(functionInfo)
     )
   );

--- a/src/codescene-tab/webview-panel.ts
+++ b/src/codescene-tab/webview-panel.ts
@@ -3,7 +3,6 @@ import { CsExtensionState } from '../cs-extension-state';
 import { InteractiveDocsParams, isInteractiveDocsParams } from '../documentation/commands';
 import { logOutputChannel } from '../log';
 import { FnToRefactor } from '../refactoring/capabilities';
-import { refactoringSymbol, toConfidenceSymbol } from '../refactoring/commands';
 import { RefactoringRequest } from '../refactoring/request';
 import { decorateCode, targetEditor } from '../refactoring/utils';
 import Telemetry from '../telemetry';
@@ -223,7 +222,7 @@ export class CodeSceneTabPanel implements Disposable {
         confidence: { level, title },
       } = response;
 
-      const highlightCode = toConfidenceSymbol(level) === refactoringSymbol;
+      const highlightCode = level > 1;
       const editor = targetEditor(document);
       if (highlightCode && editor) {
         editor.selection = new vscode.Selection(fnToRefactor.range.start, fnToRefactor.range.end);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,8 +64,11 @@ async function startExtension(context: vscode.ExtensionContext) {
   CsServerVersion.init();
 
   CsExtensionState.addListeners(context, csContext.aceApi);
-  csContext.aceApi.onDidChangeState((state) => {
-    CsExtensionState.setACEState(state);
+  csContext.aceApi.onDidChangeState((event) => {
+    CsExtensionState.setACEState(event);
+    if (event.state === 'enabled' || event.state === 'disabled') {
+      Reviewer.instance.refreshDeltas();
+    }
   });
 
   // send telemetry on activation (gives us basic usage stats)

--- a/src/refactoring/capabilities.ts
+++ b/src/refactoring/capabilities.ts
@@ -2,8 +2,8 @@ import { DocumentSelector, languages, Range, TextDocument } from 'vscode';
 import { EnclosingFn, findEnclosingFunctions } from '../codescene-interop';
 import { fileTypeToLanguageId, toDistinctLanguageIds } from '../language-support';
 import { logOutputChannel } from '../log';
-import { RefactoringRequest } from './request';
 import { PreFlightResponse, RefactorSupport } from './model';
+import { RefactoringRequest } from './request';
 
 export interface FnToRefactor {
   name: string;
@@ -91,6 +91,8 @@ export class RefactoringCapabilities {
     );
 
     const distinctSupportedLines = new Set(supportedTargets.map((d: RefactoringTarget) => d.line));
+    if (distinctSupportedLines.size === 0) return;
+
     const enclosingFnsWithSupportedSmells = await findEnclosingFunctions(
       document.fileName,
       [...distinctSupportedLines],

--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -99,16 +99,3 @@ export class CsRefactoringCommands implements vscode.Disposable {
     this.disposables = [];
   }
 }
-
-export const refactoringSymbol = '✨';
-const codeImprovementGuideSymbol = '🧐';
-export const pendingSymbol = '⏳';
-
-export function toConfidenceSymbol(level?: number) {
-  if (!isDefined(level)) return pendingSymbol;
-  if (level > 1) {
-    return refactoringSymbol;
-  } else if (level === 1) {
-    return codeImprovementGuideSymbol;
-  }
-}

--- a/src/review/codeaction.ts
+++ b/src/review/codeaction.ts
@@ -34,14 +34,14 @@ class ReviewCodeActionProvider implements vscode.CodeActionProvider, vscode.Disp
     const actions: vscode.CodeAction[] = [];
     const diagnosticsInRange = diagnostics.filter((diagnostic) => diagnostic.range.contains(range));
 
-    const refactoringTargets: RefactoringTarget[] = diagnosticsInRange
+    const refactoringTargets = diagnosticsInRange
       .map((diagnostic) => {
         const category = getCsDiagnosticCode(diagnostic.code);
         if (!category) return;
         return {
           category,
           line: diagnostic.range.start.line + 1,
-        };
+        } as RefactoringTarget;
       })
       .filter(isDefined);
 

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -98,6 +98,12 @@ class ReviewCache {
     }
   }
 
+  refreshDeltas() {
+    this._cache.forEach((item) => {
+      void item.runDeltaAnalysis();
+    });
+  }
+
   /**
    * Get review cache item. (note that fileName is same as uri.fsPath)
    */
@@ -192,6 +198,10 @@ class CachingReviewer {
     this.setOrUpdate(document, csReview);
 
     return csReview;
+  }
+
+  refreshDeltas() {
+    this.reviewCache.refreshDeltas();
   }
 
   /**


### PR DESCRIPTION
Make sure that the code-health-monitor won't show any function as refactorable if disabling ace. Likewise, if enabling again, it should be refreshed again.