### PR TITLE
fix(control-center): Opening settings outside of a workspace

### DIFF
--- a/src/control-center/view-provider.ts
+++ b/src/control-center/view-provider.ts
@@ -42,41 +42,38 @@ export class ControlCenterViewProvider implements WebviewViewProvider /* , Dispo
   }
 
   private handleMessages(message: any) {
-    switch (message.command) {
-      case 'open-settings':
-        void vscode.commands.executeCommand(
-          'workbench.action.openWorkspaceSettings',
-          '@ext:codescene.codescene-vscode'
-        );
-        return;
-      case 'show-code-health-analysis-error':
-      case 'show-ace-error':
-        logOutputChannel.show();
-        return;
-      case 'open-ai-pricing':
-        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/product/ai-coding#pricing'));
-        return;
-      case 'open-documentation':
-        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.io/docs'));
-        return;
-      case 'open-terms-and-policies':
-        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/policies'));
-        return;
-      case 'open-ai-privacy-principles':
-        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/product/ace/principles'));
-        return;
-      case 'open-contact-codescene':
-        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/company/contact-us'));
-        return;
-      case 'raise-support-ticket':
-        void vscode.env.openExternal(vscode.Uri.parse('https://supporthub.codescene.com/kb-tickets/new'));
-        return;
-      case 'copy-machine-id':
+    const commands: { [key: string]: () => void } = {
+      openAiPricing: () =>
+        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/product/ai-coding#pricing')),
+      showLogOutput: () => logOutputChannel.show(),
+      openSettings: () =>
+        vscode.commands
+          .executeCommand('workbench.action.openWorkspaceSettings', '@ext:codescene.codescene-vscode')
+          .then(
+            () => {},
+            (err) => {
+              logOutputChannel.info('Not inside a workspace, opening general/user settings instead.');
+              void vscode.commands.executeCommand('workbench.action.openSettings', '@ext:codescene.codescene-vscode');
+            }
+          ),
+      openDocumentation: () => void vscode.env.openExternal(vscode.Uri.parse('https://codescene.io/docs')),
+      openTermsAndPolicies: () => void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/policies')),
+      openAiPrivacyPrinciples: () =>
+        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/product/ace/principles')),
+      openContactCodescene: () =>
+        void vscode.env.openExternal(vscode.Uri.parse('https://codescene.com/company/contact-us')),
+      raiseSupportTicket: () =>
+        void vscode.env.openExternal(vscode.Uri.parse('https://supporthub.codescene.com/kb-tickets/new')),
+      copyMachineId: () =>
         void vscode.env.clipboard.writeText(vscode.env.machineId).then(() => {
           void vscode.window.showInformationMessage('Copied machine-id to clipboard.');
-        });
-        return;
-    }
+        }),
+    };
+
+    const cmd = commands[message.command];
+
+    if (!cmd) throw new Error(`Command not implemented: "${message.command}"!`);
+    cmd.call(this);
   }
 
   update() {

--- a/src/control-center/webview-script.ts
+++ b/src/control-center/webview-script.ts
@@ -8,21 +8,21 @@ function sendMessage(command: string, data?: object) {
 
 function main() {
   // Account
-  addClickListenerToElementById('upgrade-link', () => sendMessage('open-ai-pricing'));
+  addClickListenerToElementById('upgrade-link', () => sendMessage('openAiPricing'));
 
   // Status
-  addClickEventForClass('code-health-analysis-badge', 'badge-error', () => sendMessage('show-code-health-analysis-error'));
+  addClickEventForClass('code-health-analysis-badge', 'badge-error', () => sendMessage('showLogOutput'));
   addClickEventForClass('ace-badge', 'badge-error', () => sendMessage('show-ace-error'));
 
   // More
-  addClickListenerToElementById('codescene-settings', () => sendMessage('open-settings'));
-  addClickListenerToElementById('documentation', () => sendMessage('open-documentation'));
-  addClickListenerToElementById('terms-and-policies', () => sendMessage('open-terms-and-policies'));
-  addClickListenerToElementById('privacy-principles', () => sendMessage('open-ai-privacy-principles'));
-  addClickListenerToElementById('contact-codescene', () => sendMessage('open-contact-codescene'));
-  addClickListenerToElementById('support-ticket-link', () => sendMessage('raise-support-ticket'));
+  addClickListenerToElementById('codescene-settings', () => sendMessage('openSettings'));
+  addClickListenerToElementById('documentation', () => sendMessage('openDocumentation'));
+  addClickListenerToElementById('terms-and-policies', () => sendMessage('openTermsAndPolicies'));
+  addClickListenerToElementById('privacy-principles', () => sendMessage('openAiPrivacyPrinciples'));
+  addClickListenerToElementById('contact-codescene', () => sendMessage('openContactCodescene'));
+  addClickListenerToElementById('support-ticket-link', () => sendMessage('raiseSupportTicket'));
 
-  addClickListenerToElementById('machine-id', () => sendMessage('copy-machine-id'));
+  addClickListenerToElementById('machine-id', () => sendMessage('copyMachineId'));
 }
 
 function addClickListenerToElementById(elementId: string, listener: () => void) {


### PR DESCRIPTION
We'll still default to opening the workspace settings to not break old behaviour/expectations. When outside of a workspace (or when failing to open workspace settings for any reason) we'll open general/user settings instead.