### PR TITLE
chore(refactoring): Adjust and clarify ACE acknowledgement banner

### DIFF
--- a/src/codescene-tab/webview-panel.ts
+++ b/src/codescene-tab/webview-panel.ts
@@ -192,14 +192,24 @@ export class CodeSceneTabPanel implements Disposable {
 
     const ackContent = /*html*/ `
       <div class="ace-acknowledgement-container">
-        <p class="header">CodeScene ACE - AI-Powered Refactoring</p>
-        <p>CodeScene ACE combines multiple LLMs with fact-based validation. ACE chooses the best LLM for the job, 
-        validates its output, and proposes refactoring for cleaner code which is easier to maintain.</p>
+        <h4>CodeScene ACE - AI-Powered Refactoring</h4>
+        <p><a href="https://codescene.com/product/ai-coding">CodeScene ACE</a> combines multiple LLMs with fact-based validation. 
+        ACE chooses the best LLM for the job, validates its output, and proposes refactoring for cleaner code which is easier 
+        to maintain.</p>
         <p>CodeScene ACE is built on our CodeHealth™ Metric, the only code analysis metric with a proven business impact.</p>
-        <a href="https://codescene.com/product/ace/principles">View CodeScene's AI Privacy Principles</a><br>
-        <vscode-button id="acknowledge-button">Show me CodeScene ACE</vscode-button>
-        <hr>
-        <p class="dimmed">You can disable CodeScene ACE anytime in settings.</p>
+
+        <ul>
+          <li><span class="codicon codicon-check green"></span> Your code is never stored by us or the LLMs</li>
+          <li><span class="codicon codicon-check green"></span> Your code is only shared with carefully selected LLMs</li>
+          <li><span class="codicon codicon-check green"></span> Your code is not used to train any LLM</li>
+          <li><span class="codicon codicon-check green"></span> All communication with CodeScene ACE is fully encrypted</li>
+        </ul>
+
+        <a href="https://codescene.com/product/ace/principles" class="privacy-link">View CodeScene's AI Privacy Principles</a><br>
+        <div class="button-container">
+          <vscode-button id="acknowledge-button">Show me CodeScene ACE</vscode-button>
+        </div>
+        <p class="fineprint">You can disable CodeScene ACE anytime in settings.</p>
       </div>
     `;
 

--- a/src/codescene-tab/webview/ace-acknowledgement-styles.css
+++ b/src/codescene-tab/webview/ace-acknowledgement-styles.css
@@ -8,12 +8,36 @@
     font-weight: 600;
   }
 
-  p.dimmed {
+  p.fineprint {
     color: var(--vscode-descriptionForeground);
     margin-bottom: 0;
+    font-size: 11px;
+    text-align: center;
+    line-height: initial;
   }
 
-  #acknowledge-button {
-    margin-top: 8px;
+  .green {
+    color: var(--vscode-terminal-ansiBrightGreen);
+  }
+
+  ul {
+    padding-inline-start: 14px;
+    margin-bottom: 1.2em;
+  }
+
+  li {
+    display: flex;
+    gap: 5px;
+    align-items: center;
+  }
+
+  .privacy-link {
+    margin: 8px 0;
+  }
+
+  .button-container {
+    display: flex;
+    margin: 14px 0 10px 0;
+    justify-content: center;
   }
 }

--- a/src/codescene-tab/webview/styles.css
+++ b/src/codescene-tab/webview/styles.css
@@ -1,6 +1,22 @@
-h2.cs-common {
+body {
+  font-size: var(--vscode-font-size);
+  line-height: 18px;
+}
+
+h2 {
+  font-size: 18px;
   border: none;
-  margin-bottom: 2px;
+  margin: 20px 0 12px 0;
+}
+
+h3 {
+  font-size: 15px;
+  margin: 12px 0 10px 0;
+}
+
+h4 {
+  font-size: 14px;
+  margin: 0 0 8px 0;
 }
 
 .hidden {
@@ -62,5 +78,5 @@ h2.cs-common {
 .button-container {
   display: inline-flex;
   gap: 10px;
-  margin-top: 12px;
+  margin: 12px 0;
 }

--- a/src/codescene-tab/webview/utils.ts
+++ b/src/codescene-tab/webview/utils.ts
@@ -26,9 +26,9 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
 
   const cssTags = [];
   cssTags.push(
-    cssTag(webView, ['out', 'codescene-tab', 'webview', 'styles.css']),
     cssTag(webView, ['assets', 'markdown-languages.css']),
     cssTag(webView, ['assets', 'highlight.css']),
+    cssTag(webView, ['out', 'codescene-tab', 'webview', 'styles.css']),
     cssTag(webView, ['out', 'codicons', 'codicon.css'], 'vscode-codicon-stylesheet') // NOTE - vscode-elements needs an id for the stylesheet tag ¯\_(ツ)_/¯
   );
 
@@ -56,7 +56,7 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
 
     <body>
         ${scriptTags.join('\n')}
-        <h2 class="cs-common">${title}</h2>
+        <h2>${title}</h2>
         ${Array.isArray(bodyContent) ? bodyContent.join('\n') : bodyContent}
     </body>
 

--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -23,11 +23,6 @@ export class CsRefactoringCommands implements vscode.Disposable {
     );
   }
 
-  private presentRefactoringRequestCmd(request?: RefactoringRequest) {
-    if (!request) return;
-    CodeSceneTabPanel.show(request);
-  }
-
   private async requestAndPresentRefactoringCmd(document: vscode.TextDocument, fnToRefactor?: FnToRefactor, skipCache?: boolean) {
     if (!fnToRefactor) return;
     if (!CsExtensionState.acknowledgedAceUsage) {
@@ -36,7 +31,7 @@ export class CsRefactoringCommands implements vscode.Disposable {
     }
 
     const request = new RefactoringRequest(fnToRefactor, document, skipCache);
-    this.presentRefactoringRequestCmd(request);
+    CodeSceneTabPanel.show(request);
   }
 
   private async applyRefactoringCmd(refactoring: RefactoringRequest) {


### PR DESCRIPTION
Add some details about common security concerns
<img width="528" alt="image" src="https://github.com/user-attachments/assets/ca71015d-99c2-4c74-bdfe-c417288d00c0">


This commit also customizes some of the common styles used by the codescene-tab. Previously those styles were inherited from the markdown.css stylesheet