### PR TITLE
chore(code-health-monitor): ch monitor and details-view UX updates

### DIFF
--- a/src/code-health-monitor/details/styles.css
+++ b/src/code-health-monitor/details/styles.css
@@ -2,6 +2,15 @@ body {
   line-height: 20px;
 }
 
+h2 {
+  font-size: 16px;
+  margin: 4px 0;
+}
+
+a:focus {
+  outline: none;
+}
+
 .flex-row {
   display: flex;
   gap: 6px;
@@ -15,11 +24,16 @@ body {
 }
 
 .block {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
 }
 
-.function-info {
+.color-red {
+  color: var(--vscode-errorForeground);
+}
+
+.function-summary {
   margin-top: 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
 }
 
 .function-name {
@@ -27,7 +41,7 @@ body {
   font-weight: bold;
 }
 
-.function-coordinate {
+.filename-and-smell {
   gap: 10px;
 }
 
@@ -35,12 +49,7 @@ body {
   margin-bottom: 14px;
 }
 
-.issue-details {
-  border-top: 1px solid rgba(255, 255, 255, 0.18);
-  padding-top: 20px;
-}
-
-.issue-icon-link {
-  color: var(--vscode-foreground);
-  line-height: 0;
+.issue-link {
+  font-weight: bold;
+  text-decoration: none;
 }

--- a/src/code-health-monitor/details/view.ts
+++ b/src/code-health-monitor/details/view.ts
@@ -112,8 +112,7 @@ class CodeHealthDetailsView implements WebviewViewProvider, Disposable {
 
   private functionInfoContent(functionInfo: DeltaFunctionInfo) {
     return `
-    ${this.fileAndFunctionInfo(functionInfo)}
-    ${this.functionDescription(functionInfo)}
+    ${this.fileAndCodeSmellSummary(functionInfo)}
     <div class="block">
       ${refactoringButton(functionInfo.fnToRefactor)}
     </div>
@@ -121,32 +120,19 @@ class CodeHealthDetailsView implements WebviewViewProvider, Disposable {
     `;
   }
 
-  private fileAndFunctionInfo(functionInfo: DeltaFunctionInfo) {
+  private fileAndCodeSmellSummary(functionInfo: DeltaFunctionInfo) {
     const fileName = basename(functionInfo.parent.document.uri.fsPath);
+    const smellInfo =
+      functionInfo.children.length === 1 ? functionInfo.children[0].changeDetail.category : 'Multiple Code Smells';
     return /*html*/ `
-      <div class="block function-info">
-        <div class="function-name flex-row large"><span class="codicon codicon-symbol-method"></span><span>${functionInfo.fnName}</span></div>
-        <div class="function-coordinate flex-row">
+      <div class="block function-summary">
+        <h2>${functionInfo.fnName}</h2>
+        <div class="flex-row filename-and-smell">
           <div class="flex-row">${fileName}</div> <!-- TODO seti file type theme icon ? -->
-          <div class="flex-row"><span class="codicon codicon-list-flat"></span> Line:${functionInfo.range.start.line}</div>
+          <div class="flex-row"><span class="codicon codicon-warning"></span> ${smellInfo}</div>
         </div>
       </div>
     `;
-  }
-
-  private functionDescription(functionInfo: DeltaFunctionInfo) {
-    const categories = functionInfo.children.map((issue) => issue.changeDetail.category);
-    const description =
-      categories.length > 0 &&
-      /*html*/ `
-      <div class="block">
-        <p>CodeScene identified the following code ${pluralize('smell', categories.length)}: <strong>${categories.join(
-        ', '
-      )}</strong> resulting in a decline in Code Health.
-        </p>
-      </div>`;
-
-    return description ? description : '';
   }
 
   private issueDetails(functionInfo: DeltaFunctionInfo) {
@@ -154,9 +140,9 @@ class CodeHealthDetailsView implements WebviewViewProvider, Disposable {
       (issue, ix) => /*html*/ `
       <div class="issue">
         <div class="flex-row">
-          <span class="codicon codicon-warning"></span> 
-          <strong>${issue.changeDetail.category}</strong>
-          <a href="" class="issue-icon-link" issue-index="${ix}"><span class="codicon codicon-link-external"></span></a>
+          <span class="codicon codicon-chrome-close color-red"></span> 
+          <strong>${capitalize(issue.changeDetail['change-type'])}: </strong>
+          <a href="" class="issue-link" issue-index="${ix}">${issue.changeDetail.category}</a>
         </div>
         ${issue.changeDetail.description}
       </div>
@@ -168,4 +154,8 @@ class CodeHealthDetailsView implements WebviewViewProvider, Disposable {
         ${issueDetails.join('')}
       </div>`;
   }
+}
+
+function capitalize(text: string) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
 }

--- a/src/code-health-monitor/details/webview-script.ts
+++ b/src/code-health-monitor/details/webview-script.ts
@@ -12,7 +12,7 @@ function sendMessage(command: string, data?: object) {
 function main() {
   document.getElementById('refactoring-button')?.addEventListener('click', () => sendMessage('request-and-present-refactoring'));
 
-  for (const link of Array.from(document.getElementsByClassName('issue-icon-link'))) {
+  for (const link of Array.from(document.getElementsByClassName('issue-link'))) {
     link.addEventListener('click', (e) => issueClickHandler(e));
   }
 }

--- a/src/code-health-monitor/tree-model.ts
+++ b/src/code-health-monitor/tree-model.ts
@@ -148,36 +148,23 @@ export class DeltaFunctionInfo implements DeltaTreeViewItem {
       arguments: [this],
     };
 
-    if (this.isRefactoringSupported) {
-      this.presentAsRefactorable(item);
-    } else {
-      this.presentAsDefault(item);
-    }
+    item.iconPath = new vscode.ThemeIcon('symbol-function');
+    item.description = this.isRefactoringSupported ? 'Auto-Refactor' : undefined;
+    item.tooltip = this.tooltip();
     return item;
   }
 
-  private tooltip(refactorable?: boolean) {
+  private tooltip() {
     const issues = issuesCount(this.children);
     const tips = [`Function "${this.fnName}"`];
 
     issues && tips.push(`Contains ${issues} ${pluralize('issue', issues)} degrading code health`);
-    refactorable && tips.push('Auto-refactor available');
+    this.isRefactoringSupported && tips.push('Auto-refactor available');
     return tips.join(' • ');
   }
 
   public get isRefactoringSupported() {
     return isDefined(this.fnToRefactor);
-  }
-
-  private presentAsDefault(item: vscode.TreeItem) {
-    item.iconPath = new vscode.ThemeIcon('symbol-function');
-    item.tooltip = this.tooltip();
-  }
-
-  private presentAsRefactorable(item: vscode.TreeItem) {
-    item.iconPath = new vscode.ThemeIcon('sparkle');
-    item.description = 'Auto-Refactor';
-    item.tooltip = this.tooltip(true);
   }
 }
 

--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -174,11 +174,11 @@ export function refactoringButton(refactoring?: FnToRefactor) {
   if (!refactoring) {
     return /* html */ `
       <vscode-button id="refactoring-button" icon="circle-slash" secondary disabled>
-        Auto-refactor
+        Auto-Refactor
       </vscode-button>`;
   }
   return /* html */ `
     <vscode-button id="refactoring-button" icon="sparkle" primary>
-      Auto-refactor
+      Auto-Refactor
     </vscode-button>`;
 }


### PR DESCRIPTION
Updating with latest sketches.
<img width="402" alt="image" src="https://github.com/user-attachments/assets/3afcc891-af78-4a31-b263-062e7054c3c1">

Getting the seti-icons with correct coloring is not trivial, leaving that for now.
Also, the [vscode-element](https://github.com/vscode-elements/elements) button is not designed to be able to stretch, so keeping that in the standard look for now.