### PR TITLE
fix(refactoring-panel): Correctly present refactoring reasons

### DIFF
--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -88,26 +88,20 @@ function reasonsContent(response: RefactorResponse) {
     'reasons-with-details': reasonsWithDetails,
     confidence: { 'review-header': reviewHeader, level },
   } = response;
+
   let reasons;
-  if (presentReasons(response)) {
-    const reasonLi = reasonsWithDetails.map((reason) => `<li>${reason.summary}</li>`).join('\n');
-    reasons = /*html*/ `
-          <ul>${reasonLi}</ul>
-        `;
-  } else {
+  if (response.confidence.level === 0) {
     reasons =
       "The LLMs couldn't provide an ideal refactoring due to the specific complexities of the code. Though not an endorsed solution, it is displayed as a guide to help refine your approach.";
+  } else {
+    const reasonListItems = reasonsWithDetails.map((reason) => `<li>${reason.summary}</li>`);
+    reasons = reasonListItems.length > 0 ? `<ul>${reasonListItems.join('\n')}</ul>` : null;
   }
+
   // ReviewHeader is optional in the API, but is always present for confidence > 1  (i.e. autoRefactorContent)
   const safeHeader = reviewHeader || 'Reasons for review';
   const isCollapsed = level > 2;
-  return collapsibleContent(safeHeader, reasons, isCollapsed);
-}
-
-function presentReasons(response: RefactorResponse) {
-  return (
-    response.confidence.level !== 0 && response['reasons-with-details'] && response['reasons-with-details'].length > 0
-  );
+  return reasons ? collapsibleContent(safeHeader, reasons, isCollapsed) : '';
 }
 
 function acceptAndRejectButtons() {
@@ -182,3 +176,5 @@ export function refactoringButton(refactoring?: FnToRefactor) {
       Auto-Refactor
     </vscode-button>`;
 }
+
+export { reasonsContent };

--- a/src/test/suite/refactoring-components.test.ts
+++ b/src/test/suite/refactoring-components.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import { reasonsContent } from '../../codescene-tab/webview/refactoring-components';
+import { RefactorResponse } from '../../refactoring/model';
+
+const code = 'function foo() {}\n';
+
+suite('Refactor panel components Test Suite', () => {
+  test('Expected reasons for conf 0', async () => {
+    const response: RefactorResponse = {
+      code,
+      'reasons-with-details': [{ summary: 'summary' }],
+      'refactoring-properties': { 'added-code-smells': [], 'removed-code-smells': [] },
+      confidence: {
+        description: 'no-confidence',
+        level: 0,
+        title: 'Refactoring results',
+        'recommended-action': {
+          description: 'Unverified refactoring',
+          details: 'LLMs failed to identify a sufficiently effective refactoring.',
+        },
+        'review-header': 'Reason for unverified refactoring',
+      },
+    };
+    const content = reasonsContent(response);
+    assert.match(
+      content,
+      /The LLMs couldn't provide an ideal refactoring due to the specific complexities of the code. Though not an endorsed solution, it is displayed as a guide to help refine your approach./
+    );
+  });
+
+  test('Expected reasons for full conf (4), with no reasons(-with-details)', async () => {
+    const response: RefactorResponse = {
+      code,
+      'reasons-with-details': [],
+      'refactoring-properties': { 'added-code-smells': [], 'removed-code-smells': [] },
+      confidence: {
+        description: 'full-confidence',
+        level: 4,
+        title: 'Refactoring suggestion',
+        'recommended-action': {
+          description: 'Quick inspection',
+          details: 'The refactoring improves code health and preserves the semantics of the code.',
+        },
+        'review-header': 'Refactoring notes',
+      },
+    };
+    const content = reasonsContent(response);
+    assert.equal(content, '');
+  });
+});


### PR DESCRIPTION
When getting a refactoring with no `reasons-with-details` (i.e. probably a high/full confidence refactoring), the (folded) “**Refactoring notes**” would show a text about LLMs not finding a suitable refactoring if unfolded.

Solved by skipping the colllapsible header altogether if no reasons are supplied in the service response.