### PR TITLE
fix(refactoring/documentation): Add file-changes message when applicable

### DIFF
--- a/src/codescene-tab/webview/components.ts
+++ b/src/codescene-tab/webview/components.ts
@@ -34,25 +34,41 @@ export function functionLocationContent({
   position,
   filePath,
   fnName,
+  isStale,
 }: {
   position: Position;
   filePath: string;
   fnName?: string;
+  isStale?: boolean;
 }) {
   const fileName = basename(filePath);
 
   const fnNameHtml = fnName
     ? `<span class="codicon codicon-symbol-method"></span>
-      ${fnName}`
+       <span class="${isStale ? 'strikeout' : ''}">${fnName}</span>`
     : '';
 
   return /*html*/ `
     <div id="function-location" class="flex-row">
       <span class="file-name">${fileName}</span>
       ${fnNameHtml}
-      <span class="line-no">[Ln ${position.line + 1}]</span>
+      <span class="line-no ${isStale ? 'strikeout' : ''}">[Ln ${position.line + 1}]</span>
     </div>
     <hr>
+    `;
+}
+
+export function fileChangesDetectedContent(description: string) {
+  return /*html*/ `
+    <div class="file-changes-detected">
+      <div class="codicon codicon-warning warning-icon"></div>
+      <div class="content">
+        <div class="header">File Changes Detected</div>
+        <span>${description}</span>
+        <vscode-button id="close-button" icon="close" secondary aria-label="Close" title="Close">Close Panel</vscode-button>
+        </div>
+      </div>
+    </div>
     `;
 }
 

--- a/src/codescene-tab/webview/documentation-script.ts
+++ b/src/codescene-tab/webview/documentation-script.ts
@@ -9,6 +9,7 @@ function sendMessage(command: string) {
 }
 
 function main() {
+  document.getElementById('close-button')?.addEventListener('click', () => sendMessage('close'));
   document.getElementById('function-location')?.addEventListener('click', () => sendMessage('goto-function-location'));
   document
     .getElementById('refactoring-button')

--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -30,7 +30,7 @@ function retryButton() {
           </vscode-button>`;
 }
 
-export function refactoringContent(response: RefactorResponse, languageId: string) {
+export function refactoringContent(response: RefactorResponse, languageId: string, isStale: boolean) {
   const decoratedCode = decorateCode(response, languageId);
   const code = { content: decoratedCode, languageId };
   const { level } = response.confidence;
@@ -39,7 +39,7 @@ export function refactoringContent(response: RefactorResponse, languageId: strin
   } else if (level === 1) {
     return codeImprovementContent(response, code);
   }
-  return autoRefactorContent(response, code);
+  return autoRefactorContent(response, code, isStale);
 }
 
 type Code = {
@@ -74,9 +74,9 @@ async function codeSmellsGuide(codeSmell: string) {
     `;
 }
 
-async function autoRefactorContent(response: RefactorResponse, code: CodeWithLangId) {
+async function autoRefactorContent(response: RefactorResponse, code: CodeWithLangId, isStale: boolean) {
   const content = /*html*/ `
-        ${acceptAndRejectButtons()}
+        ${isStale ? '' : acceptAndRejectButtons()}
         ${reasonsContent(response)}
         ${collapsibleContent('Refactored code', await codeContainerContent(code))}
     `;

--- a/src/codescene-tab/webview/refactoring-script.ts
+++ b/src/codescene-tab/webview/refactoring-script.ts
@@ -10,11 +10,17 @@ function sendMessage(command: string) {
 }
 
 function main() {
-  document.getElementById('function-location')?.addEventListener('click', () => sendMessage('gotoFunctionLocation'));
-  document.getElementById('diff-button')?.addEventListener('click', () => sendMessage('showDiff'));
-  document.getElementById('reject-button')?.addEventListener('click', () => sendMessage('reject'));
-  document.getElementById('apply-button')?.addEventListener('click', () => sendMessage('apply'));
-  document.getElementById('retry-button')?.addEventListener('click', () => sendMessage('retry'));
-  document.getElementById('copy-to-clipboard-button')?.addEventListener('click', () => sendMessage('copyCode'));
-  document.getElementById('show-logoutput-link')?.addEventListener('click', () => sendMessage('showLogoutput'));
+  addClickEventListener('close-button', 'close');
+  addClickEventListener('function-location', 'gotoFunctionLocation');
+  addClickEventListener('diff-button', 'showDiff');
+  addClickEventListener('reject-button', 'reject');
+  addClickEventListener('apply-button', 'apply');
+  addClickEventListener('retry-button', 'retry');
+  addClickEventListener('copy-to-clipboard-button', 'copyCode');
+  addClickEventListener('show-logoutput-link', 'showLogoutput');
+}
+
+function addClickEventListener(elementId: string, command: string) {
+  const buttonEl = document.getElementById(elementId);
+  buttonEl?.addEventListener('click', () => sendMessage(command));
 }

--- a/src/codescene-tab/webview/refactoring-styles.css
+++ b/src/codescene-tab/webview/refactoring-styles.css
@@ -39,7 +39,6 @@
 .refactoring-summary {
   background-color: var(--vscode-textCodeBlock-background);
   border-left: 2px solid var(--vscode-textCodeBlock-background);
-  font-size: 12px;
   padding: 10px 14px;
   margin-top: 14px;
 }
@@ -62,7 +61,6 @@
 }
 
 .refactoring-summary-header {
-  text-transform: uppercase;
   font-weight: 600;
 }
 

--- a/src/codescene-tab/webview/styles.css
+++ b/src/codescene-tab/webview/styles.css
@@ -27,6 +27,10 @@ h4 {
   cursor: pointer;
 }
 
+.strikeout {
+  text-decoration: line-through;
+}
+
 .flex-row {
   display: flex;
   gap: 4px;
@@ -54,6 +58,35 @@ h4 {
 
 #function-location:hover {
   background-color: var(--vscode-toolbar-hoverBackground);
+}
+
+.file-changes-detected {
+  background-color: var(--vscode-textCodeBlock-background);
+  border-left: 2px solid var(--vscode-editorWarning-foreground);
+  padding: 10px 14px;
+  margin-top: 14px;
+  display: flex;
+  gap: 8px;
+
+  .warning-icon {
+    color: var(--vscode-editorWarning-foreground);
+    padding-top: 5px;
+  }
+
+  div.content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  div.header {
+    font-weight: 600;
+  }
+
+  #close-button {
+    margin-top: 6px;
+  }
 }
 
 .expand-indicator {


### PR DESCRIPTION
If the side panel is open with either a code smell documentation or a refactoring we'll present a warning message on certain code changes. The current condition is when the user makes edits _in_ or _above_ the function considered in the panel.