### PR TITLE
Telemetry event overview

### DIFF
--- a/src/auth/auth-provider.ts
+++ b/src/auth/auth-provider.ts
@@ -156,7 +156,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
    */
   private async login() {
     this.cancelLogin();
-    Telemetry.instance.logUsage('auth/attempted');
+    Telemetry.logUsage('auth/attempted');
     return window.withProgress<LoginResponse>(
       {
         location: ProgressLocation.Notification,
@@ -175,7 +175,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
         const cancelledByButtonPromise = promiseFromEvent(
           cancelButtonToken.onCancellationRequested,
           (_, __, reject) => {
-            Telemetry.instance.logUsage('auth/cancelled');
+            Telemetry.logUsage('auth/cancelled');
             reject('User Cancelled');
           }
         ).promise;
@@ -184,7 +184,7 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
         if (CsAuthenticationProvider.runningLogin) {
           promises.push(
             promiseFromEvent(CsAuthenticationProvider.runningLogin.token.onCancellationRequested, (_, __, reject) => {
-              Telemetry.instance.logUsage('auth/cancelled');
+              Telemetry.logUsage('auth/cancelled');
               reject('Cancelled due to starting another login attempt');
             }).promise
           );
@@ -219,24 +219,24 @@ export class CsAuthenticationProvider implements AuthenticationProvider, Disposa
       const userId = query.get('user-id');
 
       if (token === null) {
-        Telemetry.instance.logUsage('auth/rejected');
+        Telemetry.logUsage('auth/rejected');
         reject('No token found in redirect');
         return;
       }
 
       if (name === null) {
-        Telemetry.instance.logUsage('auth/rejected');
+        Telemetry.logUsage('auth/rejected');
         reject('No name found in redirect');
         return;
       }
 
       if (userId === null) {
-        Telemetry.instance.logUsage('auth/rejected');
+        Telemetry.logUsage('auth/rejected');
         reject('No user-id found in redirect');
         return;
       }
 
-      Telemetry.instance.logUsage('auth/successful');
+      Telemetry.logUsage('auth/successful');
       resolve({ name, token, userId });
     };
   }

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -2,7 +2,6 @@ import vscode from 'vscode';
 import { Branch, GitExtension, Repository } from '../../types/git';
 import { AceAPI } from '../refactoring/addon';
 import Reviewer from '../review/reviewer';
-import { registerCommandWithTelemetry } from '../telemetry';
 import { register as registerCodeLens } from './codelens';
 import { register as registerCodeHealthDetailsView } from './details/view';
 import { DeltaFunctionInfo } from './tree-model';
@@ -17,14 +16,6 @@ export function activate(context: vscode.ExtensionContext, aceApi?: AceAPI) {
     return;
   }
 
-  const selectFunctionDisposable = vscode.commands.registerCommand(
-    'codescene.codeHealthMonitor.selectFunction',
-    (functionInfo: DeltaFunctionInfo) => {
-      void vscode.commands.executeCommand('codescene.monitorCodeLens.showFunction', functionInfo);
-      void vscode.commands.executeCommand('codescene.codeHealthDetailsView.showDetails', functionInfo);
-    }
-  );
-
   const codeHealthMonitorView = new CodeHealthMonitorView(context);
   registerCodeLens(context);
   registerCodeHealthDetailsView(context);
@@ -35,16 +26,12 @@ export function activate(context: vscode.ExtensionContext, aceApi?: AceAPI) {
   context.subscriptions.push(
     codeHealthMonitorView,
     ...repoStateListeners,
-    registerCommandWithTelemetry({
-      commandId: 'codescene.codeHealthMonitorHelp',
-      handler: () => {
-        void vscode.commands.executeCommand(
-          'markdown.showPreviewToSide',
-          vscode.Uri.parse(`csdoc:code-health-monitor.md`)
-        );
-      },
-    }),
-    selectFunctionDisposable
+    vscode.commands.registerCommand('codescene.codeHealthMonitorHelp', () => {
+      void vscode.commands.executeCommand(
+        'markdown.showPreviewToSide',
+        vscode.Uri.parse(`csdoc:code-health-monitor.md`)
+      );
+    })
   );
 }
 

--- a/src/code-health-monitor/codelens.ts
+++ b/src/code-health-monitor/codelens.ts
@@ -59,7 +59,7 @@ export class CodeHealthMonitorCodeLens implements vscode.CodeLensProvider<vscode
         new vscode.CodeLens(new vscode.Range(functionStartLine, functionStartLine), {
           title: '$(sparkle) CodeScene ACE',
           command: 'codescene.requestAndPresentRefactoring',
-          arguments: [functionInfo.parent.document, functionInfo.fnToRefactor],
+          arguments: [functionInfo.parent.document, 'codelens (code-health-monitor)', functionInfo.fnToRefactor],
         })
       );
     }
@@ -70,7 +70,7 @@ export class CodeHealthMonitorCodeLens implements vscode.CodeLensProvider<vscode
           new vscode.CodeLens(this.lensRange(issue.position, order++), {
             title: `$(warning) ${issue.changeDetail.category}`,
             command: 'codescene.openInteractiveDocsPanel',
-            arguments: [issueToDocsParams(issue, functionInfo)],
+            arguments: [issueToDocsParams(issue, functionInfo), 'codelens (code-health-monitor)'],
           })
         );
       });

--- a/src/code-health-monitor/tree-model.ts
+++ b/src/code-health-monitor/tree-model.ts
@@ -69,6 +69,14 @@ export class FileWithIssues implements DeltaTreeViewItem {
     return new DeltaInfoItem(scoreInfo);
   }
 
+  get nIssues() {
+    return this.fileLevelIssues.length + this.functionLevelIssues.length;
+  }
+
+  get nRefactorableFunctions() {
+    return this.functionLevelIssues.filter((fn) => fn.isRefactoringSupported).length;
+  }
+
   get scoreChange() {
     const oldScore = this.deltaForFile['old-score'] || 10;
     const newScore = this.deltaForFile['new-score'];
@@ -142,12 +150,6 @@ export class DeltaFunctionInfo implements DeltaTreeViewItem {
 
   toTreeItem(): vscode.TreeItem {
     const item = new vscode.TreeItem(this.fnName, vscode.TreeItemCollapsibleState.None);
-    item.command = {
-      command: 'codescene.codeHealthMonitor.selectFunction',
-      title: 'Show function for code health monitoring',
-      arguments: [this],
-    };
-
     item.iconPath = new vscode.ThemeIcon('symbol-function');
     item.description = this.isRefactoringSupported ? 'Auto-Refactor' : undefined;
     item.tooltip = this.tooltip();
@@ -190,7 +192,7 @@ export class DeltaIssue implements DeltaTreeViewItem {
     item.command = {
       command: 'codescene.openInteractiveDocsPanel',
       title: 'Open interactive documentation',
-      arguments: [issueToDocsParams(this, fnInfo)],
+      arguments: [issueToDocsParams(this, fnInfo), 'code-health-tree-view'],
     };
     return item;
   }

--- a/src/code-health-rules/index.ts
+++ b/src/code-health-rules/index.ts
@@ -1,24 +1,19 @@
-import { window, ExtensionContext } from 'vscode';
-import { registerCommandWithTelemetry } from '../telemetry';
+import { commands, ExtensionContext, window } from 'vscode';
 import { checkCodeHealthRules } from './check-rules';
 import { createRulesTemplate } from './rules-template';
+import Telemetry from '../telemetry';
 
 export function register(context: ExtensionContext) {
-  const createRulesTemplateCmd = registerCommandWithTelemetry({
-    commandId: 'codescene.createRulesTemplate',
-    handler: () => {
+  context.subscriptions.push(
+    commands.registerCommand('codescene.createRulesTemplate', () => {
+      Telemetry.logUsage('createRulesTemplate');
       createRulesTemplate().catch((error: Error) => {
         void window.showErrorMessage(error.message);
       });
-    },
-  });
-  context.subscriptions.push(createRulesTemplateCmd);
-
-  const createCheckRules = registerCommandWithTelemetry({
-    commandId: 'codescene.checkRules',
-    handler: () => {
+    }),
+    commands.registerCommand('codescene.checkRules', () => {
+      Telemetry.logUsage('checkRules');
       void checkCodeHealthRules();
-    },
-  });
-  context.subscriptions.push(createCheckRules);
+    })
+  );
 }

--- a/src/codescene-tab/webview-panel.ts
+++ b/src/codescene-tab/webview-panel.ts
@@ -144,6 +144,7 @@ export class CodeSceneTabPanel implements Disposable {
       },
       reject: () => {
         this.deselectRefactoring(refactoring);
+        Telemetry.instance.logUsage('refactor/rejected', refactoring.eventData);
         this.dispose();
       },
       retry: async () => {

--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -149,7 +149,7 @@ async function codeContainerContent(code: CodeWithLangId, showDiff = true) {
 async function unverifiedRefactoring(response: RefactorResponse, code: CodeWithLangId) {
   return /*html*/ `
     ${reasonsContent(response)}
-    ${collapsibleContent('Refactored code (unverified)', await codeContainerContent(code))}
+    ${collapsibleContent('Refactored code (unverified)', await codeContainerContent(code, false))}
   `;
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,7 +111,7 @@ async function startExtension(context: vscode.ExtensionContext) {
  */
 function finalizeActivation() {
     // send telemetry on activation (gives us basic usage stats)
-    Telemetry.instance.logUsage('onActivateExtension');
+    Telemetry.logUsage('onActivateExtension');
     void vscode.commands.executeCommand('setContext', 'codescene.asyncActivationFinished', true);
 }
 

--- a/src/refactoring/api.ts
+++ b/src/refactoring/api.ts
@@ -12,7 +12,6 @@ import { getPortalUrl } from '../configuration';
 import { CsExtensionState } from '../cs-extension-state';
 import { CsRestApi, isCodeSceneSession } from '../cs-rest-api';
 import { logOutputChannel } from '../log';
-import Telemetry from '../telemetry';
 import { getFileExtension, isDefined, rangeStr } from '../utils';
 import { FnToRefactor } from './capabilities';
 import { AceCredits, PreFlightResponse, RefactorConfidence, RefactorRequest, RefactorResponse } from './model';
@@ -111,11 +110,10 @@ export class RefactoringAPI {
 }
 
 function logFetchRefactoringRequest(request: RefactoringRequest) {
-  const { traceId, fnToRefactor, skipCache, eventData } = request;
+  const { traceId, fnToRefactor, skipCache } = request;
   logOutputChannel.debug(
     `Refactor request for ${logIdString(traceId, fnToRefactor)}${skipCache === true ? ' (retry)' : ''}`
   );
-  Telemetry.instance.logUsage('refactor/requested', eventData);
 }
 
 /**

--- a/src/refactoring/model.ts
+++ b/src/refactoring/model.ts
@@ -64,11 +64,15 @@ export interface ReasonsWithDetails {
   details?: ReasonDetails[];
 }
 
+interface Metadata {
+  'cached?'?: boolean;
+}
 export interface RefactorResponse {
   confidence: RefactorConfidence;
   'reasons-with-details': ReasonsWithDetails[];
   'refactoring-properties': RefactorProperties;
   code: string;
+  metadata: Metadata;
 }
 
 export interface AceCredits {

--- a/src/refactoring/request.ts
+++ b/src/refactoring/request.ts
@@ -44,8 +44,8 @@ export class RefactoringRequest {
   }
 
   get eventData() {
-    const eventData: any = { 'trace-id': this.traceId };
-    if (this.skipCache) eventData['skip-cache'] = true;
+    const eventData: any = { traceId: this.traceId };
+    if (this.skipCache) eventData.skipCache = true;
     return eventData;
   }
 

--- a/src/review/codeaction.ts
+++ b/src/review/codeaction.ts
@@ -54,7 +54,7 @@ class ReviewCodeActionProvider implements vscode.CodeActionProvider, vscode.Disp
       refactorAction.command = {
         command: 'codescene.requestAndPresentRefactoring',
         title: 'Refactor using CodeScene ACE',
-        arguments: [document, fnToRefactor],
+        arguments: [document, 'codeaction', fnToRefactor],
       };
       actions.push(refactorAction);
     }
@@ -68,7 +68,7 @@ class ReviewCodeActionProvider implements vscode.CodeActionProvider, vscode.Disp
       action.command = {
         command: 'codescene.openInteractiveDocsPanel',
         title,
-        arguments: [toDocsParams(category, diagnostic.range.start, document, fnToRefactor)],
+        arguments: [toDocsParams(category, diagnostic.range.start, document, fnToRefactor), 'codeaction'],
       };
       actions.push(action);
     });

--- a/src/review/codelens.ts
+++ b/src/review/codelens.ts
@@ -116,7 +116,7 @@ export class CsReviewCodeLensProvider
     return {
       title,
       command: 'codescene.openInteractiveDocsPanel',
-      arguments: [toDocsParams(category, diagnostic.range.start, document, fnToRefactor)],
+      arguments: [toDocsParams(category, diagnostic.range.start, document, fnToRefactor), 'codelens (review)'],
     };
   }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -34,7 +34,7 @@ export class StatsCollector {
   sendCurrentStats() {
     if (this.stats.analysis.length > 0) {
       for (const byLanguage of this.stats.analysis) {
-        Telemetry.instance.logUsage('stats', { stats: { analysis: byLanguage } });
+        Telemetry.logUsage('stats', { stats: { analysis: byLanguage } });
       }
     }
     this.clear();

--- a/src/terms-conditions.ts
+++ b/src/terms-conditions.ts
@@ -1,15 +1,13 @@
 import { commands, env, ExtensionContext, Uri, window } from 'vscode';
 import { CsExtensionState } from './cs-extension-state';
-import Telemetry, { registerCommandWithTelemetry } from './telemetry';
+import Telemetry from './telemetry';
 
 export function registerTermsAndPoliciesCmds(context: ExtensionContext) {
   context.subscriptions.push(
-    registerCommandWithTelemetry({
-      commandId: 'codescene.revokeTerms',
-      handler: async () => {
-        await CsExtensionState.setAcceptedTermsAndPolicies(undefined);
-        void window.showInformationMessage('Terms and Privacy Policy agreement has now been revoked');
-      },
+    commands.registerCommand('codescene.revokeTerms', async () => {
+      Telemetry.logUsage('revokeTerms');
+      await CsExtensionState.setAcceptedTermsAndPolicies(undefined);
+      void window.showInformationMessage('Terms and Privacy Policy agreement has now been revoked');
     }),
     // Mostly for testing, users should rarely need to revoke this since it is controlled by a setting as well
     // The acceptance is just for notifying the user about the feature
@@ -30,7 +28,7 @@ export async function acceptTermsAndPolicies(context: ExtensionContext): Promise
     'View Terms & Policies'
   );
 
-  Telemetry.instance.logUsage('termsAndPoliciesResponse', { selection });
+  Telemetry.logUsage('termsAndPoliciesResponse', { selection });
 
   switch (selection) {
     case 'Accept':

--- a/src/terms-conditions.ts
+++ b/src/terms-conditions.ts
@@ -1,6 +1,6 @@
 import { commands, env, ExtensionContext, Uri, window } from 'vscode';
 import { CsExtensionState } from './cs-extension-state';
-import { registerCommandWithTelemetry } from './telemetry';
+import Telemetry, { registerCommandWithTelemetry } from './telemetry';
 
 export function registerTermsAndPoliciesCmds(context: ExtensionContext) {
   context.subscriptions.push(
@@ -29,6 +29,8 @@ export async function acceptTermsAndPolicies(context: ExtensionContext): Promise
     'Decline',
     'View Terms & Policies'
   );
+
+  Telemetry.instance.logUsage('termsAndPoliciesResponse', { selection });
 
   switch (selection) {
     case 'Accept':

--- a/src/test/suite/refactor-utils.test.ts
+++ b/src/test/suite/refactor-utils.test.ts
@@ -10,6 +10,7 @@ suite('Refactor utils Test Suite', () => {
     'reasons-with-details': [],
     'refactoring-properties': { 'added-code-smells': [], 'removed-code-smells': [] },
     confidence: { level: 3, 'recommended-action': { description: '', details: '' }, description: '', title: '' },
+    metadata: {},
   };
 
   test("Return code as is if there's no reasons-with-details", async () => {

--- a/src/test/suite/refactoring-components.test.ts
+++ b/src/test/suite/refactoring-components.test.ts
@@ -20,6 +20,7 @@ suite('Refactor panel components Test Suite', () => {
         },
         'review-header': 'Reason for unverified refactoring',
       },
+      metadata: {},
     };
     const content = reasonsContent(response);
     assert.match(
@@ -43,6 +44,7 @@ suite('Refactor panel components Test Suite', () => {
         },
         'review-header': 'Refactoring notes',
       },
+      metadata: {},
     };
     const content = reasonsContent(response);
     assert.equal(content, '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export function assertError(val: unknown): Error | undefined {
 export function reportError(pre: string, error: Error) {
   const message = `${pre}. ${error.message}`;
   delete error.stack;
-  logOutputChannel.error(`${message}: ${JSON.stringify(error)}`);
+  logOutputChannel.error(`${message} ${JSON.stringify(error)}`);
   void vscode.window.showErrorMessage(message);
   void vscode.commands.executeCommand('codescene.controlCenterView.focus');
 }


### PR DESCRIPTION
After discussion with Product, we're doing an overhaul of the user telemetry in order to be able to find a good market fit.

Some notes: 
* Replace the extensionId prefix that's automatically added by the TelemetrySender in order to keep event name length down
* Remove all command/ events - we're only interested in actual user actions
* When sending telemetry from a command, we make sure to add a "source" property