### PR TITLE
Ensure control-center is resolved while initializing

### DIFF
--- a/src/control-center/view-provider.ts
+++ b/src/control-center/view-provider.ts
@@ -46,14 +46,17 @@ export class ControlCenterViewProvider implements WebviewViewProvider, Disposabl
   }
 
   private handleVisibilityEvents(view: vscode.WebviewView) {
-    // On first resolve ("resolveWebviewView is called when a view first becomes visible")
-    Telemetry.logUsage('control-center/visibility', { visible: view.visible });
     view.onDidChangeVisibility(
       // On subsequent visibility changes (void event - use view.visible)
       () => Telemetry.logUsage('control-center/visibility', { visible: view.visible }),
       this,
       this.disposables
     );
+  }
+
+  // Just to be able to send visibility status on startup. Can't do that on resolveWebviewView since we don't know if DevtoolsAPI is available.
+  public sendStartupTelemetry() {
+    Telemetry.logUsage('control-center/visibility', { visible: this.view?.visible ? true : false });
   }
 
   private handleMessages(message: any) {

--- a/src/cs-extension-state.ts
+++ b/src/cs-extension-state.ts
@@ -1,7 +1,7 @@
 import vscode, { Uri } from 'vscode';
 import { AnalysisEvent } from './analysis-common';
 import { DeltaAnalyser } from './code-health-monitor/analyser';
-import { ControlCenterViewProvider, registerControlCenterViewProvider } from './control-center/view-provider';
+import { ControlCenterViewProvider } from './control-center/view-provider';
 import { CsStatusBar } from './cs-statusbar';
 import { logOutputChannel } from './log';
 import { AceAPI } from './refactoring/addon';
@@ -47,11 +47,13 @@ const acknowledgedAceUsageKey = 'acknowledgedAceUsage';
  */
 export class CsExtensionState {
   readonly stateProperties: CsStateProperties;
-  readonly controlCenterView: ControlCenterViewProvider;
   readonly statusBar: CsStatusBar;
   readonly extensionUri: Uri;
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly controlCenterView: ControlCenterViewProvider
+  ) {
     this.stateProperties = {
       features: {
         analysis: { state: 'loading' },
@@ -59,7 +61,6 @@ export class CsExtensionState {
       },
     };
     this.extensionUri = context.extensionUri;
-    this.controlCenterView = registerControlCenterViewProvider(context);
     context.subscriptions.push(
       vscode.commands.registerCommand('codescene.extensionState.clearErrors', () => {
         CsExtensionState.clearErrors();
@@ -76,8 +77,8 @@ export class CsExtensionState {
 
   private static _instance: CsExtensionState;
 
-  static init(context: vscode.ExtensionContext) {
-    CsExtensionState._instance = new CsExtensionState(context);
+  static init(context: vscode.ExtensionContext, controlCenterView: ControlCenterViewProvider) {
+    CsExtensionState._instance = new CsExtensionState(context, controlCenterView);
   }
 
   static get acceptedTermsAndPolicies() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ export async function activate(context: vscode.ExtensionContext) {
       const error = assertError(e) || new Error('Unknown error');
       CsExtensionState.setAnalysisState({ state: 'error', error });
       reportError('Unable to start extension', error);
+      Telemetry.logUsage('on_activate_extension_error', { errorMessage: error.message });
     }
   );
 }
@@ -122,7 +123,7 @@ async function startExtension(context: vscode.ExtensionContext, devtoolsApi: Dev
  */
 function finalizeActivation(ccProvider: ControlCenterViewProvider) {
   // send telemetry on activation (gives us basic usage stats)
-  Telemetry.logUsage('onActivateExtension');
+  Telemetry.logUsage('on_activate_extension');
   ccProvider.sendStartupTelemetry();
   void vscode.commands.executeCommand('setContext', 'codescene.asyncActivationFinished', true);
 }

--- a/src/refactoring/addon.ts
+++ b/src/refactoring/addon.ts
@@ -79,10 +79,8 @@ async function enable(context: vscode.ExtensionContext, devtoolsApi: DevtoolsAPI
 
     logOutputChannel.info('ACE enabled!');
     return capabilities;
-  } catch (unknownErr) {
-    const error = assertError(unknownErr);
-    if (!error) return;
-
+  } catch (e) {
+    const error = assertError(e) || new Error('Unknown error');
     stateEmitter.fire({ state: 'error', error });
     reportError('Unable to enable refactoring capabilities', error);
   }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -4,12 +4,11 @@ import * as vscode from 'vscode';
 import { getPortalUrl } from './configuration';
 import { CsExtensionState } from './cs-extension-state';
 import { logAxiosError } from './cs-rest-api';
-import { ExecResult, SimpleExecutor } from './executor';
-import { logOutputChannel } from './log';
 import { DevtoolsAPI } from './devtools-interop/api';
+import { logOutputChannel } from './log';
 
 export default class Telemetry {
-  private static _instance: Telemetry;
+  private static _instance?: Telemetry;
 
   private static eventPrefix = 'vscode';
 
@@ -45,6 +44,10 @@ export default class Telemetry {
   }
 
   static logUsage(eventName: string, eventData?: any) {
+    if (!Telemetry._instance) {
+      logOutputChannel.warn(`[Telemetry] Attempted to log event "${eventName}" before telemetry was initialized`);
+      return;
+    }
     Telemetry._instance.telemetryLogger.logUsage(eventName, eventData);
   }
 

--- a/src/terms-conditions.ts
+++ b/src/terms-conditions.ts
@@ -18,7 +18,7 @@ export function registerTermsAndPoliciesCmds(context: ExtensionContext) {
   );
 }
 
-export async function acceptTermsAndPolicies(context: ExtensionContext): Promise<boolean> {
+export async function acceptTermsAndPolicies(context: ExtensionContext): Promise<true> {
   if (CsExtensionState.acceptedTermsAndPolicies === true) return true;
 
   Telemetry.logUsage('terms_and_policies_shown');


### PR DESCRIPTION
### Problem
When using async/await in the `activate` function, the control-center panel `resolveWebviewView` never gets called until the binary download and T&C acceptance is done. So the only way for a user to get feedback is through the statusbar-item.

### Solution
Changing this back to promise-based lets the control-center resolve immediately, letting it be displayed during the download and T&C accept procedures. This makes it much clearer as to what's going on in startup, which is particularly important while downloading on slow connections.

The startup changes also causes some telemetry-event changes
* `control-center/visibility` is run immediately after `on_activate_extension`
* Add `on_activate_extension_error` event (and keep moving towards snake_case)