### PR TITLE
fix(code-health-monitor): Respect file delete/rename/move

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
       try {
         await acceptTermsAndPolicies(context); // throws Error if terms are not accepted
-        Reviewer.init(binaryPath);
+        Reviewer.init(binaryPath, context);
         DeltaAnalyser.init(binaryPath);
         CsExtensionState.setAnalysisState({ state: 'enabled' });
         await startExtension(context, devtoolsApi);


### PR DESCRIPTION
Uses `fileSystemWatcher` to detect deletions both inside and outside the editor and make sure that delta analysis results are cleared for the deleted/renamed/moved files.