### PR TITLE
Retry ACE connection on fail

### DIFF
--- a/src/control-center/view-provider.ts
+++ b/src/control-center/view-provider.ts
@@ -63,6 +63,11 @@ export class ControlCenterViewProvider implements WebviewViewProvider, Disposabl
     const commands: { [key: string]: () => void } = {
       openAiPricing: () => this.openLink('https://codescene.com/product/ai-coding#pricing'),
       showLogOutput: () => logOutputChannel.show(),
+      retryAce: () => {
+        logOutputChannel.show();
+        logOutputChannel.info('Retrying ACE activation...');
+        void vscode.commands.executeCommand('codescene.ace.activate');
+      },
       openSettings: () => {
         Telemetry.logUsage('control-center/open-settings');
         vscode.commands
@@ -234,7 +239,7 @@ export class ControlCenterViewProvider implements WebviewViewProvider, Disposabl
         break;
       case 'error':
         iconClass = 'codicon-error';
-        tooltip = aceFeature.error ? aceFeature.error.message : '';
+        tooltip = 'Click to retry connecting to CodeScene ACE';
         text = 'error';
         break;
     }

--- a/src/control-center/webview-script.ts
+++ b/src/control-center/webview-script.ts
@@ -12,7 +12,7 @@ function main() {
 
   // Status
   addClickEventForClass('code-health-analysis-badge', 'badge-error', () => sendMessage('showLogOutput'));
-  addClickEventForClass('ace-badge', 'badge-error', () => sendMessage('show-ace-error'));
+  addClickEventForClass('ace-badge', 'badge-error', () => sendMessage('retryAce'));
 
   // More
   addClickListenerToElementById('codescene-settings', () => sendMessage('openSettings'));


### PR DESCRIPTION
When ACE fails to initialize due to for example a connection error - this PR adds a simple albeit a quite secret way to retry initialization by just clicking on the `error` badge.
The plan is to refine the UX later on, but with this we can use the `codescene.ace.activate` command introduced in the PR to retry regardless of UX.