### PR TITLE
Bugfix: Refresh code health details on updates

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -4,7 +4,6 @@ import { AceAPI } from '../refactoring/addon';
 import Reviewer from '../review/reviewer';
 import { register as registerCodeLens } from './codelens';
 import { register as registerCodeHealthDetailsView } from './details/view';
-import { DeltaFunctionInfo } from './tree-model';
 import { CodeHealthMonitorView } from './tree-view';
 
 export function activate(context: vscode.ExtensionContext, aceApi?: AceAPI) {

--- a/src/code-health-monitor/codelens.ts
+++ b/src/code-health-monitor/codelens.ts
@@ -8,12 +8,8 @@ export function register(context: vscode.ExtensionContext) {
   const codeLensProvider = new CodeHealthMonitorCodeLens();
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(reviewDocumentSelector(), codeLensProvider),
-    vscode.commands.registerCommand('codescene.monitorCodeLens.showFunction', (functionInfo: DeltaFunctionInfo) => {
-      const uri = functionInfo.parent.document.uri;
-      const pos = functionInfo.range.start;
-      const location = new vscode.Location(uri, pos);
+    vscode.commands.registerCommand('codescene.monitorCodeLens.showForFunction', (functionInfo: DeltaFunctionInfo) => {
       codeLensProvider.showFor(functionInfo);
-      void vscode.commands.executeCommand('editor.action.goToLocations', uri, pos, [location]);
     }),
     vscode.commands.registerCommand('codescene.monitorCodeLens.dismiss', (documentUri: Uri) => {
       codeLensProvider.dismiss(documentUri);

--- a/src/code-health-monitor/tree-model.ts
+++ b/src/code-health-monitor/tree-model.ts
@@ -163,6 +163,12 @@ export class DeltaFunctionInfo implements DeltaTreeViewItem {
     item.iconPath = new vscode.ThemeIcon('symbol-function');
     item.description = this.isRefactoringSupported ? 'Auto-Refactor' : undefined;
     item.tooltip = this.tooltip();
+    item.command = {
+      command: 'codescene.codeHealthMonitor.showDeltaFunctionInfo',
+      title: 'Show details for function',
+      arguments: [this],
+    };
+
     return item;
   }
 


### PR DESCRIPTION
### Problem
When a function is selected in the code health monitor and shown in the details view, it's not properly updated even if the function presented has been improved/degraded in any way.

### Solution
Make sure that the content of the details view is updated regardless of the old tree-view selection.