### PR TITLE
chore: Add a file-icon along the filename in refactor and details view

### DIFF
--- a/src/code-health-monitor/details/view.ts
+++ b/src/code-health-monitor/details/view.ts
@@ -154,7 +154,7 @@ class CodeHealthDetailsView implements WebviewViewProvider, Disposable {
       <div class="block function-summary">
         <h2>${functionInfo.fnName}</h2>
         <div class="flex-row filename-and-smell">
-          <div class="flex-row">${fileName}</div> <!-- TODO seti file type theme icon ? -->
+          <div class="flex-row"><span class="codicon codicon-file"></span> ${fileName}</div>
           <div class="flex-row"><span class="codicon codicon-warning"></span> ${smellInfo}</div>
         </div>
       </div>

--- a/src/codescene-tab/webview/components.ts
+++ b/src/codescene-tab/webview/components.ts
@@ -50,7 +50,7 @@ export function functionLocationContent({
 
   return /*html*/ `
     <div id="function-location" class="flex-row">
-      <span class="file-name">${fileName}</span>
+      <span class="codicon codicon-file"></span><span class="file-name">${fileName}</span>
       ${fnNameHtml}
       <span class="line-no ${isStale ? 'strikeout' : ''}">[Ln ${position.line + 1}]</span>
     </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/84450fac-e8a6-4420-a6e6-0ecd8793076f)

Unfortunately there seems to be no way of tapping into the vscode icon-theme and presenting the same filename icon as is done in the native tree-views. See https://github.com/microsoft/vscode/issues/183893

Let's not try to hack around it by adding hard-coded icons or using haxx like this either https://stackoverflow.com/questions/66178468/vscode-api-how-to-get-icons-from-file-icon-theme