### PR TITLE
fix(language-support): Make sure review and refactoring DocumentMatchers are in sync with the analysis lib

### DIFF
--- a/src/language-support.ts
+++ b/src/language-support.ts
@@ -1,95 +1,62 @@
 import vscode from 'vscode';
-import { isDefined } from './utils';
 
-const extToLanguageId = new Map<string, string | string[]>([
-  ['js', 'javascript'],
-  ['mjs', 'javascript'],
-  ['sj', 'javascript'],
-
-  ['jsx', 'javascriptreact'],
-
-  ['ts', 'typescript'],
-  ['tsx', 'typescriptreact'],
-
-  ['brs', 'brightscript'],
-  ['bs', 'brighterscript'],
-
-  ['cls', 'apex'],
-  ['tgr', 'apex'],
-  ['trigger', 'apex'],
-
-  ['c', 'c'],
-
-  ['clj', 'clojure'],
-  ['cljc', 'clojure'],
-  ['cljs', 'clojure'],
-
-  ['cc', 'cpp'],
-  ['cpp', 'cpp'],
-  ['cxx', 'cpp'],
-  ['h', 'cpp'],
-  ['hh', 'cpp'],
-  ['hpp', 'cpp'],
-  ['hxx', 'cpp'],
-  ['ipp', 'cpp'],
-
-  ['m', 'objective-c'],
-  ['mm', ['objective-c', 'objective-cpp']],
-
-  ['cs', 'csharp'],
-  ['erl', 'erlang'],
-  ['go', 'go'],
-  ['groovy', 'groovy'],
-  ['java', 'java'],
-  ['kt', 'kotlin'],
-  ['php', 'php'],
-
-  ['pm', ['perl', 'perl6']],
-  ['pl', ['perl', 'perl6']],
-
-  ['ps1', 'powershell'],
-  ['psd1', 'powershell'],
-  ['psm1', 'powershell'],
-
-  ['py', 'python'],
-  ['rb', 'ruby'],
-  ['rs', 'rust'],
-  ['swift', 'swift'],
-  ['vb', 'vb'],
-  ['vue', 'vue'],
-
-  ['dart', 'dart'],
-  ['scala', 'scala'],
-]);
+const supportedExtensions = [
+  '.brs',
+  '.bs',
+  '.c',
+  '.cc',
+  '.clj',
+  '.cljc',
+  '.cljs',
+  '.cls',
+  '.cpp',
+  '.cs',
+  '.cxx',
+  '.dart',
+  '.efx',
+  '.emx',
+  '.erl',
+  '.ex',
+  '.exs',
+  '.go',
+  '.groovy',
+  '.h',
+  '.hh',
+  '.hpp',
+  '.hxx',
+  '.ipp',
+  '.java',
+  '.js',
+  '.jsx',
+  '.kt',
+  '.m',
+  '.mjs',
+  '.mm',
+  '.php',
+  '.pl',
+  '.pm',
+  '.ps1',
+  '.psd1',
+  '.psm1',
+  '.py',
+  '.pyi',
+  '.rb',
+  '.rs',
+  '.scala',
+  '.sj',
+  '.swift',
+  '.tcl',
+  '.tgr',
+  '.trigger',
+  '.ts',
+  '.tsx',
+  '.vb',
+  '.vue',
+];
 
 /**
  * @returns List of DocumentFilters for scheme 'file' for all cs supported languages
  */
 export function reviewDocumentSelector(): vscode.DocumentSelector {
-  const distinctLangIds = new Set<string>();
-  for (let langId of extToLanguageId.values()) {
-    if (Array.isArray(langId)) {
-      langId.forEach((id) => distinctLangIds.add(id));
-    } else {
-      distinctLangIds.add(langId);
-    }
-  }
-
-  return Array.from(distinctLangIds).map((langId) => ({ language: langId, scheme: 'file' }));
-}
-
-/**
- * Maps the preflight response file extensions* to langauge identifiers supported by vscode.
- * https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
- * *Extensions are from CodeScene's internal analysis library.
- *
- * This is used in determining what files to enable refactoring features for.
- */
-export function fileTypeToLanguageId(fileType: string) {
-  return extToLanguageId.get(fileType);
-}
-
-export function toDistinctLanguageIds(supportedFileTypes: string[]): string[] {
-  const definedLangIds = supportedFileTypes.flatMap(fileTypeToLanguageId).filter(isDefined);
-  return [...new Set(definedLangIds)];
+  return supportedExtensions.map((extInclDot) => ({ scheme: 'file', pattern: `**/*${extInclDot}` }));
 }

--- a/src/refactoring/addon.ts
+++ b/src/refactoring/addon.ts
@@ -3,7 +3,6 @@ import { AxiosError } from 'axios';
 import vscode from 'vscode';
 import { AceFeature } from '../cs-extension-state';
 import CsDiagnostics from '../diagnostics/cs-diagnostics';
-import { toDistinctLanguageIds } from '../language-support';
 import { logOutputChannel } from '../log';
 import { assertError, reportError } from '../utils';
 import { RefactoringAPI } from './api';
@@ -101,17 +100,3 @@ function disable() {
   stateEmitter.fire({ state: 'disabled' });
   logOutputChannel.info('ACE disabled!');
 }
-
-/**
- *
- * @param refactoringSupport
- * @returns A list of distinct DocumentSelectors for the supported file types
- */
-function toRefactoringDocumentSelector(supportedFileTypes: string[]): vscode.DocumentSelector {
-  return toDistinctLanguageIds(supportedFileTypes).map((language) => ({
-    language,
-    scheme: 'file',
-  }));
-}
-
-export { toRefactoringDocumentSelector }; // For test only


### PR DESCRIPTION
Instead of translating extensions supported by the analysis lib into vscode languageIds and checking against that - we're matching directly on an extension pattern (**/*.ext)
This keeps us from having mismatches with for example `.edn` files being detected as 'clojure' and sent for review.