### PR TITLE
fix: Score rounding issues

### DIFF
--- a/src/code-health-monitor/model.ts
+++ b/src/code-health-monitor/model.ts
@@ -1,6 +1,6 @@
 import { FnToRefactor } from '../refactoring/capabilities';
 import { Range } from '../review/model';
-import { roundScore } from '../review/utils';
+import { formatScore } from '../review/utils';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export interface DeltaForFile {
@@ -11,9 +11,9 @@ export interface DeltaForFile {
 }
 
 export function scorePresentation(delta: DeltaForFile) {
-  const oldScorePresentation = delta['old-score'] ? roundScore(delta['old-score']) : 'n/a';
-  const newScorePresentation = delta['new-score'] ? roundScore(delta['new-score']) : 'n/a';
-  if (oldScorePresentation === newScorePresentation) return oldScorePresentation;
+  if (delta['old-score'] === delta['new-score']) return formatScore(delta['old-score']);
+  const oldScorePresentation = delta['old-score'] || 'n/a';
+  const newScorePresentation = delta['new-score'] || 'n/a';
   return `${oldScorePresentation} → ${newScorePresentation}`;
 }
 

--- a/src/code-health-monitor/tree-model.ts
+++ b/src/code-health-monitor/tree-model.ts
@@ -1,8 +1,8 @@
 import vscode from 'vscode';
 import { issueToDocsParams } from '../documentation/commands';
 import { FnToRefactor } from '../refactoring/capabilities';
-import { roundScore, vscodeRange } from '../review/utils';
-import { isDefined, pluralize } from '../utils';
+import { vscodeRange } from '../review/utils';
+import { isDefined, pluralize, round } from '../utils';
 import { DeltaAnalysisState } from './analyser';
 import { ChangeDetail, DeltaForFile, FunctionInfo, isDegradation, isImprovement, scorePresentation } from './model';
 import { toFileWithIssuesUri } from './presentation';
@@ -75,7 +75,7 @@ export class FileWithIssues implements DeltaTreeViewItem {
     const { icon, tooltip } = iconAndTooltip();
     scoreInfo.tooltip = `${tooltip} ${exploreText}`;
     scoreInfo.iconPath = icon;
-    scoreInfo.description = `(${roundScore(this.scorePercentageChange)}%)`;
+    scoreInfo.description = `(${round(this.scorePercentageChange, 2)}%)`;
     return new DeltaInfoItem(scoreInfo);
   }
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -19,7 +19,7 @@ export class DownloadError extends Error {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const REQUIRED_DEVTOOLS_VERSION = 'da9e1735c9b3d3b7ff5334cb7b54b02ec1da86f5';
+const REQUIRED_DEVTOOLS_VERSION = '1985bd79a043d793d15c661e0140c38bcefe5bc5';
 
 const artifacts: { [platform: string]: { [arch: string]: string } } = {
   darwin: {

--- a/src/review/utils.ts
+++ b/src/review/utils.ts
@@ -53,11 +53,8 @@ export function reviewCodeSmellToDiagnostics(codeSmell: CodeSmell, document: vsc
   return diagnostic;
 }
 
-export function roundScore(score: number): number {
-  return +score.toFixed(2);
-}
 export function formatScore(score: number | void): string {
-  return score ? `${roundScore(score)}/10` : 'n/a';
+  return score ? `${score}/10` : 'n/a';
 }
 
 const detailSeparator = ' (';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import vscode, { Range } from 'vscode';
-import Telemetry from './telemetry';
 import { logOutputChannel } from './log';
 
 export function getFileExtension(filename: string) {
@@ -34,6 +33,10 @@ export function reportError(pre: string, error: Error) {
 
 export function pluralize(noun: string, count: number) {
   return Math.abs(count) <= 1 ? noun : `${noun}s`;
+}
+
+export function round(score: number, nDecimals: number): number {
+  return +score.toFixed(nDecimals);
 }
 
 let logoUrl: string | undefined;


### PR DESCRIPTION
No score (review or delta) should be rounded on the client - We should only use what's provided by the analysis api/binary. Bump in `download.ts` to use new binary with corrected presentation code.