### PR TITLE
chore(binary): Adapt to new devtools binary

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -19,7 +19,7 @@ export class DownloadError extends Error {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const REQUIRED_DEVTOOLS_VERSION = 'd118df84a89a5159ff29f8b98f20dd2d90c23150';
+const REQUIRED_DEVTOOLS_VERSION = '461af8a3a85e861a23d92e1cb6806fc97fc7d909';
 
 const artifacts: { [platform: string]: { [arch: string]: string } } = {
   darwin: {

--- a/src/refactoring/capabilities.ts
+++ b/src/refactoring/capabilities.ts
@@ -129,9 +129,9 @@ function targetsInRange(refactoringTargets: RefactoringTarget[], fnRange: Range)
 function rangeFromEnclosingFn(enclosingFn: EnclosingFn) {
   return new Range(
     enclosingFn['start-line'] - 1,
-    enclosingFn['start-column'],
+    enclosingFn['start-column'] - 1, // <- check this!
     enclosingFn['end-line'] - 1,
-    enclosingFn['end-column']
+    enclosingFn['end-column'] - 1
   );
 }
 

--- a/src/review/model.ts
+++ b/src/review/model.ts
@@ -4,7 +4,6 @@ export interface ReviewResult {
   score?: number;
   'file-level-code-smells': CodeSmell[];
   'function-level-code-smells': ReviewFunction[];
-  'expression-level-code-smells': CodeSmell[];
   'raw-score': string;
 }
 

--- a/src/review/utils.ts
+++ b/src/review/utils.ts
@@ -72,11 +72,6 @@ export function reviewResultToDiagnostics(reviewResult: ReviewResult, document: 
     diagnostics.push(...reviewFunctionToDiagnostics(fun, document));
   }
 
-  const expressionDiagnostics = reviewResult['expression-level-code-smells']
-    .map((cs) => reviewCodeSmellToDiagnostics(cs, document))
-    .filter(isDefined);
-  diagnostics.push(...expressionDiagnostics);
-
   const fileLevelDiagnostics = reviewResult['file-level-code-smells']
     .map((cs) => reviewCodeSmellToDiagnostics(cs, document))
     .filter(isDefined);

--- a/src/test/suite/refactoring-capabilities.test.ts
+++ b/src/test/suite/refactoring-capabilities.test.ts
@@ -84,8 +84,8 @@ const enclosingFn1: EnclosingFn = {
   'end-line': 1,
   body: 'const a = () => {};',
   'function-type': 'FatArrrowFn',
-  'start-column': 0,
-  'end-column': 19,
+  'start-column': 1,
+  'end-column': 20,
   'active-code-size': 1,
 };
 
@@ -95,8 +95,8 @@ const enclosingFn2: EnclosingFn = {
   'end-line': 101,
   body: 'function notSoGoodXX(\n  intersects,\n  endRel,\n  startRel,\n  endX,\n  endY,\n  minX,\n  minY,\n  maxX,\n  maxY,\n  slope\n) {\n  if (\n    !intersects &&\n    !!(endRel & Relationship.RIGHT) &&\n    !(startRel & Relationship.RIGHT)\n  ) {\n    // potentially intersects right\n    y = endY - (endX - maxX) * slope;\n    intersects = y >= minY && y <= maxY;\n  }\n\n  switch (param.type) {\n    case "Identifier":\n      nodes.push(param);\n      break;\n\n    case "ObjectPattern":\n      for (const prop of param.properties) {\n        if (prop.type === "RestElement") {\n          extract_identifiers(prop.argument, nodes);\n        } else {\n          extract_identifiers(prop.value, nodes);\n        }\n      }\n\n      break;\n\n    case "ArrayPattern":\n      for (const element of param.elements) {\n        if (element) extract_identifiers(element, nodes);\n      }\n\n      break;\n\n    case "RestElement":\n      extract_identifiers(param.argument, nodes);\n      break;\n\n    case "AssignmentPattern":\n      extract_identifiers(param.left, nodes);\n      break;\n  }\n}',
   'function-type': 'StandaloneFn',
-  'start-column': 0,
-  'end-column': 1,
+  'start-column': 1,
+  'end-column': 2,
   'active-code-size': 54,
 };
 

--- a/src/test/suite/review-utils.test.ts
+++ b/src/test/suite/review-utils.test.ts
@@ -69,8 +69,13 @@ suite('reviewIssueToDiagnostics', () => {
     const reviewResult: ReviewResult = {
       score: 9.81,
       'file-level-code-smells': [],
-      'function-level-code-smells': [],
-      'expression-level-code-smells': [expressionCodeSmell],
+      'function-level-code-smells': [
+        {
+          function: 'foo',
+          range: functionCodeSmellRange,
+          'code-smells': [expressionCodeSmell],
+        },
+      ],
       'raw-score': '',
     };
 
@@ -101,12 +106,11 @@ suite('reviewIssueToDiagnostics', () => {
     assert.strictEqual(diagnostics[1].severity, vscode.DiagnosticSeverity.Warning, 'Wrong severity');
   });
 
-  test('handles file, funcition and expression level code smells', async () => {
+  test('handles file and function level code smells', async () => {
     const reviewResult: ReviewResult = {
       score: 9.81,
       'file-level-code-smells': [fileCodeSmell],
       'function-level-code-smells': [functionCodeSmell],
-      'expression-level-code-smells': [expressionCodeSmell],
       'raw-score': '',
     };
     const document = await vscode.workspace.openTextDocument({
@@ -115,12 +119,12 @@ suite('reviewIssueToDiagnostics', () => {
                       d) {
                     return 1;
                   }
-                }`,
+                }`, 
       language: 'typescript',
     });
 
     const diagnostics = reviewResultToDiagnostics(reviewResult, document);
-    assert.strictEqual(diagnostics.length, 4);
+    assert.strictEqual(diagnostics.length, 3);
 
     for (const d of diagnostics) {
       let expectedRange;


### PR DESCRIPTION
* removes expression-level-code-smells (included as file-level instead)
* Use 1-indexed columns from the enclosingFn call