### PR TITLE
fix(code-health-monitor): No badge if >99 issues in code health monitor

### DIFF
--- a/src/code-health-monitor/presentation.ts
+++ b/src/code-health-monitor/presentation.ts
@@ -19,7 +19,7 @@ class FileWithIssuesDecorationProvider implements vscode.FileDecorationProvider 
       const badge = queryParams.get('issues');
       if (!badge || Number(badge) < 1) return;
       return {
-        badge,
+        badge: (Number(badge) > 99) ? "99" : badge,
         tooltip: `${badge} ${pluralize('issue', Number(badge))} can be improved`,
       };
     }


### PR DESCRIPTION
* Display 99 if number of issues is 100 and over