### PR TITLE
feature: CS-5487: Enable CLI review caches

### DIFF
--- a/src/devtools-api/review-cache.ts
+++ b/src/devtools-api/review-cache.ts
@@ -1,0 +1,41 @@
+
+import fs from 'fs';
+import path from 'path';
+import { ExtensionContext } from 'vscode';
+
+function deleteFilesOlderThan(days: number, folderPath: string) {
+  const now = new Date();
+  const files = fs.readdirSync(folderPath);
+  const daysInMilliseconds = days * 1000 * 60 * 60 * 24;
+  files.forEach((file) => {
+    const filePath = path.join(folderPath, file);
+    const stats = fs.statSync(filePath);
+    const fileAge = now.getMilliseconds() - stats.mtime.getMilliseconds();
+    if (fileAge >= daysInMilliseconds) {
+      fs.unlinkSync(filePath);
+    }
+  });
+}
+
+export class ReviewCache {
+  private cachePath: string | undefined;
+
+  constructor(context: ExtensionContext) {
+    const storagePath = context.storageUri?.fsPath; 
+    if (storagePath) {
+      const cachePath = path.join(storagePath, ".review-caches");
+      this.cachePath = cachePath; 
+      if (!fs.existsSync(cachePath)) {
+        fs.mkdirSync(cachePath, {recursive: true});
+      }
+      deleteFilesOlderThan(30, cachePath);
+    }
+    else {
+      this.cachePath = undefined;
+    }
+  }
+
+  getCachePath(): string | undefined {
+    return this.cachePath;
+  }
+}

--- a/src/download.ts
+++ b/src/download.ts
@@ -19,7 +19,7 @@ export class DownloadError extends Error {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const REQUIRED_DEVTOOLS_VERSION = '19d9f9c8fc08f36619709fa31cdca8b17de3a737';
+const REQUIRED_DEVTOOLS_VERSION = '2b500b540e0b17e20ff317aeae9486d83cddb6b4';
 
 const artifacts: { [platform: string]: { [arch: string]: string } } = {
   darwin: {


### PR DESCRIPTION
This PR enables CLI review caches by providing a `cache-path` in review calls. 
- cache files will be stored in `ExtensionContext.storageUri`
- cache files older than 30 days will be automatically deleted