### PR TITLE
fix: Update Code Health monitor reliably - cwf (CS-5420)

### DIFF
--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -23,7 +23,6 @@ import { StatsCollector } from '../stats';
 import { Delta } from './delta-model';
 import { addRefactorableFunctionsToDeltaResult, jsonForScores } from './delta-utils';
 import { TelemetryEvent, TelemetryResponse } from './telemetry-model';
-import { getBaselineCommit } from '../code-health-monitor/addon';
 import { ReviewCache } from './review-cache';
 import { MissingAuthTokenError } from '../missing-auth-token-error';
 
@@ -113,15 +112,15 @@ export class DevtoolsAPI {
     }
   }
 
-  static async reviewBaseline(document: vscode.TextDocument) {
+  static async reviewBaseline(baselineCommit: string, document: vscode.TextDocument) {
     const fp = fileParts(document);
+    const cachePath = DevtoolsAPI.reviewCache.getCachePath();
 
-    const commitHash = await getBaselineCommit(document.uri);
-    if (!commitHash) return;
-    const path = `${commitHash}:./${fp.fileName}`;
+    const path = `${baselineCommit}:./${fp.fileName}`;
 
     const binaryOpts = {
-      args: ['review', '--output-format', 'json', path],
+      args: ['review', '--output-format', 'json', path].concat(
+        cachePath ? ['--cache-path', cachePath] :[]),
       taskId: taskId('review-base', document),
       execOptions: { cwd: fp.documentDirectory },
     };

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -2,16 +2,17 @@ import vscode from 'vscode';
 import { GitExtension, Repository } from '../types/git';
 import { SimpleExecutor } from './executor';
 import { logOutputChannel } from './log';
-import Reviewer from './review/reviewer';
 
 const gitExecutor = new SimpleExecutor();
 const gitFileDeleteEvent = new vscode.EventEmitter<string>();
 export const onFileDeletedFromGit = gitFileDeleteEvent.event;
 
-export let repoState: {
+interface RepoState {
   branch: string | undefined;
   commit: string | undefined;
-};
+}
+
+let repoState: RepoState;
 
 export function acquireGitApi() {
   try {
@@ -76,18 +77,6 @@ export function isMainBranch(currentBranch: string | undefined) {
 }
 
 /**
- * Handles the deletion of a file from the repository.
- *
- * Removes the file's review data from the review cache
- * and fires a Git file delete event for consumers (Code Health Monitor tree).
- */
-export function handleFileDeletion(fileUri: string) {
-  Reviewer.instance.reviewCache.delete(fileUri);
-
-  gitFileDeleteEvent.fire(fileUri);
-}
-
-/**
  * Retrieves the latest commit hashes from the repository.
  */
 export async function getLatestCommits(repo: Repository, amount: number = 2) {
@@ -101,41 +90,23 @@ export async function getLatestCommits(repo: Repository, amount: number = 2) {
   }
 }
 
-interface ResetBaselineArgs {
-  prevRef: string;
-  headRef: string;
-  repo: Repository;
-}
-/**
- * Resets the baseline for files changed between two Git references, when baseline is set to HEAD.
- *
- * If a file was deleted (status 6), it triggers file deletion handling.
- * For all changed files, it resets their baseline in the review cache.
- */
-export async function resetBaselineForFilesChanged({ prevRef, headRef, repo }: ResetBaselineArgs) {
-  if (headRef && prevRef) {
-    const changes = await repo.diffBetween(prevRef, headRef);
-
-    changes.forEach((change) => {
-      if (change.status === 6) {
-        handleFileDeletion(change.uri.fsPath);
-      }
-      Reviewer.instance.reviewCache.resetBaseline(change.uri.fsPath);
-    });
-  }
+export interface GitStateChange {
+  commitChanged: boolean,
+  branchChanged: boolean
 }
 
-export function updateGitState(repo: Repository) {
+export function updateGitState(repo: Repository) : GitStateChange {
   const head = repo.state.HEAD;
-  if (!head) return;
-
-  const hasRepoChanged = repoState?.commit !== head.commit;
-  if (!hasRepoChanged) {
-    return;
-  }
+  if (!head) return {commitChanged: false, branchChanged: false};
+  
+  const gitStateChange: GitStateChange = {
+    commitChanged: repoState?.commit !== head.commit,
+    branchChanged: repoState?.branch !== head.name
+  };
 
   repoState = {
     commit: head.commit,
     branch: head.name,
   };
+  return gitStateChange;
 }

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -1,5 +1,6 @@
 import { dirname } from 'path';
-import vscode, { Disposable } from 'vscode';
+import vscode, { Disposable, Uri } from 'vscode';
+import { Repository } from '../../types/git';
 import { getConfiguration } from '../configuration';
 import { AbortError, DevtoolsAPI } from '../devtools-api';
 import { Delta } from '../devtools-api/delta-model';
@@ -9,11 +10,12 @@ import { SimpleExecutor } from '../executor';
 import { logOutputChannel } from '../log';
 import { formatScore, reviewResultToDiagnostics } from './utils';
 
+import * as path from 'path';
 export default class Reviewer {
   private static _instance: CachingReviewer;
 
-  static init(context: vscode.ExtensionContext): void {
-    Reviewer._instance = new CachingReviewer();
+  static init(context: vscode.ExtensionContext, getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>): void {
+    Reviewer._instance = new CachingReviewer(getBaselineCommit);
     context.subscriptions.push(Reviewer._instance);
     logOutputChannel.info('Code reviewer initialized');
   }
@@ -24,7 +26,7 @@ export default class Reviewer {
 }
 
 export interface ReviewOpts {
-  [key: string]: string | boolean;
+  [key: string]: string | string;
 }
 
 export class CsReview {
@@ -54,12 +56,12 @@ export class ReviewCacheItem {
 
   constructor(public document: vscode.TextDocument, public review: CsReview) {
     this.documentVersion = document.version;
-    this.resetBaseline();
   }
 
   setReview(document: vscode.TextDocument, review: CsReview) {
     this.review = review;
     this.documentVersion = document.version;
+    void this.runDeltaAnalysis();
   }
 
   /**
@@ -78,8 +80,9 @@ export class ReviewCacheItem {
     this.delta = await DevtoolsAPI.delta(this.document);
   }
 
-  resetBaseline() {
-    this.baselineScore = Reviewer.instance.baselineScore(this.document);
+  setBaseline(baselineCommit: string) {
+    logOutputChannel.trace(`ReviewCacheItem.setBaseline for ${path.basename(this.document.fileName)} to ${baselineCommit}`);
+    this.baselineScore = Reviewer.instance.baselineScore(baselineCommit, this.document);
     void this.runDeltaAnalysis();
   }
 }
@@ -89,6 +92,9 @@ export class ReviewCacheItem {
  */
 class ReviewCache {
   private _cache = new Map<string, ReviewCacheItem>();
+
+  constructor(private getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>) {
+  }
 
   /**
    * Get the current review for this document given the document.version matches the review item version.
@@ -106,7 +112,7 @@ class ReviewCache {
       void item.runDeltaAnalysis();
     });
   }
-
+  
   /**
    * Get review cache item. (note that fileName is same as uri.fsPath)
    */
@@ -114,8 +120,24 @@ class ReviewCache {
     return this._cache.get(document.fileName);
   }
 
-  add(document: vscode.TextDocument, review: CsReview) {
-    this._cache.set(document.fileName, new ReviewCacheItem(document, review));
+  async add(document: vscode.TextDocument, review: CsReview) {
+    const item = new ReviewCacheItem(document, review);
+    this._cache.set(document.fileName, item);
+    logOutputChannel.trace(`ReviewCache.add: ${path.basename(document.fileName)}`);
+    const baselineCommit = await this.getBaselineCommit(document.uri);
+    if (baselineCommit) {
+      item.setBaseline(baselineCommit);
+    }
+  }
+  
+  update(document: vscode.TextDocument, review: CsReview) {
+    const reviewItem = this.get(document);
+    if (!reviewItem) return false;
+
+    logOutputChannel.trace(`ReviewCache.update: ${path.basename(document.fileName)}`);
+    reviewItem.setReview(document, review);
+    void reviewItem.runDeltaAnalysis();
+    return true;
   }
 
   delete(fsPath: string) {
@@ -130,8 +152,15 @@ class ReviewCache {
     this._cache.clear();
   }
 
-  resetBaseline(fsPath: string) {
-    this._cache.get(fsPath)?.resetBaseline();
+  setBaseline(fileFilter: (fileUri: Uri) => boolean) {
+    this._cache.forEach(async (item) => {
+      if (fileFilter(item.document.uri)) {
+        const baselineCommit = await this.getBaselineCommit(item.document.uri);
+        if (baselineCommit) {
+          void item.setBaseline(baselineCommit);
+        }
+      }
+    });
   }
 }
 
@@ -139,9 +168,10 @@ class CachingReviewer implements Disposable {
   private reviewer = new FilteringReviewer();
 
   private disposables: vscode.Disposable[] = [];
-  readonly reviewCache = new ReviewCache();
+  readonly reviewCache: ReviewCache;
 
-  constructor() {
+  constructor(getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>) {
+    this.reviewCache = new ReviewCache(getBaselineCommit);
     const deleteFileWatcher = vscode.workspace.createFileSystemWatcher('**/*', true, true, false);
     this.disposables.push(
       deleteFileWatcher,
@@ -165,33 +195,35 @@ class CachingReviewer implements Disposable {
     if (!reviewOpts.skipCache) {
       // If we have a cached CsReview for this document/version combination, return it.
       const reviewCacheItem = this.reviewCache.getExactVersion(document);
-      if (reviewCacheItem) return reviewCacheItem.review;
+      if (reviewCacheItem) {
+        return reviewCacheItem.review;
+      }
     }
 
     const reviewPromise = this.reviewer
       .review(document, reviewOpts)
       .then((reviewResult) => {
         // Clear cache of void reviews (ignored files probably)
-        if (!reviewResult) this.reviewCache.delete(document.uri.fsPath);
+        if (!reviewResult) {
+          this.reviewCache.delete(document.uri.fsPath);
+        }
         return reviewResult;
       })
       .catch((e) => this.handleReviewError(e, document));
 
     const csReview = new CsReview(document, reviewPromise);
 
-    this.setOrUpdate(document, csReview);
+    this.updateOrAdd(document, csReview);
 
     return csReview;
   }
-
+  
   refreshDeltas() {
     this.reviewCache.refreshDeltas();
   }
-
-  refreshAllDeltasAndBaselines() {
-    for (const [key, item] of this.reviewCache['_cache'].entries()) {
-      item.resetBaseline();
-    }
+  
+  setBaseline(fileFilter: (fileUri: Uri) => boolean) {
+    this.reviewCache.setBaseline(fileFilter);
   }
 
   /**
@@ -199,9 +231,9 @@ class CachingReviewer implements Disposable {
    * @param document
    * @returns
    */
-  async baselineScore(document: vscode.TextDocument) {
+  async baselineScore(baselineCommit: string, document: vscode.TextDocument) {
     return this.reviewer
-      .review(document, { baseline: true })
+      .review(document, { baseline: baselineCommit })
       .then((reviewResult) => {
         return reviewResult && reviewResult['raw-score'];
       })
@@ -213,17 +245,14 @@ class CachingReviewer implements Disposable {
    * @param document
    * @param review
    */
-  setOrUpdate(document: vscode.TextDocument, review: CsReview) {
-    const reviewItem = this.reviewCache.get(document);
-    if (reviewItem) {
-      reviewItem.setReview(document, review);
-      void reviewItem.runDeltaAnalysis();
-    } else {
+  updateOrAdd(document: vscode.TextDocument, review: CsReview) {
+    if (!this.reviewCache.update(document, review)) {
       this.reviewCache.add(document, review);
     }
   }
 
   abort(document: vscode.TextDocument): void {
+    this.reviewCache.delete(document.uri.fsPath);
     this.reviewer.abort(document);
   }
 
@@ -294,7 +323,7 @@ class FilteringReviewer {
     }
 
     if (reviewOpts.baseline) {
-      return DevtoolsAPI.reviewBaseline(document);
+      return DevtoolsAPI.reviewBaseline(reviewOpts.baseline, document);
     } else {
       return DevtoolsAPI.reviewContent(document);
     }


### PR DESCRIPTION
This PR makes the Code Health monitor update more reliably when files or baseline changes.
Some fixes:
- make baseline updates in `onRepoStateChange` work on both branch and head commit changes. Will now update the baseline for all reviewed files in that repo 
- ensure delta does not run if there's no baseline set
- make the reviewTimer in `onDidChangeTextDocument` be per file, so review will be triggered for all files when multiple files change simultaneously on disk