### PR TITLE
fix: don't skip cache when retrying a failed refactoring

### DIFF
--- a/src/codescene-tab/webview/ace/cwf-webview-ace-panel.ts
+++ b/src/codescene-tab/webview/ace/cwf-webview-ace-panel.ts
@@ -120,7 +120,10 @@ export class CodeSceneCWFAceTabPanel implements Disposable {
           request.document,
           'retry',
           request.fnToRefactor,
-          true
+          // Having true here means skipping cache, meaning retry to get another refactoring 
+          // if the first one is not what you want...
+          // But this seem to be used to retry when failed and we definitely don't want to skip cache then
+          false //true
         );
       },
       showDiff: () => {


### PR DESCRIPTION
[CS-5561](https://app.clickup.com/t/9015696197/CS-5561)