### PR TITLE
chore: add auto refactor back to docs

### DIFF
--- a/src/codescene-tab/webview/documentation/docs-data-mapper.ts
+++ b/src/codescene-tab/webview/documentation/docs-data-mapper.ts
@@ -1,10 +1,20 @@
+import vscode from 'vscode';
 import { devmode } from '../../../centralized-webview-framework/cwf-html-utils';
 import { FileMetaType, DocsContextViewProps } from '../../../centralized-webview-framework/types';
+import { CodeSmell } from '../../../devtools-api/review-model';
 import { InteractiveDocsParams } from '../../../documentation/commands';
+import { findFnToRefactor } from '../../../refactoring/utils';
+import { getAutoRefactorConfig } from '../ace/acknowledgement/ace-acknowledgement-mapper';
 import { getCWFDocType } from './utils';
+import { CodeSceneTabPanelState } from './cwf-webview-docs-panel';
 
-export function getDocsData(docType: string, fileData: FileMetaType | undefined): DocsContextViewProps {
-  const docTypeCwf = getCWFDocType(docType);
+export async function getDocsData(state: CodeSceneTabPanelState): Promise<DocsContextViewProps> {
+  const { document, issueInfo, codeSmell, fnToRefactor, fileData } = state;
+  const docTypeCwf = getCWFDocType(issueInfo.category);
+
+  const config = getAutoRefactorConfig();
+  const toRefactor = fnToRefactor ?? (await findFnToRefactor(document, codeSmell));
+
   return {
     ideType: 'VSCode',
     view: 'docs',
@@ -12,6 +22,7 @@ export function getDocsData(docType: string, fileData: FileMetaType | undefined)
     data: {
       docType: docTypeCwf,
       fileData,
+      autoRefactor: { ...config, disabled: config.disabled || !toRefactor },
     },
   };
 }

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -321,7 +321,9 @@ export class DevtoolsAPI {
       const args = DevtoolsAPI.buildRefactoringArgs(fnToRefactor, skipCache, token);
 
       logOutputChannel.info(
-        `Refactor requested for ${logIdString(fnToRefactor)}${skipCache === true ? ' (retry)' : ''}`
+        `Refactor requested for ${logIdString(fnToRefactor)}${
+          skipCache === true ? ' (retry)' : ''
+        }, with refactoring targets: [${fnToRefactor['refactoring-targets'].map((t) => t.category).join(', ')}]`
       );
       const response = await DevtoolsAPI.instance.executeAsJson<RefactorResponse>({
         args,

--- a/src/documentation/commands.ts
+++ b/src/documentation/commands.ts
@@ -3,6 +3,7 @@ import { DeltaFunctionInfo, DeltaIssue } from '../code-health-monitor/tree-model
 import { FnToRefactor } from '../devtools-api/refactor-models';
 import Telemetry from '../telemetry';
 import { CodeSceneCWFDocsTabPanel } from '../codescene-tab/webview/documentation/cwf-webview-docs-panel';
+import { CodeSmell } from '../devtools-api/review-model';
 
 export function register(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -15,11 +16,12 @@ export function register(context: vscode.ExtensionContext) {
     ),
     // A query param friendly version of openInteractiveDocsPanel
     vscode.commands.registerCommand('codescene.openInteractiveDocsFromDiagnosticTarget', async (queryParams) => {
-      const { category, lineNo, charNo, documentUri } = queryParams;
+      const { category, lineNo, charNo, documentUri, codeSmell } = queryParams;
       Telemetry.logUsage('openInteractiveDocsPanel', { source: 'diagnostic-item', category });
       const params: InteractiveDocsParams = {
         issueInfo: { category, position: new vscode.Position(lineNo, charNo) },
         document: await findOrOpenDocument(documentUri),
+        codeSmell,
       };
       CodeSceneCWFDocsTabPanel.show(params);
     }),
@@ -53,6 +55,7 @@ export interface InteractiveDocsParams {
   issueInfo: IssueInfo;
   document?: vscode.TextDocument;
   fnToRefactor?: FnToRefactor;
+  codeSmell?: CodeSmell;
 }
 
 export function isInteractiveDocsParams(obj: unknown): obj is InteractiveDocsParams {

--- a/src/refactoring/utils.ts
+++ b/src/refactoring/utils.ts
@@ -11,6 +11,8 @@ import vscode, {
 import { FnToRefactor, RefactorResponse } from '../devtools-api/refactor-models';
 import { isDefined } from '../utils';
 import { RefactoringRequest } from './request';
+import { DevtoolsAPI } from '../devtools-api';
+import { CodeSmell } from '../devtools-api/review-model';
 
 function singleLineCommentSeparator(languageId: string) {
   switch (languageId) {
@@ -154,4 +156,11 @@ export function isFunctionUnchangedInDocument(
     return { shouldUpdateRange: true, isStale: false };
   }
   return { shouldUpdateRange: false, isStale: true };
+}
+
+export async function findFnToRefactor(document: vscode.TextDocument | undefined, codeSmell: CodeSmell | undefined) {
+  if (document && codeSmell) {
+    const fn = await DevtoolsAPI.fnsToRefactorFromCodeSmell(document, codeSmell);
+    return fn;
+  }
 }

--- a/src/review/utils.ts
+++ b/src/review/utils.ts
@@ -32,7 +32,7 @@ export function reviewCodeSmellToDiagnostics(codeSmell: CodeSmell, document: vsc
   }
   const diagnostic = new CsDiagnostic(range, message, vscode.DiagnosticSeverity.Warning, codeSmell);
   diagnostic.source = csSource;
-  diagnostic.code = createDiagnosticCodeWithTarget(category, range.start, document);
+  diagnostic.code = createDiagnosticCodeWithTarget(category, range.start, document, codeSmell);
   return diagnostic;
 }
 
@@ -77,8 +77,13 @@ export function getCsDiagnosticCode(code?: string | number | { value: string | n
  * @param category
  * @returns
  */
-function createDiagnosticCodeWithTarget(category: string, position: vscode.Position, document: vscode.TextDocument) {
-  const args = [{ category, lineNo: position.line, charNo: position.character, documentUri: document.uri }];
+function createDiagnosticCodeWithTarget(
+  category: string,
+  position: vscode.Position,
+  document: vscode.TextDocument,
+  codeSmell: CodeSmell
+) {
+  const args = [{ category, lineNo: position.line, charNo: position.character, documentUri: document.uri, codeSmell }];
   const openDocCommandUri = vscode.Uri.parse(
     `command:codescene.openInteractiveDocsFromDiagnosticTarget?${encodeURIComponent(JSON.stringify(args))}`
   );


### PR DESCRIPTION
### PR Overview

- The auto-refactoring button is now visible again in the CWF documentation view.
- The button is disabled if an auth token is missing or if the selected code smell cannot be refactored.
- When documentation is opened from a specific lens or diagnostic item (for example, a “Complex Conditional” entry in the Problems tab or an underline for a single code smell), only that code smell is used as the refactoring target. If it’s opened from an underline quick action that includes multiple code smells, all of them become refactoring targets.
- Added logging for refactoring targets in the refactoring initiation info message.

**Known Limitation**

In some cases, depending on the currently focused document (file), triggering a refactoring may cause the docs view to split again, even though it’s already displayed as a split view of the actual file. This behavior will be investigated further in a separate ticket.