### PR TITLE
feature: observe files open by the user

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -40,7 +40,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Review all changed/added files once when repository state is ready
   const gitChangeLister = new GitChangeLister(gitApi, DevtoolsAPI.concurrencyLimitingExecutor);
-  gitChangeLister.setupInitialReview(context);
+  gitChangeLister.start(context);
 
   context.subscriptions.push(
     codeHealthMonitorView,

--- a/src/code-health-monitor/tree-view.ts
+++ b/src/code-health-monitor/tree-view.ts
@@ -1,5 +1,5 @@
 import vscode from 'vscode';
-import { DevtoolsAPI } from '../devtools-api';
+import { DevtoolsAPI, DeltaAnalysisEvent } from '../devtools-api';
 import { logOutputChannel } from '../log';
 import Telemetry from '../telemetry';
 import { isDefined, pluralize, showDocAtPosition } from '../utils';
@@ -37,7 +37,11 @@ export class CodeHealthMonitorView implements vscode.Disposable {
       vscode.commands.registerCommand('codescene.codeHealthMonitorSelectBaseline', async () => {
         void this.treeDataProvider.selectBaseline();
       }),
-      DevtoolsAPI.onDidDeltaAnalysisComplete((e) => this.treeDataProvider.syncTree(e)),
+      DevtoolsAPI.onDidDeltaAnalysisComplete((e: DeltaAnalysisEvent) => {
+        if (e.updateMonitor) {
+          this.treeDataProvider.syncTree(e);
+        }
+      }),
       onFileDeletedFromGit((e) => {
         this.treeDataProvider.removeTreeEntry(e);
       }),

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -162,11 +162,12 @@ export class DevtoolsAPI {
    * Runs delta analysis and returns the result. Also fires onDidDeltaAnalysisComplete when analysis is complete.
    *
    * @param document
+   * @param updateMonitor whether to update the Code Health Monitor tree view
    * @param oldScore raw base64 encoded score
    * @param newScore raw base64 encoded score
    * @returns Delta if any changes were detected or undefined when no improvements/degradations were found.
    */
-  static async delta(document: TextDocument, oldScore?: string | void, newScore?: string | void) {
+  static async delta(document: TextDocument, updateMonitor: boolean, oldScore?: string | void, newScore?: string | void) {
     const inputJsonString = jsonForScores(oldScore, newScore);
     if (!inputJsonString) {
       logOutputChannel.debug(`Delta analysis skipped for ${basename(document.fileName)}: no input scores`);
@@ -191,7 +192,7 @@ export class DevtoolsAPI {
       } else {
         logOutputChannel.debug(`Delta analysis completed for ${basename(document.fileName)}: no changes detected`);
       }
-      DevtoolsAPI.deltaAnalysisEmitter.fire({ document, result: deltaResult });
+      DevtoolsAPI.deltaAnalysisEmitter.fire({ document, result: deltaResult, updateMonitor });
       return deltaResult;
     } catch (e) {
       const error = assertError(e);
@@ -485,4 +486,5 @@ export type ReviewEvent = {
 export type DeltaAnalysisEvent = {
   document: vscode.TextDocument;
   result?: Delta;
+  updateMonitor: boolean; // Please set this to false if triggering reviews due to opening files, and to true if triggering reviews due to Git changes.
 };

--- a/src/diagnostics/cs-diagnostics.ts
+++ b/src/diagnostics/cs-diagnostics.ts
@@ -24,7 +24,7 @@ export default class CsDiagnostics {
     CsDiagnostics.collection.set(uri, diagnostics);
   }
 
-  static review(document: vscode.TextDocument, reviewOpts?: ReviewOpts) {
+  static review(document: vscode.TextDocument, reviewOpts: ReviewOpts) {
     if (vscode.languages.match(CsDiagnostics.documentSelector, document) === 0) {
       return;
     }

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -18,7 +18,7 @@ export class GitChangeLister {
     this.executor = executor;
   }
 
-  setupInitialReview(context: vscode.ExtensionContext): void {
+  start(context: vscode.ExtensionContext): void {
     if (this.gitApi.repositories.length === 0) {
       logOutputChannel.error('Code Health Monitor: No repositories found for initial review');
       return;
@@ -74,7 +74,7 @@ export class GitChangeLister {
         void this.executor.executeTask(async () => {
           try {
             const document = await vscode.workspace.openTextDocument(filePath);
-            CsDiagnostics.review(document);
+            CsDiagnostics.review(document, { skipMonitorUpdate: false });
           } catch (error) {
             logOutputChannel.error(`Could not review ${filePath}: ${error}`);
           }

--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -69,7 +69,7 @@ export class CsRefactoringCommands implements vscode.Disposable {
 
       // Immediately trigger a re-review of the new file-content
       // This is important, since otherwise the review is controlled by the debounced review done in the onDidChangeTextDocument (extension.ts)
-      CsDiagnostics.review(document);
+      CsDiagnostics.review(document, { skipMonitorUpdate: false });
       Telemetry.logUsage('refactor/applied', refactoring.eventData);
     });
   }

--- a/src/review/caching-reviewer.ts
+++ b/src/review/caching-reviewer.ts
@@ -33,7 +33,7 @@ export class CachingReviewer implements Disposable {
     }
   }
 
-  review(document: vscode.TextDocument, reviewOpts: ReviewOpts = {}): CsReview {
+  review(document: vscode.TextDocument, reviewOpts: ReviewOpts): CsReview {
     if (!reviewOpts.skipCache) {
       // If we have a cached CsReview for this document/version combination, return it.
       const reviewCacheItem = this.reviewCache.getExactVersion(document);
@@ -55,7 +55,7 @@ export class CachingReviewer implements Disposable {
 
     const csReview = new CsReview(document, reviewPromise);
 
-    this.updateOrAdd(document, csReview);
+    this.updateOrAdd(document, csReview, reviewOpts.skipMonitorUpdate);
 
     return csReview;
   }
@@ -73,9 +73,9 @@ export class CachingReviewer implements Disposable {
    * @param document
    * @returns
    */
-  async baselineScore(baselineCommit: string, document: vscode.TextDocument) {
+  async baselineScore(baselineCommit: string, document: vscode.TextDocument, skipMonitorUpdate: boolean) {
     return this.reviewer
-      .review(document, { baseline: baselineCommit })
+      .review(document, { baseline: baselineCommit, skipMonitorUpdate })
       .then((reviewResult) => {
         return reviewResult && reviewResult['raw-score'];
       })
@@ -86,10 +86,11 @@ export class CachingReviewer implements Disposable {
    * Store the diagnostics promise in the cache, or update it with the
    * @param document
    * @param review
+   * @param skipMonitorUpdate
    */
-  updateOrAdd(document: vscode.TextDocument, review: CsReview) {
-    if (!this.reviewCache.update(document, review)) {
-      void this.reviewCache.add(document, review);
+  updateOrAdd(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean) {
+    if (!this.reviewCache.update(document, review, skipMonitorUpdate)) {
+      void this.reviewCache.add(document, review, skipMonitorUpdate);
     }
   }
 

--- a/src/review/filtering-reviewer.ts
+++ b/src/review/filtering-reviewer.ts
@@ -56,7 +56,7 @@ export class FilteringReviewer {
     return ignored;
   }
 
-  async review(document: vscode.TextDocument, reviewOpts: ReviewOpts = {}): Promise<Review | void> {
+  async review(document: vscode.TextDocument, reviewOpts: ReviewOpts): Promise<Review | void> {
     const ignored = await this.isIgnored(document);
 
     if (ignored) {

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -1,0 +1,64 @@
+import vscode from 'vscode';
+import { reviewDocumentSelector } from '../language-support';
+import CsDiagnostics from '../diagnostics/cs-diagnostics';
+import Reviewer from './reviewer';
+
+/**
+ * Observes open file events and triggers reviews accordingly.
+ */
+export class OpenFilesObserver {
+  private reviewTimers = new Map<string, NodeJS.Timeout>();
+  private context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
+  start(): void {
+    // This provides the initial diagnostics when a file is opened.
+    this.context.subscriptions.push(
+      vscode.workspace.onDidOpenTextDocument((document: vscode.TextDocument) => {
+        CsDiagnostics.review(document, { skipMonitorUpdate: true });
+      })
+    );
+
+    // Close document listener for cancelling reviews and refactoring requests
+    this.context.subscriptions.push(
+      vscode.workspace.onDidCloseTextDocument((document: vscode.TextDocument) => {
+        Reviewer.instance.abort(document);
+      })
+    );
+
+    const docSelector = reviewDocumentSelector();
+
+    // This provides the diagnostics when a file is edited.
+    this.context.subscriptions.push(
+      vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
+        // avoid reviewing non-matching documents
+        if (vscode.languages.match(docSelector, e.document) === 0) {
+          return;
+        }
+        const filePath = e.document.fileName;
+        clearTimeout(this.reviewTimers.get(filePath));
+        // Run review after 1 second of no edits to this file
+        this.reviewTimers.set(
+          filePath,
+          setTimeout(() => {
+            CsDiagnostics.review(e.document, { skipMonitorUpdate: true });
+          }, 1000)
+        );
+      })
+    );
+
+    // This provides the initial diagnostics when the extension is first activated.
+    vscode.workspace.textDocuments.forEach((document: vscode.TextDocument) => {
+      CsDiagnostics.review(document, { skipMonitorUpdate: true });
+    });
+  }
+
+  dispose(): void {
+    // Clear all pending timers
+    this.reviewTimers.forEach((timer) => clearTimeout(timer));
+    this.reviewTimers.clear();
+  }
+}

--- a/src/review/review-cache.ts
+++ b/src/review/review-cache.ts
@@ -22,7 +22,7 @@ export class ReviewCache {
 
   refreshDeltas() {
     this._cache.forEach((item) => {
-      void item.runDeltaAnalysis();
+      void item.runDeltaAnalysis({ skipMonitorUpdate: false });
     });
   }
 
@@ -33,23 +33,23 @@ export class ReviewCache {
     return this._cache.get(document.fileName);
   }
 
-  async add(document: vscode.TextDocument, review: CsReview) {
+  async add(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean) {
     const item = new ReviewCacheItem(document, review);
     this._cache.set(document.fileName, item);
     logOutputChannel.trace(`ReviewCache.add: ${path.basename(document.fileName)}`);
     const baselineCommit = await this.getBaselineCommit(document.uri);
     if (baselineCommit) {
-      item.setBaseline(baselineCommit);
+      item.setBaseline(baselineCommit, skipMonitorUpdate);
     }
   }
 
-  update(document: vscode.TextDocument, review: CsReview) {
+  update(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean) {
     const reviewItem = this.get(document);
     if (!reviewItem) return false;
 
     logOutputChannel.trace(`ReviewCache.update: ${path.basename(document.fileName)}`);
-    reviewItem.setReview(document, review);
-    void reviewItem.runDeltaAnalysis();
+    reviewItem.setReview(document, review, skipMonitorUpdate);
+    void reviewItem.runDeltaAnalysis({ skipMonitorUpdate });
     return true;
   }
 
@@ -70,7 +70,7 @@ export class ReviewCache {
       if (fileFilter(item.document.uri)) {
         const baselineCommit = await this.getBaselineCommit(item.document.uri);
         if (baselineCommit) {
-          void item.setBaseline(baselineCommit);
+          void item.setBaseline(baselineCommit, false);
         }
       }
     });

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -20,5 +20,8 @@ export default class Reviewer {
 }
 
 export interface ReviewOpts {
-  [key: string]: string | string;
+  skipCache?: string;
+  baseline?: string;
+  skipMonitorUpdate: boolean; // Please set this to false if triggering reviews due to opening files, and to true if triggering reviews due to Git changes.
+  [key: string]: string | boolean | undefined;
 }


### PR DESCRIPTION
In addition to files open via the filesystem (i.e. Git events/parsing), we now also observe files as opened by the user (i.e. VS Code UI).

This restores this code: https://github.com/codescene-oss/codescene-vscode/blob/4f547b892eec7d42bae5488563627e36b2b1d060/src/extension.ts#L147-L185

With the difference that:

* It's now encapsulated into a class
* Reviews triggered in this fashion don't end up in the CHM.