### PR TITLE
feat: restore SingleTaskExecutor for `refactor` tasks

### DIFF
--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -5,6 +5,7 @@ import {
   FnToRefactor,
   PreFlightResponse,
   RefactorResponse,
+  REFACTOR_TASK_ID,
 } from './refactor-models';
 
 import { basename, dirname } from 'path';
@@ -350,7 +351,7 @@ skipCache === true ? ' (retry)' : ''
       const response = await DevtoolsAPI.instance.executeAsJson<RefactorResponse>({
         args,
         execOptions: { signal },
-        taskId: 'refactor', // Limit to only 1 refactoring at a time
+        taskId: REFACTOR_TASK_ID, // Limit to only 1 refactoring at a time
       });
       logOutputChannel.info(
         `Refactor request done ${logIdString(fnToRefactor, response['trace-id'])}${

--- a/src/devtools-api/refactor-models.ts
+++ b/src/devtools-api/refactor-models.ts
@@ -2,6 +2,9 @@
 import { Range as VscodeRange } from 'vscode';
 import { Range } from '../devtools-api/review-model';
 
+export const REFACTOR_TASK_ID = 'refactor';
+export const SINGLE_EXECUTOR_TASK_IDS = [REFACTOR_TASK_ID];
+
 export interface CreditsInfoError {
   'credits-info': CreditsInfo;
   /**


### PR DESCRIPTION
Generally, the SingleTaskExecutor isn't of much use anymore given that parallelism and caching make less desirable to limit executions.

But for refactoring , limiting execution at one task at a time makes sense.