### PR TITLE
fix: parse stdout on known error codes (and bump cli to corresponding version)

### DIFF
--- a/src/artifact-info.ts
+++ b/src/artifact-info.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const REQUIRED_DEVTOOLS_VERSION = '51b8a5fca83792d9335274a1c07a0c575f2dbe3a';
+export const REQUIRED_DEVTOOLS_VERSION = 'f36e0be8d3520c077b74ca562571b7958e01f527';
 
 export const artifacts: { [platform: string]: { [arch: string]: string } } = {
   darwin: {

--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -92,11 +92,11 @@ export class DevtoolsAPIImpl {
   private handleNonZeroExitCodes(args: string[], { exitCode, stdout, stderr }: ExecResult): never {
     switch (exitCode) {
       case 10: // exit code for DevtoolsErrorModel
-        const devtoolsError = safeJsonParse(stderr) as DevtoolsErrorModel;
+        const devtoolsError = safeJsonParse(stdout) as DevtoolsErrorModel;
         logOutputChannel.debug(`devtools exit(${exitCode}) '${args.join(' ')}': ${devtoolsError.message}`);
         throw new DevtoolsError(devtoolsError);
       case 11: // exit code for CreditInfoError
-        const creditsInfoError = safeJsonParse(stderr) as CreditsInfoErrorModel;
+        const creditsInfoError = safeJsonParse(stdout) as CreditsInfoErrorModel;
         logOutputChannel.debug(`devtools exit(${exitCode}) '${args.join(' ')}': ${creditsInfoError.message}`);
         throw new CreditsInfoError(
           creditsInfoError.message,


### PR DESCRIPTION
This PR updates to a version of the CLI that prints the formatted json error responses to stdout just like all other json responses. This is done to avoid seeing unrelated warning logs from JVM that are printed to stderr (and make json parsing fail)