### PR TITLE
feat: cache most `fns-to-refactor` calls

### DIFF
--- a/src/codescene-tab/webview-panel.ts
+++ b/src/codescene-tab/webview-panel.ts
@@ -1,6 +1,7 @@
 import vscode, { Disposable, ViewColumn, WebviewPanel } from 'vscode';
 import { CsExtensionState } from '../cs-extension-state';
 import { DevtoolsAPI } from '../devtools-api';
+import { fnsToRefactorCache } from '../devtools-api/fns-to-refactor-cache';
 import { FnToRefactor } from '../devtools-api/refactor-models';
 import { CodeSmell } from '../devtools-api/review-model';
 import { InteractiveDocsParams, isInteractiveDocsParams } from '../documentation/commands';
@@ -403,7 +404,7 @@ export class CodeSceneTabPanel implements Disposable {
           'end-column': -1,
         },
       };
-      if (document) return await DevtoolsAPI.fnsToRefactorFromCodeSmell(document, codeSmell);
+      if (document) return await fnsToRefactorCache.fnsToRefactor(document, codeSmell);
     }
   }
 

--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -56,6 +56,7 @@ export class DevtoolsAPIImpl {
         taskId,
         ignoreError: true,
       };
+      logOutputChannel.info("Running task: " + JSON.stringify(task));
       // singleTaskExecutor used to be more broadly used, but now with parallelism and caching, it's better to favor concurrencyLimitingExecutor except for the
       // `refactor` operation (or any other member of SINGLE_EXECUTOR_TASK_IDS) since it represents work that is potentially costly, backend-side.
       if (SINGLE_EXECUTOR_TASK_IDS.includes(taskId)) {
@@ -69,6 +70,7 @@ export class DevtoolsAPIImpl {
         args,
         ignoreError: true,
       };
+      logOutputChannel.info("Running command: " + JSON.stringify(command));
       result = await this.simpleExecutor.execute(command, execOptions, input);
     }
 

--- a/src/devtools-api/fns-to-refactor-cache.ts
+++ b/src/devtools-api/fns-to-refactor-cache.ts
@@ -1,0 +1,86 @@
+import vscode from 'vscode';
+import { FnToRefactor } from './refactor-models';
+import { CodeSmell } from './review-model';
+import { DevtoolsAPI } from '.';
+import { logOutputChannel } from '../log';
+import { basename } from 'path';
+
+/**
+ * Shared cache for fnsToRefactor results to avoid redundant binary calls.
+ * Key format: <uri>:v<version>:<line>:<character>:<category>
+ */
+class FnsToRefactorCache {
+  private cache = new Map<string, FnToRefactor | undefined>();
+
+  // Kept private in order to enforce use of the caching layer.
+  private async fnsToRefactorFromCodeSmell(
+    document: vscode.TextDocument,
+    codeSmell: CodeSmell
+  ): Promise<FnToRefactor | undefined> {
+    const result = await (DevtoolsAPI as any).fnsToRefactor(document, ['--code-smells', JSON.stringify([codeSmell])]);
+    return result?.[0];
+  }
+
+  private buildCacheKey(document: vscode.TextDocument, codeSmell: CodeSmell): string {
+    const line = codeSmell['highlight-range']['start-line'];
+    const character = codeSmell['highlight-range']['start-column'];
+    return `${document.uri.toString()}:v${document.version}:${line}:${character}:${codeSmell.category}`;
+  }
+
+  async fnsToRefactor(document: vscode.TextDocument, codeSmell: CodeSmell): Promise<FnToRefactor | undefined> {
+    const cacheKey = this.buildCacheKey(document, codeSmell);
+
+    const cached = this.cache.get(cacheKey);
+    if (this.cache.has(cacheKey)) {
+      return cached;
+    }
+
+    const result = await this.fnsToRefactorFromCodeSmell(document, codeSmell);
+    this.cache.set(cacheKey, result);
+    return result;
+  }
+
+  private isStaleEntry(key: string, docUri: string, currentVersion: number): boolean {
+    if (!key.startsWith(docUri + ':v')) {
+      return false;
+    }
+
+    const versionMatch = key.match(/:v(\d+):/);
+    if (!versionMatch) {
+      return false;
+    }
+
+    const cachedVersion = parseInt(versionMatch[1], 10);
+    return cachedVersion < currentVersion;
+  }
+
+  invalidateForDocument(document: vscode.TextDocument): void {
+    const docUri = document.uri.toString();
+    const currentVersion = document.version;
+    const keysToDelete: string[] = [];
+
+    for (const key of this.cache.keys()) {
+      if (this.isStaleEntry(key, docUri, currentVersion)) {
+        keysToDelete.push(key);
+      }
+    }
+
+    keysToDelete.forEach((key) => this.cache.delete(key));
+  }
+
+  cleanupForDocument(document: vscode.TextDocument): void {
+    const docUri = document.uri.toString();
+    const keysToDelete: string[] = [];
+
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(docUri + ':v')) {
+        keysToDelete.push(key);
+      }
+    }
+
+    keysToDelete.forEach((key) => this.cache.delete(key));
+  }
+
+}
+
+export const fnsToRefactorCache = new FnsToRefactorCache();

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -256,16 +256,6 @@ export class DevtoolsAPI {
     DevtoolsAPI.preflightRequestEmitter.fire({ state: 'disabled' });
   }
 
-  static async fnsToRefactorFromCodeSmell(document: TextDocument, codeSmell: CodeSmell) {
-    const result = await this.fnsToRefactor(document, ['--code-smells', JSON.stringify([codeSmell])]);
-    return result?.[0];
-  }
-
-  static async fnsToRefactorFromCodeSmells(document: TextDocument, codeSmells: CodeSmell[]) {
-    if (codeSmells.length === 0) return [];
-    return this.fnsToRefactor(document, ['--code-smells', JSON.stringify(codeSmells)]);
-  }
-
   static async fnsToRefactorFromDelta(document: TextDocument, delta: Delta) {
     return this.fnsToRefactor(document, ['--delta-result', JSON.stringify(delta)]);
   }

--- a/src/refactoring/utils.ts
+++ b/src/refactoring/utils.ts
@@ -12,6 +12,7 @@ import { FnToRefactor, RefactorResponse } from '../devtools-api/refactor-models'
 import { isDefined } from '../utils';
 import { RefactoringRequest } from './request';
 import { DevtoolsAPI } from '../devtools-api';
+import { fnsToRefactorCache } from '../devtools-api/fns-to-refactor-cache';
 import { CodeSmell } from '../devtools-api/review-model';
 
 function singleLineCommentSeparator(languageId: string) {
@@ -160,7 +161,7 @@ export function isFunctionUnchangedInDocument(
 
 export async function findFnToRefactor(document: vscode.TextDocument | undefined, codeSmell: CodeSmell | undefined) {
   if (document && codeSmell) {
-    const fn = await DevtoolsAPI.fnsToRefactorFromCodeSmell(document, codeSmell);
+    const fn = await fnsToRefactorCache.fnsToRefactor(document, codeSmell);
     return fn;
   }
 }

--- a/src/review/codelens.ts
+++ b/src/review/codelens.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { scorePresentation } from '../code-health-monitor/presentation';
 import { onDidChangeConfiguration, reviewCodeLensesEnabled } from '../configuration';
 import { DevtoolsAPI } from '../devtools-api';
+import { fnsToRefactorCache } from '../devtools-api/fns-to-refactor-cache';
 import { FnToRefactor } from '../devtools-api/refactor-models';
 import { CsDiagnostic } from '../diagnostics/cs-diagnostic';
 import { toDocsParamsRanged } from '../documentation/commands';
@@ -9,9 +10,10 @@ import { isDefined } from '../utils';
 import Reviewer from './reviewer';
 import { ReviewCacheItem } from './review-cache-item';
 import { CsCodeLens } from './cs-code-lens';
+import { logOutputChannel } from '../log';
 
 export class CsReviewCodeLensProvider
-  implements vscode.CodeLensProvider<vscode.CodeLens | CsCodeLens>, vscode.Disposable
+implements vscode.CodeLensProvider<vscode.CodeLens | CsCodeLens>, vscode.Disposable
 {
   private changeCodeLensesEmitter = new vscode.EventEmitter<void>();
   onDidChangeCodeLenses = this.changeCodeLensesEmitter.event;
@@ -41,23 +43,32 @@ export class CsReviewCodeLensProvider
       onDidChangeConfiguration('enableReviewCodeLenses', () => this.changeCodeLensesEmitter.fire()),
       DevtoolsAPI.onDidReviewComplete(() => this.changeCodeLensesEmitter.fire()),
       DevtoolsAPI.onDidDeltaAnalysisComplete(() => this.changeCodeLensesEmitter.fire()),
+      vscode.workspace.onDidChangeTextDocument((event) => {
+        fnsToRefactorCache.invalidateForDocument(event.document);
+      }),
       vscode.workspace.onDidCloseTextDocument((document) => {
-        const docUri = document.uri.toString();
-        const keysToDelete: string[] = [];
-
-        for (const [key, cached] of this.commandCache.entries()) {
-          if (cached.document.uri.toString() === docUri) {
-            keysToDelete.push(key);
-          }
-        }
-
-        keysToDelete.forEach((key) => {
-          this.commandDisposables.get(key)?.dispose();
-          this.commandDisposables.delete(key);
-          this.commandCache.delete(key);
-        });
+        this.cleanupCachesForDocument(document);
       })
     );
+  }
+
+  private cleanupCachesForDocument(document: vscode.TextDocument) {
+    const docUri = document.uri.toString();
+    const commandKeysToDelete: string[] = [];
+
+    for (const [key, cached] of this.commandCache.entries()) {
+      if (cached.document.uri.toString() === docUri) {
+        commandKeysToDelete.push(key);
+      }
+    }
+
+    commandKeysToDelete.forEach((key) => {
+      this.commandDisposables.get(key)?.dispose();
+      this.commandDisposables.delete(key);
+      this.commandCache.delete(key);
+    });
+
+    fnsToRefactorCache.cleanupForDocument(document);
   }
 
   dispose() {
@@ -126,12 +137,13 @@ export class CsReviewCodeLensProvider
 
   private async openInteractiveDocsCommand(codeLens: CsCodeLens, document: vscode.TextDocument) {
     const { codeSmell, range, cacheKey } = codeLens;
-    const fnToRefactor = await DevtoolsAPI.fnsToRefactorFromCodeSmell(document, codeSmell);
+
+    const fnToRefactor = await fnsToRefactorCache.fnsToRefactor(document, codeSmell);
 
     let cached = this.commandCache.get(cacheKey);
 
     if (!cached) {
-      // Register a unique command withhout arguments to avoid VS Code's CommandsConverter cache, as mentioned above.
+      // Register a unique command without arguments to avoid VS Code's CommandsConverter cache, as mentioned above.
       const commandId = `codescene.openInteractiveDocs.${cacheKey.replace(/[^a-zA-Z0-9]/g, '_')}`;
 
       const command = vscode.commands.registerCommand(commandId, () => {
@@ -158,7 +170,7 @@ export class CsReviewCodeLensProvider
       };
       this.commandCache.set(cacheKey, cached);
     } else {
-      // Update the cached data with current values - especially for fnToRefactor which can change:
+      // Update the cached command data with current values
       cached.category = codeSmell.category;
       cached.document = document;
       cached.position = range.start;


### PR DESCRIPTION
Most `fns-to-refactor` calls are coupled to Code Lenses, so they can be invoked many times.

This commit introduces a cache to avoid creating excessive CLI processes.