### PR TITLE
feat: use Git merge-base to filter out irrelevant Git changes

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -3,7 +3,7 @@ import { API, Repository } from '../../types/git';
 import Reviewer from '../review/reviewer';
 import { register as registerCodeLens } from './codelens';
 import { register as registerHomeView } from './home/home-view';
-import { acquireGitApi, getBranchCreationCommit, isMainBranch, updateGitState } from '../git-utils';
+import { acquireGitApi, getBranchCreationCommit, getDefaultCommit, updateGitState } from '../git-utils';
 import { Baseline, CsExtensionState } from '../cs-extension-state';
 import { InteractiveDocsParams } from '../documentation/commands';
 import { CodeSceneCWFDocsTabPanel } from '../codescene-tab/webview/documentation/cwf-webview-docs-panel';
@@ -94,24 +94,6 @@ export async function getBaselineCommit(fileUri: Uri): Promise<string | undefine
 async function getHeadCommit(repo: Repository) {
   const head = repo.state.HEAD?.commit;
   return head || '';
-}
-
-/**
- * Determines the default comparison point for a file based on the current Git branch context.
- *
- * Default behavior:
- * - If on the main branch, the comparison point is the HEAD commit.
- * - If on a non-main branch, the comparison point is the branch creation commit.
- * - If the branch cannot be determined, fallback logic compares to a perfect score.
- */
-async function getDefaultCommit(repo: Repository) {
-  const isMain = isMainBranch(repo.state.HEAD?.name);
-
-  if (isMain) {
-    return await getHeadCommit(repo);
-  } else {
-    return await getBranchCreationCommit(repo);
-  }
 }
 
 /**

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -42,7 +42,7 @@ export async function getBranchCreationCommit(repo: Repository) {
   const repoPath = repo.rootUri.path;
   if (!currentBranch || !repoPath) return '';
 
-  if (isMainBranch(currentBranch)) return '';
+  if (await isMainBranch(currentBranch, repoPath)) return '';
 
   try {
     const { stdout: reflog } = await gitExecutor.execute(
@@ -65,16 +65,100 @@ export async function getBranchCreationCommit(repo: Repository) {
 }
 
 /**
- * Determines if the given branch could be the default branch.
- *
- * Checks against a list of commonly used default branch names (main, master, develop, trunk, dev).
+ * Returns the branch names that look like the main branch AND do in fact exist.
  */
-export function isMainBranch(currentBranch: string | undefined) {
-  if (!currentBranch) return false;
-
+export async function getMainBranchCandidates(repoPath: string): Promise<string[]> {
   const possibleMainBranches = ['main', 'master', 'develop', 'trunk', 'dev'];
 
-  return possibleMainBranches.includes(currentBranch);
+  try {
+    const { stdout } = await gitExecutor.execute(
+      { command: 'git', args: ['branch', '--list', '--format=%(refname:short)'] },
+      { cwd: repoPath }
+    );
+
+    const localBranches = stdout.split('\n').map(branch => branch.trim()).filter(Boolean);
+    return possibleMainBranches.filter(branch => localBranches.includes(branch));
+  } catch (err) {
+    logOutputChannel.error(`Could not get local branches for ${repoPath}: ${err}`);
+    return [];
+  }
+}
+
+/**
+ * Determines if the given branch could be the default branch.
+ *
+ * Checks against locally present main branch names (main, master, develop, trunk, dev).
+ */
+export async function isMainBranch(currentBranch: string | undefined, repoPath: string): Promise<boolean> {
+  if (!currentBranch) return false;
+
+  const localMainBranches = await getMainBranchCandidates(repoPath);
+  return localMainBranches.includes(currentBranch);
+}
+
+/**
+ * Determines the default comparison point for a file based on the current Git branch context.
+ *
+ * Default behavior:
+ * - If on the main branch, the comparison point is the HEAD commit.
+ * - If on a non-main branch, the comparison point is the branch creation commit.
+ * - If the branch cannot be determined, returns empty string.
+ *
+ * @param repo The repository to get the default commit for
+ * @returns The commit hash or empty string if not available
+ */
+export async function getDefaultCommit(repo: Repository): Promise<string> {
+  const repoPath = repo.rootUri.path;
+  const isMain = await isMainBranch(repo.state.HEAD?.name, repoPath);
+
+  if (isMain) {
+    // On main branch, use HEAD commit
+    return repo.state.HEAD?.commit || '';
+  } else {
+    // On feature branch, use branch creation commit
+    return await getBranchCreationCommit(repo);
+  }
+}
+
+/**
+ * Determines the merge-base commit.
+ *
+ * If we're on the main branch, returns the HEAD commit.
+ * If we're on a non-main branch, returns the merge-base commit between the current branch and the main branch.
+ */
+export async function getMergeBaseCommit(repo: Repository): Promise<string> {
+  const currentBranch = repo.state.HEAD?.name;
+  const repoPath = repo.rootUri.path;
+
+  if (!currentBranch || !repoPath) {
+    return '';
+  }
+
+  const isMain = await isMainBranch(currentBranch, repoPath);
+
+  if (isMain) {
+    const commit = repo.state.HEAD?.commit || '';
+    return commit;
+  }
+
+  const localMainBranches = await getMainBranchCandidates(repoPath);
+  for (const mainBranch of localMainBranches) {
+    try {
+      const { stdout: mergeBase } = await gitExecutor.execute(
+        { command: 'git', args: ['merge-base', currentBranch, mainBranch] },
+        { cwd: repoPath }
+      );
+
+      const commit = mergeBase.trim();
+      if (commit) {
+        return commit;
+      }
+    } catch (err) {
+      continue;
+    }
+  }
+
+  return '';
 }
 
 /**
@@ -99,7 +183,7 @@ export interface GitStateChange {
 export function updateGitState(repo: Repository) : GitStateChange {
   const head = repo.state.HEAD;
   if (!head) return {commitChanged: false, branchChanged: false};
-  
+
   const gitStateChange: GitStateChange = {
     commitChanged: repoState?.commit !== head.commit,
     branchChanged: repoState?.branch !== head.name

--- a/src/git/git-change-observer.ts
+++ b/src/git/git-change-observer.ts
@@ -3,8 +3,9 @@ import * as path from 'path';
 import { supportedExtensions } from '../language-support';
 import { logOutputChannel } from '../log';
 import CsDiagnostics from '../diagnostics/cs-diagnostics';
-import { fireFileDeletedFromGit } from '../git-utils';
+import { fireFileDeletedFromGit, getMergeBaseCommit } from '../git-utils';
 import { Executor } from '../executor';
+import { getRepo } from '../code-health-monitor/addon';
 
 /**
  * Observes discrete Git file changes in real-time.
@@ -33,31 +34,154 @@ export class GitChangeObserver {
     this.context.subscriptions.push(this.fileWatcher);
   }
 
+  private parseGitStatusFilename(line: string): string | null {
+
+    // e.g. "MM src/foo.clj"
+    const match = line.match(/^\S+\s+(.+)$/);
+
+    if (!match?.[1]) {
+      return null;
+    }
+
+    // Handle renames: "R  old -> new" becomes "new"
+    const filename = match[1].includes(' -> ')
+      ? match[1].split(' -> ')[1].trim()
+      : match[1];
+
+    return filename;
+  }
+
+  private async getCommittedChanges(baseCommit: string, workspacePath: string): Promise<Set<string>> {
+    const changedFiles = new Set<string>();
+
+    if (!baseCommit) {
+      return changedFiles;
+    }
+
+    const result = await this.executor.execute(
+      { command: 'git', args: ['diff', '--name-only', `${baseCommit}...HEAD`], ignoreError: true },
+      { cwd: workspacePath }
+    );
+
+    if (result.exitCode === 0) {
+      result.stdout
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0)
+        .forEach(file => {
+          changedFiles.add(file);
+        });
+    } else {
+      logOutputChannel.warn(`Failed to get committed changes vs ${baseCommit}: ${result.stderr}`);
+    }
+
+    return changedFiles;
+  }
+
+  private async getStatusChanges(workspacePath: string): Promise<Set<string>> {
+    const changedFiles = new Set<string>();
+
+    const result = await this.executor.execute(
+      { command: 'git', args: ['status', '--porcelain'], ignoreError: true },
+      { cwd: workspacePath }
+    );
+
+    if (result.exitCode === 0) {
+      result.stdout
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line.length > 0)
+        .forEach(line => {
+          const filename = this.parseGitStatusFilename(line);
+          if (filename) {
+            changedFiles.add(filename);
+          }
+        });
+    } else {
+      logOutputChannel.info(`Failed to get status changes: ${result.stderr}`);
+    }
+
+    return changedFiles;
+  }
+
+  async getChangedFilesVsBaseline(): Promise<string[]> {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      return [];
+    }
+
+    const repo = getRepo(workspaceFolder.uri);
+    const baseCommit = repo ? await getMergeBaseCommit(repo) : '';
+
+    try {
+      const workspacePath = workspaceFolder.uri.fsPath;
+      const committedChanges = await this.getCommittedChanges(baseCommit, workspacePath);
+      const statusChanges = await this.getStatusChanges(workspacePath);
+
+      const allChangedFiles = new Set([...committedChanges, ...statusChanges]);
+
+      const result = Array.from(allChangedFiles);
+      return result;
+    } catch (error) {
+      logOutputChannel.warn(`Error getting changed files vs base commit ${baseCommit}: ${error}`);
+      return [];
+    }
+  }
+
+  private isSupportedFile(filePath: string): boolean {
+    const fileExt = path.extname(filePath);
+    return supportedExtensions.includes(fileExt);
+  }
+
+  private isFileInChangedList(filePath: string, changedFiles: string[]): boolean {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+
+    if (!workspaceFolder) {
+      return true;
+    }
+
+    const relativePath = path.relative(workspaceFolder.uri.fsPath, filePath);
+
+    if (!changedFiles.includes(relativePath)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private async reviewFile(filePath: string): Promise<void> {
+    try {
+      // Load the file as a TextDocument (doesn't open in editor UI)
+      const document = await vscode.workspace.openTextDocument(filePath);
+      CsDiagnostics.review(document, { skipMonitorUpdate: false });
+    } catch (error) {
+      logOutputChannel.warn(`Could not load file for review ${filePath}: ${error}`);
+    }
+  }
+
   private async handleFileChange(uri: vscode.Uri): Promise<void> {
-    const fileExt = path.extname(uri.fsPath);
-    if (!supportedExtensions.includes(fileExt)) {
+    const filePath = uri.fsPath;
+
+    if (!this.isSupportedFile(filePath)) {
       return;
     }
 
-    const filePath = uri.fsPath;
+    const changedFiles = await this.getChangedFilesVsBaseline();
 
-    void this.executor.executeTask(async () => {
-      try {
-        // Load the file as a TextDocument (doesn't open in editor UI)
-        const document = await vscode.workspace.openTextDocument(filePath);
-        CsDiagnostics.review(document, { skipMonitorUpdate: false });
-      } catch (error) {
-        logOutputChannel.warn(`Could not load file for review ${filePath}: ${error}`);
-      }
-    });
+    if (!this.isFileInChangedList(filePath, changedFiles)) {
+      return;
+    }
+
+    void this.executor.executeTask(() => this.reviewFile(filePath));
   }
 
   private handleFileDelete(uri: vscode.Uri): void {
-    const fileExt = path.extname(uri.fsPath);
-    if (!supportedExtensions.includes(fileExt)) {
+    const filePath = uri.fsPath;
+
+    if (!this.isSupportedFile(filePath)) {
       return;
     }
-    const filePath = uri.fsPath;
+
     fireFileDeletedFromGit(filePath);
   }
 


### PR DESCRIPTION
Before, we were reacting to Git changes from e.g. switching or pulling branches, which could bring in file changes that were irrelevant to the current user branch, so an excess of files would be analyzed.

This PR fixes that, by observing `merge-base`. This can also be used in a close future for other purposes.