### PR TITLE
fix: simplify GitChangeLister

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -48,12 +48,12 @@ export function activate(context: vscode.ExtensionContext) {
   // Review all changed/added files every 9 seconds.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
   // because `CsDiagnostics.review` has built-in caching.
-  const gitChangeLister = new GitChangeLister(gitApi, DevtoolsAPI.concurrencyLimitingExecutor);
+  const gitChangeLister = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor);
   const scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
 
   void scheduledExecutor.executeTask(async () => {
     logOutputChannel.info('Starting scheduled git change review');
-    await gitChangeLister.startAsync(context);
+    await gitChangeLister.start();
   });
 
   const codeHealthMonitorHelpCommand = vscode.commands.registerCommand('codescene.codeHealthMonitorHelp', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,7 @@ function addReviewListeners(context: vscode.ExtensionContext) {
   const gitApi = acquireGitApi();
   let gitChangeObserver: GitChangeObserver | undefined;
   if (gitApi) {
-    gitChangeObserver = new GitChangeObserver(context, DevtoolsAPI.concurrencyLimitingExecutor, gitApi);
+    gitChangeObserver = new GitChangeObserver(context, DevtoolsAPI.concurrencyLimitingExecutor);
     gitChangeObserver.start();
     context.subscriptions.push(gitChangeObserver);
   }

--- a/src/git/git-change-observer.ts
+++ b/src/git/git-change-observer.ts
@@ -25,13 +25,13 @@ export class GitChangeObserver {
   //   (which may have been added to the Monitor treeview, so they need to be removed on deletion events)
   private tracker: Set<string> = new Set();
 
-  constructor(context: vscode.ExtensionContext, executor: Executor, gitApi: API) {
+  constructor(context: vscode.ExtensionContext, executor: Executor) {
     this.context = context;
     this.executor = executor;
     this.fileWatcher = this.createWatcher('**/*');
 
     // Initially fill the tracker - this ensures `handleFileDelete` works well
-    const lister = new GitChangeLister(gitApi, executor);
+    const lister = new GitChangeLister(executor);
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     if (workspaceFolder) {
       const workspacePath = getWorkspacePath(workspaceFolder);

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -30,7 +30,7 @@ suite('GitChangeLister Test Suite', () => {
 
     mockGitApi = new MockGitAPI();
     mockExecutor = new MockExecutor();
-    gitChangeLister = new GitChangeLister(mockGitApi as API, mockExecutor);
+    gitChangeLister = new GitChangeLister(mockExecutor);
   });
 
   teardown(() => {


### PR DESCRIPTION
The old implemenetation could run `git status` twice consecutively, because of the guards that were in place.