### PR TITLE
refactor: `refreshDeltas` - don't analyse non-existing files

### DIFF
--- a/src/review/review-cache.ts
+++ b/src/review/review-cache.ts
@@ -33,9 +33,17 @@ export class ReviewCache {
   }
 
   refreshDeltas() {
-    this._cache.forEach((innerMap) => {
-      innerMap.forEach((item) => {
-        void item.runDeltaAnalysis({ skipMonitorUpdate: false });
+    this._cache.forEach((innerMap, fileName) => {
+      innerMap.forEach(async (item, snapshot) => {
+        try {
+          await vscode.workspace.fs.stat(item.document.uri);
+          void item.runDeltaAnalysis({ skipMonitorUpdate: false });
+        } catch { // File doesn't exist
+          innerMap.delete(snapshot);
+          if (innerMap.size === 0) {
+            this._cache.delete(fileName);
+          }
+        }
       });
     });
   }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import Module from 'module';
+import * as fs from 'fs';
 import { DiagnosticStub } from './stubs/diagnostic-stub';
 import { EventEmitterStub } from './stubs/event-emitter-stub';
 import { RangeStub } from './stubs/range-stub';
@@ -67,6 +68,25 @@ const vscodeStub = {
       inspect: () => undefined,
       update: () => Promise.resolve(),
     }),
+    fs: {
+      stat: async (uri: any) => {
+        const fsPath = uri.fsPath || uri.path;
+        return new Promise((resolve, reject) => {
+          fs.stat(fsPath, (err: any, stats: any) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve({
+                type: stats.isFile() ? 1 : stats.isDirectory() ? 2 : 0,
+                ctime: stats.ctimeMs,
+                mtime: stats.mtimeMs,
+                size: stats.size,
+              });
+            }
+          });
+        });
+      },
+    },
   },
   languages: {
     match: (selector: any, document: any) => {


### PR DESCRIPTION
This should make ENOENT errors less likely.