### PR TITLE
fix: introduce findFilesWithIgnoreSupport

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "vscode": "^1.75.1"
   },
+  "enabledApiProposals": [
+    "findFiles2"
+  ],
   "categories": [
     "Programming Languages",
     "Linters"

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -78,8 +78,25 @@ export function getCodeHealthFileVersions(): Map<string, number> {
   return codeHealthFileVersion;
 }
 
+async function findFilesWithIgnoreSupport(
+  pattern: vscode.GlobPattern
+): Promise<vscode.Uri[]> {
+  if (typeof (vscode.workspace as any).findFiles2 === 'function') {
+    logOutputChannel.info('Using findFiles2 with useIgnoreFiles support');
+    return (vscode.workspace as any).findFiles2(
+      [pattern],
+      {
+        useIgnoreFiles: { local: true, global: true }
+      }
+    );
+  }
+
+  logOutputChannel.info('Using fallback findFiles (findFiles2 not available)');
+  return vscode.workspace.findFiles(pattern);
+}
+
 async function initializeCodeHealthFileVersions() {
-  const rulesFiles = await vscode.workspace.findFiles('**/.codescene/code-health-rules.json');
+  const rulesFiles = await findFilesWithIgnoreSupport('**/.codescene/code-health-rules.json');
 
   for (const uri of rulesFiles) {
     try {

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -85,7 +85,6 @@ async function initializeCodeHealthFileVersions() {
     try {
       const document = await vscode.workspace.openTextDocument(uri);
       codeHealthFileVersion.set(document.fileName, document.version);
-      onCodeHealthFileVersionChange();
     } catch (e) {
       logOutputChannel.warn(`Failed to open code-health-rules.json: ${uri.fsPath}`, e);
     }


### PR DESCRIPTION
* fix: remove redundant, possibly problematic `onCodeHealthFileVersionChange()` call
  * can reduce unnecessary reviews.
* fix: introduce `findFilesWithIgnoreSupport`
  * uses the newer API, avoiding searching through file with `rg` without honoring Gitignore, which can lead to performance degradation.

Fixes https://github.com/codescene-oss/codescene-vscode/issues/300