### PR TITLE
fix: CS-5753: prevent duplicate file window after accepting auto-refactor

### DIFF
--- a/src/refactoring/commands.ts
+++ b/src/refactoring/commands.ts
@@ -1,7 +1,6 @@
-import vscode, { WorkspaceEdit } from 'vscode';
+import vscode, { ViewColumn, WorkspaceEdit } from 'vscode';
 import { CsExtensionState } from '../cs-extension-state';
 import { FnToRefactor } from '../devtools-api/refactor-models';
-import CsDiagnostics from '../diagnostics/cs-diagnostics';
 import Telemetry from '../telemetry';
 import { RefactoringRequest } from './request';
 import { createTempDocument, decorateCode, findFnToRefactor, selectCode, targetEditor } from './utils';
@@ -10,6 +9,21 @@ import { CodeSceneCWFAceTabPanel } from '../codescene-tab/webview/ace/cwf-webvie
 import { CodeSceneCWFAceAcknowledgementTabPanel } from '../codescene-tab/webview/ace/acknowledgement/cwf-webview-ace-acknowledgement-panel';
 import { logOutputChannel } from '../log';
 import { CodeSmell } from '../devtools-api/review-model';
+
+/**
+ * Locate the view column of an existing tab for the given document, even when the document
+ * is not the active tab in its group (e.g. when a diff tab is on top of it).
+ */
+function findDocumentTabViewColumn(document: vscode.TextDocument): ViewColumn | undefined {
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      if (tab.input instanceof vscode.TabInputText && tab.input.uri.toString() === document.uri.toString()) {
+        return group.viewColumn;
+      }
+    }
+  }
+  return undefined;
+}
 
 export class CsRefactoringCommands implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
@@ -58,8 +72,15 @@ export class CsRefactoringCommands implements vscode.Disposable {
     } = refactoring;
 
     return refactoring.promise.then(async (response) => {
-      const editor = targetEditor(document);
-      await vscode.window.showTextDocument(document.uri, { preview: false, viewColumn: editor?.viewColumn });
+      // Close any lingering Show Diff tabs.
+      try {
+        await this.closeExistingDiffTabs();
+      } catch (e) {
+        reportError({ e, context: 'Error closing diff tabs' });
+      }
+
+      const viewColumn = targetEditor(document)?.viewColumn ?? findDocumentTabViewColumn(document) ?? ViewColumn.One;
+      await vscode.window.showTextDocument(document.uri, { preview: false, viewColumn });
       const workSpaceEdit = new WorkspaceEdit();
       workSpaceEdit.replace(document.uri, vscodeRange, response.code);
       await vscode.workspace.applyEdit(workSpaceEdit);
@@ -114,8 +135,8 @@ export class CsRefactoringCommands implements vscode.Disposable {
 
     // Use showTextDocument using the tmp doc and the target editor view column to set that editor active.
     // The diff command will then open in that same viewColumn, and not on top of the ACE panel.
-    const editor = targetEditor(document);
-    await vscode.window.showTextDocument(originalCodeTmpDoc, editor?.viewColumn, false);
+    const viewColumn = targetEditor(document)?.viewColumn ?? findDocumentTabViewColumn(document) ?? ViewColumn.One;
+    await vscode.window.showTextDocument(originalCodeTmpDoc, viewColumn, false);
     await vscode.commands.executeCommand('vscode.diff', originalCodeTmpDoc.uri, refactoringTmpDoc.uri);
 
     Telemetry.logUsage('refactor/diff-shown', refactoring.eventData);


### PR DESCRIPTION
## Summary

Fixes CS-5753. After accepting Auto-Refactor, the Show Diff tab remained open and the refactored file sometimes appeared in a new, duplicate editor tab alongside the ACE panel.

### Root cause (confirmed via debug logs)

When a `tmp-diff` tab covers the document in its original view column:

- `targetEditor(document)` returns `undefined` because the document isn't visible in any editor.
- `showTextDocument(uri, { viewColumn: undefined })` falls back to the globally active group (the ACE webview column), creating a duplicate file tab there.
- `applyRefactoringCmd` also never closed the `tmp-diff` tabs, so the Show Diff view stayed visible after accept.

### Changes (`src/refactoring/commands.ts`)

- `applyRefactoringCmd` now closes existing `tmp-diff` tabs before showing the document.
- New `findDocumentTabViewColumn` helper locates the view column of the document's existing text tab even when that tab isn't active in its group.
- View column resolution in both `applyRefactoringCmd` and `showDiffForRefactoringCmd` now uses: `targetEditor(document)?.viewColumn ?? findDocumentTabViewColumn(document) ?? ViewColumn.One`.

## Test plan

- [ ] Open a file, edit to trigger analysis.
- [ ] Close the file.
- [ ] From the Code Health Monitor, click the function, then Auto-Refactor.
- [ ] Click Show Diff twice.
- [ ] Click Accept Auto-Refactor.
- [ ] Expect only the refactored file visible: no leftover diff tab, no duplicate file tab.
- [ ] Single Show Diff click still opens the diff in the file's column (not on top of the ACE panel).
- [ ] CodeScene `code_health_review` on `src/refactoring/commands.ts` returns score 10.0.
