### PR TITLE
feat: add editor-version to telemetry payload

### DIFF
--- a/src/devtools-api/telemetry-model.ts
+++ b/src/devtools-api/telemetry-model.ts
@@ -5,6 +5,10 @@ export interface TelemetryEvent {
    */
   'editor-type': string;
   /**
+   * Version of editor, for example 1.112.0.
+   */
+  'editor-version'?: string;
+  /**
    * Name of event, this should be unique for each tracked function.
    */
   'event-name': string;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -146,6 +146,7 @@ export default class Telemetry {
       'event-time': new Date().toISOString(),
       'event-name': eventName,
       'editor-type': 'vscode',
+      'editor-version': vscode.version,
       'extension-version': this.extension.packageJSON.version,
       'process-platform': process.platform,
       'process-arch': process.arch,

--- a/src/test/suite/telemetry-integration.test.ts
+++ b/src/test/suite/telemetry-integration.test.ts
@@ -37,6 +37,7 @@ suite('Telemetry Integration Test Suite', () => {
 
     const event: TelemetryEvent = {
       'editor-type': 'VSCode',
+      'editor-version': '1.112.0',
       'event-name': 'test-event',
       'extension-version': '1.0.0'
     };
@@ -53,6 +54,7 @@ suite('Telemetry Integration Test Suite', () => {
 
     const event: TelemetryEvent = {
       'editor-type': 'VSCode',
+      'editor-version': '1.112.0',
       'event-name': 'test-event-with-user',
       'extension-version': '1.0.0',
       'user-id': 'test-user-123'
@@ -69,6 +71,7 @@ suite('Telemetry Integration Test Suite', () => {
 
     const event: TelemetryEvent = {
       'editor-type': 'VSCode',
+      'editor-version': '1.112.0',
       'event-name': 'custom-props-event',
       'extension-version': '1.0.0',
       'custom-prop-1': 'value1',
@@ -87,6 +90,7 @@ suite('Telemetry Integration Test Suite', () => {
 
     const event: TelemetryEvent = {
       'editor-type': 'VSCode',
+      'editor-version': '1.112.0',
       'event-name': 'comprehensive-event',
       'extension-version': '2.5.0',
       internal: false,


### PR DESCRIPTION
## Summary
- Add `editor-version` (e.g. `1.112.0`) to the base telemetry event payload, sourced from `vscode.version`, alongside `editor-type`.
- Mark `editor-version` as optional on the `TelemetryEvent` interface.
- Update telemetry integration test fixtures to include the new field.

How it looks in Amplitude
<img width="591" height="230" alt="image" src="https://github.com/user-attachments/assets/2b2dda67-2fa7-4f8f-a780-f1fcc478743b" />

## Test plan
- [ ] Run telemetry integration tests
- [ ] Verify telemetry events sent in a debug session include `editor-version` matching the host VS Code version
