### PR TITLE
fix: tighten CWF webview Content Security Policy (CS-11184)

### DIFF
--- a/src/centralized-webview-framework/cwf-html-utils.ts
+++ b/src/centralized-webview-framework/cwf-html-utils.ts
@@ -1,6 +1,6 @@
 import { Webview } from 'vscode';
 import { IdeContextType } from './types';
-import { getUri } from '../webview-utils';
+import { getUri, nonce } from '../webview-utils';
 import { FeatureFlags } from './types/cwf-feature';
 export const ideType = 'VSCode';
 
@@ -110,8 +110,8 @@ export const ideStylesVars = `
   </style>
 `;
 
-export const initialDataContextScriptTag = (ideContext: IdeContextType) => /*html*/ `
-  <script>
+export const initialDataContextScriptTag = (ideContext: IdeContextType, scriptNonce: string) => /*html*/ `
+  <script nonce="${scriptNonce}">
     function setContext() {
       window.ideContext = ${JSON.stringify(ideContext)}
     }
@@ -119,9 +119,9 @@ export const initialDataContextScriptTag = (ideContext: IdeContextType) => /*htm
   </script>
 `;
 
-export const generateContextScriptTag = (ideContext: IdeContextType) => {
+export const generateContextScriptTag = (ideContext: IdeContextType, scriptNonce: string) => {
   return `
-  <script>
+  <script nonce="${scriptNonce}">
     function setContext() {
       window.ideContext = ${JSON.stringify(ideContext)}
     }
@@ -129,19 +129,20 @@ export const generateContextScriptTag = (ideContext: IdeContextType) => {
   </script>`;
 };
 
-export const getCsp = (webview: Webview) => [
+export const getCsp = (webview: Webview, scriptNonce: string) => [
   `default-src 'none';`,
-  `script-src ${webview.cspSource} 'unsafe-eval' 'unsafe-inline' https://* `,
-  `style-src ${webview.cspSource} 'self' 'unsafe-inline' https://*`,
-  `img-src ${webview.cspSource} 'self' data: 'unsafe-inline' https://*`,
+  `script-src ${webview.cspSource} 'nonce-${scriptNonce}'`,
+  `style-src ${webview.cspSource} 'unsafe-inline'`,
+  `img-src ${webview.cspSource} data:`,
   `font-src ${webview.cspSource}`,
-  `connect-src https://*`,
+  `connect-src ${webview.cspSource}`,
 ];
 
 export function initBaseContent(webView: Webview, initialIdeContext: IdeContextType) {
+  const scriptNonce = nonce();
   const scriptUri = getUri(webView, 'cs-cwf', 'assets', 'index.js');
   const stylesUri = getUri(webView, 'cs-cwf', 'assets', 'index.css');
-  const csp = getCsp(webView);
+  const csp = getCsp(webView, scriptNonce);
 
   // The full html with all previous varaibles included
   return /*html*/ `<!DOCTYPE html>
@@ -153,11 +154,11 @@ export function initBaseContent(webView: Webview, initialIdeContext: IdeContextT
       <link rel="stylesheet" type="text/css" href="${stylesUri}">
       <title>VSCode React Webview</title>
       ${ideStylesVars}
-      ${initialDataContextScriptTag(initialIdeContext)}
+      ${initialDataContextScriptTag(initialIdeContext, scriptNonce)}
     </head>
     <body>
       <div id="root"></div>
-      <script type="module" src="${scriptUri}"></script>
+      <script type="module" nonce="${scriptNonce}" src="${scriptUri}"></script>
     </body>
   </html>`;
 }


### PR DESCRIPTION
## Summary

The CWF webview CSP was overly permissive (`'unsafe-eval'`, `'unsafe-inline'`, `https://*`) — effectively disabling XSS containment in the Home / Docs / ACE panels.

This switches to a nonce-based `script-src` and removes wildcard origins from all directives.

## Changes

- Remove `'unsafe-eval'`, `'unsafe-inline'`, and `https://*` from `script-src`
- Add nonce-based script loading (generated per render)
- Tighten `style-src` (keep `'unsafe-inline'` for VS Code theme vars, drop `https://*`)
- Tighten `img-src` to `cspSource` + `data:` only
- Tighten `connect-src` to `cspSource` only
- Add `nonce` attribute to both inline and module script tags

## Validation

- `npm run build` (typecheck + lint + bundle)
- Manual F5 test: CWF panel renders, no CSP violations in DevTools console