### PR TITLE
fix: redact sensitive executor log args (CS-11183)

### DIFF
--- a/src/simple-executor.ts
+++ b/src/simple-executor.ts
@@ -16,14 +16,17 @@ export function parseJsonInput(input: string): any {
 
 const SENSITIVE_KEYS = new Set(['token', 'accessToken', 'Authorization']);
 
+function maybeRedactValue(key: string, value: any): any {
+  return SENSITIVE_KEYS.has(key) ? '[REDACTED]' : value;
+}
+
 export function objectToArray(obj: any): any[] {
   if (Array.isArray(obj)) {
     return obj;
   }
   if (typeof obj === 'object' && obj !== null) {
     const { 'file-content': _, ...rest } = obj;
-    
-    return Object.entries(rest).flatMap(([key, value]) => [`'${key}'`, SENSITIVE_KEYS.has(key) ? '[REDACTED]' : value]);
+    return Object.entries(rest).flatMap(([key, value]) => [`'${key}'`, maybeRedactValue(key, value)]);
   }
   return [];
 }

--- a/src/simple-executor.ts
+++ b/src/simple-executor.ts
@@ -14,13 +14,16 @@ export function parseJsonInput(input: string): any {
   }
 }
 
+const SENSITIVE_KEYS = new Set(['token', 'accessToken', 'Authorization']);
+
 export function objectToArray(obj: any): any[] {
   if (Array.isArray(obj)) {
     return obj;
   }
   if (typeof obj === 'object' && obj !== null) {
     const { 'file-content': _, ...rest } = obj;
-    return Object.entries(rest).flatMap(([key, value]) => [`'${key}'`, value]);
+    
+    return Object.entries(rest).flatMap(([key, value]) => [`'${key}'`, SENSITIVE_KEYS.has(key) ? '[REDACTED]' : value]);
   }
   return [];
 }

--- a/src/test/suite/simple-executor.test.ts
+++ b/src/test/suite/simple-executor.test.ts
@@ -27,6 +27,9 @@ suite('SimpleExecutor Test Suite', () => {
       assert.deepStrictEqual(objectToArray([]), []);
       assert.deepStrictEqual(objectToArray({ 'file-content': 'ignored', key: 'value' }), ["'key'", 'value']);
       assert.deepStrictEqual(objectToArray({ 'file-content': 'ignored' }), []);
+      assert.deepStrictEqual(objectToArray({ 'token': 'secret-bearer-token', key: 'value' }), ["'token'", '[REDACTED]', "'key'", 'value']);
+      assert.deepStrictEqual(objectToArray({ 'accessToken': 'secret', key: 'value' }), ["'accessToken'", '[REDACTED]', "'key'", 'value']);
+      assert.deepStrictEqual(objectToArray({ 'Authorization': 'Bearer xyz', key: 'value' }), ["'Authorization'", '[REDACTED]', "'key'", 'value']);
     });
   });
 


### PR DESCRIPTION
## Summary

Prevents CodeScene auth tokens from being written to the VS Code output logs.

The issue was that executor logging merged JSON stdin payloads into the logged command arguments for easier debugging. Refactoring requests include an auth token in that payload, which meant the token could appear in the "CodeScene" output channel and persisted VS Code logs.

## Changes

- Redact known sensitive keys in executor log output:
  - `token`
  - `accessToken`
  - `Authorization`
- Preserve the existing behavior of omitting `file-content` from logs.
- Add unit coverage for sensitive key redaction.

## Screenshot
<img width="2373" height="39" alt="image" src="https://github.com/user-attachments/assets/0bb2cb1f-7cfe-463e-8e5e-f4c434cec44b"/>

Replaces #307 (closed fork PR — reopened from upstream branch to enable CI secrets).