### PR TITLE
fix: tighten CWF webview Content Security Policy (CS-11184)

### DIFF
--- a/.github/workflows/code-coverage-gates.yml
+++ b/.github/workflows/code-coverage-gates.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Configure Git
       run: git config --global advice.defaultBranchName false
 
+    - name: Pretest
+      run: npm run pretest
+      env:
+        CI: true
+
     - name: Generate code coverage
       run: npm run test:coverage
       env:

--- a/src/centralized-webview-framework/cwf-html-utils.ts
+++ b/src/centralized-webview-framework/cwf-html-utils.ts
@@ -110,10 +110,14 @@ export const ideStylesVars = `
   </style>
 `;
 
+function safeJsonStringify(obj: unknown): string {
+  return JSON.stringify(obj).replace(/</g, '\\u003c').replace(/>/g, '\\u003e').replace(/&/g, '\\u0026');
+}
+
 export const initialDataContextScriptTag = (ideContext: IdeContextType, scriptNonce: string) => /*html*/ `
   <script nonce="${scriptNonce}">
     function setContext() {
-      window.ideContext = ${JSON.stringify(ideContext)}
+      window.ideContext = ${safeJsonStringify(ideContext)}
     }
     setContext();
   </script>
@@ -123,7 +127,7 @@ export const generateContextScriptTag = (ideContext: IdeContextType, scriptNonce
   return `
   <script nonce="${scriptNonce}">
     function setContext() {
-      window.ideContext = ${JSON.stringify(ideContext)}
+      window.ideContext = ${safeJsonStringify(ideContext)}
     }
     setContext();
   </script>`;

--- a/src/centralized-webview-framework/cwf-html-utils.ts
+++ b/src/centralized-webview-framework/cwf-html-utils.ts
@@ -71,7 +71,7 @@ export const ideStylesVars = `
       ${Object.keys(opacityHexLookup)
         .map(
           (opacity) =>
-            `--cs-theme-foreground-${opacity}: color-mix(in srgb, var(--vscode-foreground) ${opacity}%, transparent);`
+            `--cs-theme-foreground-${opacity}: color-mix(in srgb, var(--vscode-foreground) ${opacity}%, transparent);`,
         )
         .join('\n      ')}
 
@@ -86,7 +86,7 @@ export const ideStylesVars = `
       ${Object.keys(opacityHexLookup)
         .map(
           (opacity) =>
-            `--cs-theme-button-foreground-${opacity}: color-mix(in srgb, var(--vscode-button-foreground) ${opacity}%, transparent);`
+            `--cs-theme-button-foreground-${opacity}: color-mix(in srgb, var(--vscode-button-foreground) ${opacity}%, transparent);`,
         )
         .join('\n      ')}
 
@@ -94,7 +94,7 @@ export const ideStylesVars = `
       ${Object.keys(opacityHexLookup)
         .map(
           (opacity) =>
-            `--cs-theme-button-background-${opacity}: color-mix(in srgb, var(--vscode-button-background) ${opacity}%, transparent);`
+            `--cs-theme-button-background-${opacity}: color-mix(in srgb, var(--vscode-button-background) ${opacity}%, transparent);`,
         )
         .join('\n      ')}
       --cs-theme-button-secondaryForeground: var(--vscode-button-secondaryForeground);
@@ -103,7 +103,7 @@ export const ideStylesVars = `
       ${Object.keys(opacityHexLookup)
         .map(
           (opacity) =>
-            `--cs-theme-button-secondaryBackground-${opacity}: color-mix(in srgb, var(--vscode-button-secondaryBackground) ${opacity}%, transparent);`
+            `--cs-theme-button-secondaryBackground-${opacity}: color-mix(in srgb, var(--vscode-button-secondaryBackground) ${opacity}%, transparent);`,
         )
         .join('\n      ')}
     }

--- a/src/centralized-webview-framework/cwf-html-utils.ts
+++ b/src/centralized-webview-framework/cwf-html-utils.ts
@@ -1,6 +1,6 @@
 import { Webview } from 'vscode';
 import { IdeContextType } from './types';
-import { getUri } from '../webview-utils';
+import { getUri, nonce } from '../webview-utils';
 import { FeatureFlags } from './types/cwf-feature';
 export const ideType = 'VSCode';
 
@@ -110,8 +110,8 @@ export const ideStylesVars = `
   </style>
 `;
 
-export const initialDataContextScriptTag = (ideContext: IdeContextType) => /*html*/ `
-  <script>
+export const initialDataContextScriptTag = (ideContext: IdeContextType, scriptNonce: string) => /*html*/ `
+  <script nonce="${scriptNonce}">
     function setContext() {
       window.ideContext = ${JSON.stringify(ideContext)}
     }
@@ -119,9 +119,9 @@ export const initialDataContextScriptTag = (ideContext: IdeContextType) => /*htm
   </script>
 `;
 
-export const generateContextScriptTag = (ideContext: IdeContextType) => {
+export const generateContextScriptTag = (ideContext: IdeContextType, scriptNonce: string) => {
   return `
-  <script>
+  <script nonce="${scriptNonce}">
     function setContext() {
       window.ideContext = ${JSON.stringify(ideContext)}
     }
@@ -129,19 +129,20 @@ export const generateContextScriptTag = (ideContext: IdeContextType) => {
   </script>`;
 };
 
-export const getCsp = (webview: Webview) => [
+export const getCsp = (webview: Webview, scriptNonce: string) => [
   `default-src 'none';`,
-  `script-src ${webview.cspSource} 'unsafe-eval' 'unsafe-inline' https://* `,
-  `style-src ${webview.cspSource} 'self' 'unsafe-inline' https://*`,
-  `img-src ${webview.cspSource} 'self' data: 'unsafe-inline' https://*`,
+  `script-src ${webview.cspSource} 'nonce-${scriptNonce}'`,
+  `style-src ${webview.cspSource} 'unsafe-inline'`,
+  `img-src ${webview.cspSource} data:`,
   `font-src ${webview.cspSource}`,
-  `connect-src https://*`,
+  `connect-src ${webview.cspSource}`,
 ];
 
 export function initBaseContent(webView: Webview, initialIdeContext: IdeContextType) {
+  const scriptNonce = nonce();
   const scriptUri = getUri(webView, 'cs-cwf', 'assets', 'index.js');
   const stylesUri = getUri(webView, 'cs-cwf', 'assets', 'index.css');
-  const csp = getCsp(webView);
+  const csp = getCsp(webView, scriptNonce);
 
   // The full html with all previous varaibles included
   return /*html*/ `<!DOCTYPE html>
@@ -153,11 +154,11 @@ export function initBaseContent(webView: Webview, initialIdeContext: IdeContextT
       <link rel="stylesheet" type="text/css" href="${stylesUri}">
       <title>VSCode React Webview</title>
       ${ideStylesVars}
-      ${initialDataContextScriptTag(initialIdeContext)}
+      ${initialDataContextScriptTag(initialIdeContext, scriptNonce)}
     </head>
     <body>
       <div id="root"></div>
-      <script type="module" src="${scriptUri}"></script>
+      <script type="module" nonce="${scriptNonce}" src="${scriptUri}"></script>
     </body>
   </html>`;
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -178,6 +178,20 @@ const vscodeStub = {
       toString: () => path,
       toJSON: () => ({ scheme: 'file', path }),
     }),
+    joinPath: (base: any, ...segments: string[]) => {
+      const joined = [base.toString(), ...segments].join('/');
+      return {
+        scheme: 'file',
+        authority: '',
+        path: joined,
+        query: '',
+        fragment: '',
+        fsPath: joined,
+        with: () => ({}),
+        toString: () => joined,
+        toJSON: () => ({ scheme: 'file', path: joined }),
+      };
+    },
   },
 };
 

--- a/src/test/suite/cwf-html-utils.test.ts
+++ b/src/test/suite/cwf-html-utils.test.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import {
+  generateContextScriptTag,
+  getCsp,
+  initialDataContextScriptTag,
+} from '../../centralized-webview-framework/cwf-html-utils';
+
+suite('cwf-html-utils Test Suite', () => {
+  const fakeWebview = { cspSource: 'vscode-resource:' } as any;
+
+  test('getCsp uses provided nonce and restrictive directives', () => {
+    const csp = getCsp(fakeWebview, 'abc123');
+    assert.deepStrictEqual(csp, [
+      `default-src 'none';`,
+      `script-src vscode-resource: 'nonce-abc123'`,
+      `style-src vscode-resource: 'unsafe-inline'`,
+      `img-src vscode-resource: data:`,
+      `font-src vscode-resource:`,
+      `connect-src vscode-resource:`,
+    ]);
+  });
+
+  test('initialDataContextScriptTag escapes HTML-sensitive characters and applies nonce', () => {
+    const html = initialDataContextScriptTag({ payload: '</script><img src=x>&' } as any, 'n1');
+    assert.ok(html.includes('<script nonce="n1">'));
+    assert.ok(html.includes('\\u003c/script\\u003e\\u003cimg src=x\\u003e\\u0026'));
+    assert.ok(!html.includes('</script><img'));
+  });
+
+  test('generateContextScriptTag escapes HTML-sensitive characters and applies nonce', () => {
+    const html = generateContextScriptTag({ payload: '<&>' } as any, 'n2');
+    assert.ok(html.includes('<script nonce="n2">'));
+    assert.ok(html.includes('\\u003c\\u0026\\u003e'));
+  });
+});

--- a/src/test/suite/cwf-html-utils.test.ts
+++ b/src/test/suite/cwf-html-utils.test.ts
@@ -2,11 +2,16 @@ import * as assert from 'assert';
 import {
   generateContextScriptTag,
   getCsp,
+  initBaseContent,
   initialDataContextScriptTag,
 } from '../../centralized-webview-framework/cwf-html-utils';
+import { CsExtensionState } from '../../cs-extension-state';
 
 suite('cwf-html-utils Test Suite', () => {
-  const fakeWebview = { cspSource: 'vscode-resource:' } as any;
+  const fakeWebview = {
+    cspSource: 'vscode-resource:',
+    asWebviewUri: (uri: any) => uri.toString(),
+  } as any;
 
   test('getCsp uses provided nonce and restrictive directives', () => {
     const csp = getCsp(fakeWebview, 'abc123');
@@ -31,5 +36,20 @@ suite('cwf-html-utils Test Suite', () => {
     const html = generateContextScriptTag({ payload: '<&>' } as any, 'n2');
     assert.ok(html.includes('<script nonce="n2">'));
     assert.ok(html.includes('\\u003c\\u0026\\u003e'));
+  });
+
+  test('initBaseContent produces valid HTML with nonce and CSP', () => {
+    // Set up CsExtensionState with a fake extensionUri
+    (CsExtensionState as any)._instance = { extensionUri: { toString: () => '/ext' } };
+
+    const html = initBaseContent(fakeWebview, {} as any);
+    assert.ok(html.includes('<!DOCTYPE html>'));
+    assert.ok(html.includes('Content-Security-Policy'));
+    assert.ok(html.includes("default-src 'none';"));
+    assert.ok(/nonce="[A-Za-z0-9]+"/.test(html));
+    // Verify nonce is consistent across script tags
+    const nonces = html.match(/nonce="([A-Za-z0-9]+)"/g)!;
+    assert.ok(nonces.length >= 2);
+    assert.strictEqual(nonces[0], nonces[1]);
   });
 });


### PR DESCRIPTION
## Summary

The CWF webview CSP was overly permissive (`'unsafe-eval'`, `'unsafe-inline'`, `https://*`) — effectively disabling XSS containment in the Home / Docs / ACE panels.

This PR tightens the CSP and fixes an inline script injection vector.

## Changes

### CS-11184: Tighten CSP

- Remove `'unsafe-eval'`, `'unsafe-inline'`, and `https://*` from `script-src`
- Add nonce-based script loading (generated per render)
- Tighten `style-src` (keep `'unsafe-inline'` for VS Code theme vars, drop `https://*`)
- Tighten `img-src` to `cspSource` + `data:` only
- Tighten `connect-src` to `cspSource` only
- Add `nonce` attribute to both inline and module script tags

### CS-11185: Escape JSON in inline script tags

- Add `safeJsonStringify()` that replaces `<`, `>`, `&` with Unicode escapes after `JSON.stringify`
- Prevents script breakout if user-controlled fields (filenames, branch names, error messages) contain `</script>`

## Validation

- `npm run build` (typecheck + lint + bundle)
- Manual F5 test: CWF panel renders, no CSP violations in DevTools console