### PR TITLE
CS-11398: run pretest explicitly before test and coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Configure Git
       run: git config --global advice.defaultBranchName false
 
+    - name: Pretest
+      run: npm run pretest
+      env:
+        CI: true
+
     - name: Generate code coverage
       run: npm run test:coverage
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,10 @@ jobs:
     - name: Configure Git
       run: git config --global advice.defaultBranchName false
 
+    - run: npm run pretest
+      env:
+        CI: true
+
     - run: npm test
       env:
         CI: true


### PR DESCRIPTION
## Summary
CI tests started failing after `ignore-scripts=true` was added to `.npmrc`, because npm lifecycle hooks (including `pretest`) are skipped in CI.

This PR makes the pretest step explicit in workflows so test artifacts are always generated before running tests.

## Changes
- Added `npm run pretest` before `npm test` in `.github/workflows/test.yml`
- Added `npm run pretest` before `npm run test:coverage` in `.github/workflows/code-coverage.yml`

## Why this fix
Relying on npm hook chaining is brittle when scripts are intentionally disabled. Running `pretest` explicitly keeps `.npmrc` hardening in place while restoring deterministic CI behavior.

## Ticket
- https://app.clickup.com/t/9015696197/CS-11398