### PR TITLE
feat: improve baseline branch detection (CS-11401)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ The **Code Health Monitor** flags for drops in code health in real time and offe
 | **Problems View** | When a file is opened in the editor, it is instantly scanned for existing Code Health issues. All discovered issues are then listed in the IDE Problems View. This way you instantly get an overview of all opportunities a file has for improvements. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/problems.png" alt="Problem View" width="2000px"/> |
 | **Custom Code Health rules** | To customize the code analysis you can either use local [Code Comment Directives](https://codescene.io/docs/guides/technical/code-health.html#disable-local-smells-via-code-comment-directives) or create a `code-health-rules.json` file which applies to the entire project. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/custom_directive.png" alt="ACR" width="2000px"/> |
 
+For delta analysis against a specific baseline branch (for example `develop` in a Git-flow repo), add `.codescene/config.json` at the repository root:
+
+```json
+{
+  "baseline_branch": "develop"
+}
+```
+
+When this file is absent, the extension uses the remote default branch (`origin/HEAD`) if available, otherwise common branch names such as `main` and `master`.
+
 
 _* Available time-limited for non CodeScene customers._
 

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -17,6 +17,7 @@ import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
 
 let gitApi: API | undefined;
+let gitChangeListerInstance: GitChangeLister | undefined;
 
 const clearTreeEmitter = new vscode.EventEmitter<void>();
 export const onTreeDataCleared = clearTreeEmitter.event;
@@ -54,13 +55,13 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
   // Review all changed/added files every 9 seconds.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
   // because `CsDiagnostics.review` has built-in caching.
-  const gitChangeLister = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
+  gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
   const scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
 
   void scheduledExecutor.executeTask(async () => {
     if (!isGitAvailable()) return;
     logOutputChannel.info('Starting scheduled git change review');
-    await gitChangeLister.start();
+    await gitChangeListerInstance!.start();
   });
 
   const codeHealthMonitorHelpCommand = vscode.commands.registerCommand('codescene.codeHealthMonitorHelp', () => {
@@ -125,7 +126,26 @@ function setBaseline(repo: Repository) {
   });
 }
 
+/** Refreshes review baselines for all open repositories after main-branch detection changes. */
+export function refreshMergeBaseBaselines(): void {
+  if (!gitApi) {
+    return;
+  }
+  for (const repo of gitApi.repositories) {
+    setBaseline(repo);
+  }
+}
+
+/** Re-scans git changes vs merge-base (e.g. after .codescene/config.json edit). */
+export async function runGitChangeLister(): Promise<void> {
+  if (!gitChangeListerInstance || !isGitAvailable()) {
+    return;
+  }
+  await gitChangeListerInstance.start();
+}
+
 export function deactivate() {
   ALL_DISPOSABLES.forEach((disposable) => disposable.dispose());
   ALL_DISPOSABLES = [];
+  gitChangeListerInstance = undefined;
 }

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
 }
 
 export function getRepo(fileUri: Uri): Repository | null {
-  if (!gitApi || !CsExtensionState.baseline) return null;
+  if (!gitApi || !CsExtensionState.hasInstance) return null;
 
   return gitApi!.getRepository(fileUri);
 }
@@ -148,4 +148,5 @@ export function deactivate() {
   ALL_DISPOSABLES.forEach((disposable) => disposable.dispose());
   ALL_DISPOSABLES = [];
   gitChangeListerInstance = undefined;
+  gitApi = undefined;
 }

--- a/src/cs-extension-state.ts
+++ b/src/cs-extension-state.ts
@@ -87,6 +87,10 @@ export class CsExtensionState {
     CsExtensionState._instance = new CsExtensionState(context);
   }
 
+  static get hasInstance(): boolean {
+    return !!this._instance;
+  }
+
   static get acknowledgedAceUsage() {
     return this._instance.context.globalState.get<boolean>(acknowledgedAceUsageKey);
   }

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -35,8 +35,7 @@ import { registerCopyDeviceIdCommand } from './device-id';
 import { GitChangeObserver } from './git/git-change-observer';
 import { OpenFilesObserver } from './review/open-files-observer';
 import { acquireGitApi, clearMainBranchCandidatesCache, deactivate as deactivateGitUtils, fireFileDeletedFromGit } from './git-utils';
-import { CODE_SCENE_DIR } from './git/codescene-repo-config';
-import path from 'path';
+import { gitRootFromCodesceneConfigUri } from './git/codescene-repo-config';
 import { DroppingScheduledExecutor } from './dropping-scheduled-executor';
 import { SimpleExecutor } from './simple-executor';
 import { getHomeViewInstance } from './code-health-monitor/home/home-view';
@@ -78,16 +77,8 @@ const onCodeHealthFileVersionChange = debounce(() => {
   });
 }, 350);
 
-function gitRootFromCodesceneFileUri(uri: vscode.Uri): string | undefined {
-  const codesceneDirPath = path.dirname(uri.fsPath);
-  if (path.basename(codesceneDirPath) !== CODE_SCENE_DIR) {
-    return undefined;
-  }
-  return path.dirname(codesceneDirPath);
-}
-
 const onCodesceneConfigChange = debounce((uri: vscode.Uri) => {
-  const gitRoot = gitRootFromCodesceneFileUri(uri);
+  const gitRoot = gitRootFromCodesceneConfigUri(uri);
   if (gitRoot) {
     clearMainBranchCandidatesCache(gitRoot);
   } else {

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -5,6 +5,8 @@ import {
   activate as activateCHMonitor,
   deactivate as deactivateAddon,
   getBaselineCommit,
+  refreshMergeBaseBaselines,
+  runGitChangeLister,
 } from './code-health-monitor/addon';
 import { refreshCodeHealthDetailsView } from './code-health-monitor/details/view';
 import { register as registerCHRulesCommands } from './code-health-rules';
@@ -32,7 +34,9 @@ import debounce = require('lodash.debounce');
 import { registerCopyDeviceIdCommand } from './device-id';
 import { GitChangeObserver } from './git/git-change-observer';
 import { OpenFilesObserver } from './review/open-files-observer';
-import { acquireGitApi, deactivate as deactivateGitUtils, fireFileDeletedFromGit } from './git-utils';
+import { acquireGitApi, clearMainBranchCandidatesCache, deactivate as deactivateGitUtils, fireFileDeletedFromGit } from './git-utils';
+import { CODE_SCENE_DIR } from './git/codescene-repo-config';
+import path from 'path';
 import { DroppingScheduledExecutor } from './dropping-scheduled-executor';
 import { SimpleExecutor } from './simple-executor';
 import { getHomeViewInstance } from './code-health-monitor/home/home-view';
@@ -69,6 +73,43 @@ const onCodeHealthFileVersionChange = debounce(() => {
       },
       (e) => {
         logOutputChannel.warn(`Failed to re-review file after rules change: ${filePath}`, e);
+      }
+    );
+  });
+}, 350);
+
+function gitRootFromCodesceneFileUri(uri: vscode.Uri): string | undefined {
+  const codesceneDirPath = path.dirname(uri.fsPath);
+  if (path.basename(codesceneDirPath) !== CODE_SCENE_DIR) {
+    return undefined;
+  }
+  return path.dirname(codesceneDirPath);
+}
+
+const onCodesceneConfigChange = debounce((uri: vscode.Uri) => {
+  const gitRoot = gitRootFromCodesceneFileUri(uri);
+  if (gitRoot) {
+    clearMainBranchCandidatesCache(gitRoot);
+  } else {
+    clearMainBranchCandidatesCache();
+  }
+
+  refreshMergeBaseBaselines();
+  void runGitChangeLister();
+
+  if (!openFilesObserverInstance) {
+    return;
+  }
+
+  const visibleFiles = openFilesObserverInstance.getAllVisibleFileNames();
+  visibleFiles.forEach((filePath) => {
+    const fileUri = vscode.Uri.file(filePath);
+    void vscode.workspace.openTextDocument(fileUri).then(
+      (document) => {
+        CsDiagnostics.review(document, { skipMonitorUpdate: true, updateDiagnosticsPane: true });
+      },
+      (e) => {
+        logOutputChannel.warn(`Failed to re-review file after config change: ${filePath}`, e);
       }
     );
   });
@@ -297,6 +338,15 @@ function addReviewListeners(context: vscode.ExtensionContext) {
 
   DISPOSABLES.push(rulesFileWatcher);
   context.subscriptions.push(rulesFileWatcher);
+
+  const configFileWatcher = vscode.workspace.createFileSystemWatcher('**/.codescene/config.json');
+
+  configFileWatcher.onDidChange((uri) => onCodesceneConfigChange(uri));
+  configFileWatcher.onDidCreate((uri) => onCodesceneConfigChange(uri));
+  configFileWatcher.onDidDelete((uri) => onCodesceneConfigChange(uri));
+
+  DISPOSABLES.push(configFileWatcher);
+  context.subscriptions.push(configFileWatcher);
 }
 
 /**

--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -5,6 +5,7 @@ import { GitExtension, Repository } from '../types/git';
 import { QueuedSingleTaskExecutor } from './queued-single-task-executor';
 import { logOutputChannel } from './log';
 import { markGitAsUnavailable } from './git/git-detection';
+import { getBaselineBranch } from './git/codescene-repo-config';
 
 export const GIT_TASK_ID = 'git';
 export const gitExecutor = new QueuedSingleTaskExecutor();
@@ -12,8 +13,16 @@ const gitFileDeleteEvent = new vscode.EventEmitter<string>();
 export const onFileDeletedFromGit = gitFileDeleteEvent.event;
 export const fireFileDeletedFromGit = (filePath: string) => gitFileDeleteEvent.fire(filePath);
 
+const POSSIBLE_MAIN_BRANCHES = ['main', 'master', 'develop', 'trunk', 'dev', 'development'];
+const ORIGIN_HEAD_REF = 'refs/remotes/origin/HEAD';
+const ORIGIN_REMOTE_PREFIX = 'refs/remotes/origin/';
+
 function isEnoentError(err: unknown): boolean {
   return (err as any)?.code === 'ENOENT';
+}
+
+function branchesEqual(a: string, b: string): boolean {
+  return a.localeCompare(b, undefined, { sensitivity: 'accent' }) === 0;
 }
 
 interface RepoState {
@@ -51,54 +60,105 @@ export function getWorkspacePath(workspaceFolder: vscode.WorkspaceFolder): strin
 
 const mainBranchCandidatesCache = new Map<string, string[]>();
 
+export function clearMainBranchCandidatesCache(gitRootPath?: string): void {
+  if (!gitRootPath) {
+    mainBranchCandidatesCache.clear();
+    return;
+  }
+  mainBranchCandidatesCache.delete(path.normalize(gitRootPath));
+}
+
 /**
- * Returns the branch names that look like the main branch AND do in fact exist.
+ * Resolves the repository default branch: config baseline_branch, then origin/HEAD, then undefined.
+ */
+export async function getDefaultBranch(repoPath: string): Promise<string | undefined> {
+  const normalizedPath = path.normalize(repoPath);
+
+  const configured = getBaselineBranch(normalizedPath);
+  if (configured) {
+    return configured;
+  }
+
+  try {
+    const { stdout, exitCode } = await gitExecutor.execute(
+      { command: 'git', args: ['symbolic-ref', ORIGIN_HEAD_REF], taskId: GIT_TASK_ID },
+      { cwd: normalizedPath }
+    );
+
+    if (exitCode !== 0) {
+      return undefined;
+    }
+
+    const target = stdout.trim();
+    if (target.startsWith(ORIGIN_REMOTE_PREFIX)) {
+      return target.substring(ORIGIN_REMOTE_PREFIX.length);
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns main branch candidates for merge-base selection.
+ * When a default branch is known, returns only that branch; otherwise static names present locally.
  */
 export async function getMainBranchCandidates(repoPath: string): Promise<string[]> {
-  const cached = mainBranchCandidatesCache.get(repoPath);
+  const normalizedPath = path.normalize(repoPath);
+  const cached = mainBranchCandidatesCache.get(normalizedPath);
   if (cached) {
     return cached;
   }
 
-  const possibleMainBranches = ['main', 'master', 'develop', 'trunk', 'dev', 'development'];
+  const defaultBranch = await getDefaultBranch(normalizedPath);
+  if (defaultBranch) {
+    const singleCandidate = [defaultBranch];
+    mainBranchCandidatesCache.set(normalizedPath, singleCandidate);
+    return singleCandidate;
+  }
 
   try {
     const { stdout, stderr, exitCode } = await gitExecutor.execute(
       { command: 'git', args: ['branch', '--list', '--format=%(refname:short)'], taskId: GIT_TASK_ID },
-      { cwd: repoPath }
+      { cwd: normalizedPath }
     );
 
     if (exitCode !== 0) {
       if (exitCode === "ENOENT") {
         markGitAsUnavailable();
       }
-      logOutputChannel.error(`Could not get local branches for ${repoPath} (exit code ${exitCode}): ${stderr}`);
+      logOutputChannel.error(`Could not get local branches for ${normalizedPath} (exit code ${exitCode}): ${stderr}`);
       return [];
     }
 
     const localBranches = stdout.split('\n').map(branch => branch.trim()).filter(Boolean);
-    const result = possibleMainBranches.filter(branch => localBranches.includes(branch));
-    mainBranchCandidatesCache.set(repoPath, result);
+    const result = POSSIBLE_MAIN_BRANCHES.filter(branch => localBranches.includes(branch));
+    mainBranchCandidatesCache.set(normalizedPath, result);
     return result;
   } catch (err) {
     if (isEnoentError(err)) {
       markGitAsUnavailable();
     }
-    logOutputChannel.error(`Could not get local branches for ${repoPath}: ${err}`);
+    logOutputChannel.error(`Could not get local branches for ${normalizedPath}: ${err}`);
     return [];
   }
 }
 
 /**
- * Determines if the given branch could be the default branch.
- *
- * Checks against locally present main branch names (main, master, develop, trunk, dev, development).
+ * Determines if the given branch is the repository default / main branch.
  */
 export async function isMainBranch(currentBranch: string | undefined, repoPath: string): Promise<boolean> {
   if (!currentBranch) return false;
 
-  const localMainBranches = await getMainBranchCandidates(repoPath);
-  return localMainBranches.includes(currentBranch);
+  const normalizedPath = path.normalize(repoPath);
+  const defaultBranch = await getDefaultBranch(normalizedPath);
+  if (defaultBranch) {
+    return branchesEqual(currentBranch, defaultBranch);
+  }
+
+  const localMainBranches = await getMainBranchCandidates(normalizedPath);
+  return localMainBranches.some((branch) => branchesEqual(branch, currentBranch));
 }
 
 /**

--- a/src/git/codescene-repo-config.ts
+++ b/src/git/codescene-repo-config.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+
+export const CODE_SCENE_DIR = '.codescene';
+export const CONFIG_FILE_NAME = 'config.json';
+
+interface CodesceneConfigModel {
+  baseline_branch?: string;
+}
+
+/**
+ * Reads optional baseline_branch from {gitRoot}/.codescene/config.json.
+ */
+export function getBaselineBranch(gitRootPath: string | undefined): string | undefined {
+  if (!gitRootPath) {
+    return undefined;
+  }
+
+  const configPath = path.join(
+    gitRootPath.replace(/[/\\]+$/, ''),
+    CODE_SCENE_DIR,
+    CONFIG_FILE_NAME
+  );
+
+  if (!fs.existsSync(configPath)) {
+    return undefined;
+  }
+
+  try {
+    const json = fs.readFileSync(configPath, 'utf8');
+    const model = JSON.parse(json) as CodesceneConfigModel;
+    const branch = model?.baseline_branch?.trim();
+    return branch || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/git/codescene-repo-config.ts
+++ b/src/git/codescene-repo-config.ts
@@ -8,6 +8,15 @@ interface CodesceneConfigModel {
   baseline_branch?: string;
 }
 
+/** Derives the git repository root from a `.codescene/*` file URI. */
+export function gitRootFromCodesceneConfigUri(uri: { fsPath: string }): string | undefined {
+  const codesceneDirPath = path.dirname(uri.fsPath);
+  if (path.basename(codesceneDirPath) !== CODE_SCENE_DIR) {
+    return undefined;
+  }
+  return path.dirname(codesceneDirPath);
+}
+
 /**
  * Reads optional baseline_branch from {gitRoot}/.codescene/config.json.
  */

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -111,7 +111,7 @@ export class GitChangeLister {
     if (!baseCommit) {
       const currentBranch = repo?.state.HEAD?.name;
       if (currentBranch){
-        const isMain = await isMainBranch(currentBranch, workspacePath);
+        const isMain = await isMainBranch(currentBranch, gitRootPath);
 
         if (!isMain) {
           logOutputChannel.warn('Could not determine merge-base commit');

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -38,7 +38,42 @@ export function restoreDefaultWorkspaceFolders() {
   vscodeStub.workspace.workspaceFolders = defaultWorkspaceFolders as any;
 }
 
+let mockGitRepositories: any[] = [];
+
+export function setMockGitRepositories(repos: any[]) {
+  mockGitRepositories = repos;
+}
+
+export function clearMockGitRepositories() {
+  mockGitRepositories = [];
+}
+
+function createMockGitApi() {
+  return {
+    repositories: mockGitRepositories,
+    getRepository: (uri: { fsPath?: string; path?: string }) => {
+      const fsPath = uri.fsPath || uri.path || '';
+      return mockGitRepositories.find((repo) => fsPath.startsWith(repo.rootUri.fsPath)) || null;
+    },
+  };
+}
+
 const vscodeStub = {
+  extensions: {
+    getExtension: (id: string) => {
+      if (id === 'vscode.git') {
+        return {
+          exports: {
+            getAPI: (version: number) => {
+              void version;
+              return createMockGitApi();
+            },
+          },
+        };
+      }
+      return undefined;
+    },
+  },
   window: {
     createOutputChannel: (name: string) => ({
       append: (text: string) => enableTestLogging && process.stdout.write(`[${name}] ${text}`),
@@ -57,13 +92,40 @@ const vscodeStub = {
     showErrorMessage: (message: string, ...items: any[]) => Promise.resolve(undefined),
     showInformationMessage: (message: string, ...items: any[]) => Promise.resolve(undefined),
     showWarningMessage: (message: string, ...items: any[]) => Promise.resolve(undefined),
+    registerWebviewViewProvider: (id: string, provider: any) => {
+      void id;
+      void provider;
+      return { dispose: () => {} };
+    },
+    createTreeView: (id: string, opts: any) => {
+      void id;
+      void opts;
+      return {
+      badge: undefined,
+      dispose: () => {},
+    };
+    },
+    createStatusBarItem: () => ({
+      text: '',
+      tooltip: '',
+      command: '',
+      backgroundColor: undefined,
+      show: () => {},
+      hide: () => {},
+      dispose: () => {},
+    }),
   },
+  StatusBarAlignment: { Left: 1, Right: 2 },
   commands: {
     registerCommand: () => ({ dispose: () => {} }),
     executeCommand: () => Promise.resolve(),
   },
   workspace: {
     workspaceFolders: defaultWorkspaceFolders as any,
+    onDidChangeConfiguration: (listener: any) => {
+      void listener;
+      return { dispose: () => {} };
+    },
     createFileSystemWatcher: () => ({
       onDidCreate: () => ({ dispose: () => {} }),
       onDidChange: () => ({ dispose: () => {} }),
@@ -128,6 +190,9 @@ const vscodeStub = {
       dispose: () => {},
     }),
     registerCodeActionsProvider: () => ({
+      dispose: () => {}
+    }),
+    registerCodeLensProvider: () => ({
       dispose: () => {}
     }),
   },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,6 +8,8 @@ import { SelectionStub } from './stubs/selection-stub';
 import { WorkspaceEditStub } from './stubs/workspace-edit-stub';
 import { CodeActionStub } from './stubs/code-action-stub';
 import { ThemeColorStub } from './stubs/theme-color-stub';
+import { ThemeIconStub } from './stubs/theme-icon-stub';
+import { TreeItemStub } from './stubs/tree-item-stub';
 
 export let enableTestLogging = false;
 export function setEnableTestLogging(value: boolean) {
@@ -210,6 +212,9 @@ const vscodeStub = {
     Hint: 3,
   },
   ThemeColor: ThemeColorStub,
+  TreeItem: TreeItemStub,
+  TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+  ThemeIcon: ThemeIconStub,
   CodeActionKind: {
     QuickFix: 'quickfix',
     Refactor: 'refactor',

--- a/src/test/stubs/theme-icon-stub.ts
+++ b/src/test/stubs/theme-icon-stub.ts
@@ -1,0 +1,3 @@
+export class ThemeIconStub {
+  constructor(public id: string) {}
+}

--- a/src/test/stubs/tree-item-stub.ts
+++ b/src/test/stubs/tree-item-stub.ts
@@ -1,0 +1,17 @@
+export class TreeItemStub {
+  label?: string;
+  collapsibleState?: number;
+  iconPath?: unknown;
+  tooltip?: string;
+  command?: unknown;
+  resourceUri?: unknown;
+
+  constructor(label?: string | unknown, collapsibleState?: number) {
+    if (typeof label === 'string') {
+      this.label = label;
+    } else if (label && typeof label === 'object') {
+      this.resourceUri = label;
+    }
+    this.collapsibleState = collapsibleState;
+  }
+}

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -1,0 +1,141 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { Uri } from 'vscode';
+import {
+  activate as activateCodeHealthMonitor,
+  deactivate as deactivateCodeHealthMonitor,
+  refreshMergeBaseBaselines,
+  runGitChangeLister,
+} from '../../code-health-monitor/addon';
+import { CsExtensionState } from '../../cs-extension-state';
+import { DevtoolsAPI } from '../../devtools-api';
+import Reviewer from '../../review/reviewer';
+import { GitChangeLister } from '../../git/git-change-lister';
+import { markGitAsUnavailable, resetGitAvailability } from '../../git/git-detection';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import { setMockGitRepositories, clearMockGitRepositories, mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
+import { ensureBinary } from '../integration_helper';
+
+suite('Code Health Monitor Addon Test Suite', () => {
+  let mockContext: ReturnType<typeof createMockExtensionContext>;
+  const repoRoot = path.join(__dirname, '../../../test-git-repo-addon');
+
+  function createMockRepo(rootPath: string = repoRoot) {
+    return {
+      rootUri: Uri.file(rootPath),
+      state: {
+        HEAD: { name: 'main', commit: 'abc123' },
+        refs: [],
+        remotes: [],
+        submodules: [],
+        rebaseCommit: undefined,
+        mergeChanges: [],
+        indexChanges: [],
+        workingTreeChanges: [],
+        untrackedChanges: [],
+        onDidChange: () => ({ dispose: () => {} }),
+      },
+    };
+  }
+
+  suiteSetup(async function () {
+    this.timeout(60000);
+    const binaryPath = await ensureBinary();
+    mockContext = createMockExtensionContext(repoRoot);
+    CsExtensionState.init(mockContext);
+    Reviewer.init(mockContext, async () => undefined, () => new Map());
+    DevtoolsAPI.init(binaryPath, mockContext);
+  });
+
+  setup(() => {
+    resetGitAvailability();
+    clearMockGitRepositories();
+    mockWorkspaceFolders([createMockWorkspaceFolder(repoRoot)]);
+  });
+
+  teardown(() => {
+    deactivateCodeHealthMonitor();
+    resetGitAvailability();
+    clearMockGitRepositories();
+    restoreDefaultWorkspaceFolders();
+  });
+
+  test('refreshMergeBaseBaselines is a no-op when git API is unavailable', () => {
+    refreshMergeBaseBaselines();
+  });
+
+  test('runGitChangeLister is a no-op before code health monitor activation', async () => {
+    await runGitChangeLister();
+  });
+
+  test('refreshMergeBaseBaselines updates review baselines for all repositories', () => {
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+
+    let setBaselineCalls = 0;
+    const originalSetBaseline = Reviewer.instance.setBaseline.bind(Reviewer.instance);
+    Reviewer.instance.setBaseline = (fileFilter) => {
+      setBaselineCalls += 1;
+      return originalSetBaseline(fileFilter);
+    };
+
+    refreshMergeBaseBaselines();
+
+    assert.strictEqual(setBaselineCalls, 1);
+    Reviewer.instance.setBaseline = originalSetBaseline;
+  });
+
+  test('runGitChangeLister invokes lister after activation', async function () {
+    this.timeout(20000);
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+
+    let startCalled = false;
+    const originalStart = GitChangeLister.prototype.start;
+    GitChangeLister.prototype.start = async function () {
+      startCalled = true;
+      return originalStart.call(this);
+    };
+
+    await runGitChangeLister();
+
+    assert.strictEqual(startCalled, true);
+    GitChangeLister.prototype.start = originalStart;
+  });
+
+  test('runGitChangeLister is a no-op when git is unavailable', async () => {
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    markGitAsUnavailable();
+
+    let startCalled = false;
+    const originalStart = GitChangeLister.prototype.start;
+    GitChangeLister.prototype.start = async function () {
+      startCalled = true;
+      return originalStart.call(this);
+    };
+
+    await runGitChangeLister();
+
+    assert.strictEqual(startCalled, false);
+    GitChangeLister.prototype.start = originalStart;
+  });
+
+  test('deactivate clears git change lister instance', async () => {
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    deactivateCodeHealthMonitor();
+
+    let startCalled = false;
+    const originalStart = GitChangeLister.prototype.start;
+    GitChangeLister.prototype.start = async function () {
+      startCalled = true;
+      return originalStart.call(this);
+    };
+
+    await runGitChangeLister();
+
+    assert.strictEqual(startCalled, false);
+    GitChangeLister.prototype.start = originalStart;
+  });
+});

--- a/src/test/suite/codescene-repo-config.test.ts
+++ b/src/test/suite/codescene-repo-config.test.ts
@@ -5,6 +5,7 @@ import {
   CODE_SCENE_DIR,
   CONFIG_FILE_NAME,
   getBaselineBranch,
+  gitRootFromCodesceneConfigUri,
 } from '../../git/codescene-repo-config';
 
 suite('Codescene Repo Config Test Suite', () => {
@@ -51,5 +52,17 @@ suite('Codescene Repo Config Test Suite', () => {
 
   test('getBaselineBranch when git root undefined returns undefined', () => {
     assert.strictEqual(getBaselineBranch(undefined), undefined);
+  });
+
+  test('gitRootFromCodesceneConfigUri returns repo root for config path', () => {
+    const configPath = path.join(gitRootPath, CODE_SCENE_DIR, CONFIG_FILE_NAME);
+    assert.strictEqual(gitRootFromCodesceneConfigUri({ fsPath: configPath }), gitRootPath);
+  });
+
+  test('gitRootFromCodesceneConfigUri returns undefined for non-codescene path', () => {
+    assert.strictEqual(
+      gitRootFromCodesceneConfigUri({ fsPath: path.join(gitRootPath, 'src', 'file.ts') }),
+      undefined
+    );
   });
 });

--- a/src/test/suite/codescene-repo-config.test.ts
+++ b/src/test/suite/codescene-repo-config.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  CODE_SCENE_DIR,
+  CONFIG_FILE_NAME,
+  getBaselineBranch,
+} from '../../git/codescene-repo-config';
+
+suite('Codescene Repo Config Test Suite', () => {
+  let gitRootPath: string;
+  let configPath: string;
+
+  setup(() => {
+    gitRootPath = path.join(__dirname, `../../../test-codescene-config-${Date.now()}`);
+    const codesceneDir = path.join(gitRootPath, CODE_SCENE_DIR);
+    fs.mkdirSync(codesceneDir, { recursive: true });
+    configPath = path.join(codesceneDir, CONFIG_FILE_NAME);
+  });
+
+  teardown(() => {
+    if (fs.existsSync(gitRootPath)) {
+      fs.rmSync(gitRootPath, { recursive: true, force: true });
+    }
+  });
+
+  test('getBaselineBranch when file missing returns undefined', () => {
+    assert.ok(!fs.existsSync(configPath));
+    assert.strictEqual(getBaselineBranch(gitRootPath), undefined);
+  });
+
+  test('getBaselineBranch when valid returns branch name', () => {
+    fs.writeFileSync(configPath, '{"baseline_branch":"develop"}');
+    assert.strictEqual(getBaselineBranch(gitRootPath), 'develop');
+  });
+
+  test('getBaselineBranch when whitespace only returns undefined', () => {
+    fs.writeFileSync(configPath, '{"baseline_branch":" "}');
+    assert.strictEqual(getBaselineBranch(gitRootPath), undefined);
+  });
+
+  test('getBaselineBranch when invalid json returns undefined', () => {
+    fs.writeFileSync(configPath, 'not json');
+    assert.strictEqual(getBaselineBranch(gitRootPath), undefined);
+  });
+
+  test('getBaselineBranch when property missing returns undefined', () => {
+    fs.writeFileSync(configPath, '{"other":"value"}');
+    assert.strictEqual(getBaselineBranch(gitRootPath), undefined);
+  });
+
+  test('getBaselineBranch when git root undefined returns undefined', () => {
+    assert.strictEqual(getBaselineBranch(undefined), undefined);
+  });
+});

--- a/src/test/suite/git-utils.test.ts
+++ b/src/test/suite/git-utils.test.ts
@@ -3,7 +3,14 @@ import { execSync } from 'child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import { Uri } from 'vscode';
-import { getMergeBaseCommit } from '../../git-utils';
+import {
+  clearMainBranchCandidatesCache,
+  getDefaultBranch,
+  getMainBranchCandidates,
+  getMergeBaseCommit,
+  isMainBranch,
+} from '../../git-utils';
+import { CODE_SCENE_DIR, CONFIG_FILE_NAME } from '../../git/codescene-repo-config';
 import { Repository, RepositoryState, Branch, RepositoryUIState } from '../../../types/git';
 
 suite('Git Utils Test Suite', () => {
@@ -116,6 +123,82 @@ suite('Git Utils Test Suite', () => {
     return await getMergeBaseCommit(repo);
   }
 
+  function setupOriginHead(defaultBranch: string): void {
+    const branchSha = execSync(`git rev-parse ${defaultBranch}`, { cwd: testRepoPath }).toString().trim();
+    execSync(`git update-ref refs/remotes/origin/${defaultBranch} ${branchSha}`, {
+      cwd: testRepoPath,
+      stdio: 'pipe',
+    });
+    execSync(`git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/${defaultBranch}`, {
+      cwd: testRepoPath,
+      stdio: 'pipe',
+    });
+  }
+
+  function writeBaselineConfig(branch: string): void {
+    const codesceneDir = path.join(testRepoPath, CODE_SCENE_DIR);
+    fs.mkdirSync(codesceneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codesceneDir, CONFIG_FILE_NAME),
+      JSON.stringify({ baseline_branch: branch })
+    );
+    clearMainBranchCandidatesCache(testRepoPath);
+  }
+
+  suite('main branch detection', () => {
+    test('getMainBranchCandidates uses origin/HEAD when set', async function () {
+      this.timeout(20000);
+      const mainCommitSha = createBranchWithCommit('main');
+      createBranch('master');
+      commitFile('master.ts', 'export const master = true;', 'Commit on master');
+      switchBranch('main');
+      setupOriginHead('main');
+      clearMainBranchCandidatesCache(testRepoPath);
+
+      const candidates = await getMainBranchCandidates(testRepoPath);
+      assert.deepStrictEqual(candidates, ['main']);
+
+      const featureCommitSha = createFeatureBranch('feature-origin-main');
+      const result = await testMergeBase('feature-origin-main', featureCommitSha);
+      assert.strictEqual(result, mainCommitSha);
+    });
+
+    test('getMainBranchCandidates uses baseline_branch from config', async () => {
+      createBranchWithCommit('develop');
+      createFeatureBranch('feature-on-develop');
+      writeBaselineConfig('develop');
+
+      const candidates = await getMainBranchCandidates(testRepoPath);
+      assert.deepStrictEqual(candidates, ['develop']);
+      assert.strictEqual(await isMainBranch('develop', testRepoPath), true);
+      assert.strictEqual(await isMainBranch('main', testRepoPath), false);
+    });
+
+    test('config baseline_branch overrides origin/HEAD', async function () {
+      this.timeout(20000);
+      createBranchWithCommit('main');
+      createBranch('develop');
+      commitFile('develop.ts', 'export const d = true;', 'develop commit');
+      switchBranch('main');
+      setupOriginHead('main');
+      writeBaselineConfig('develop');
+
+      assert.strictEqual(await getDefaultBranch(testRepoPath), 'develop');
+      const candidates = await getMainBranchCandidates(testRepoPath);
+      assert.deepStrictEqual(candidates, ['develop']);
+    });
+
+    test('clearMainBranchCandidatesCache clears one repo', async function () {
+      this.timeout(20000);
+      createBranchWithCommit('main');
+      await getMainBranchCandidates(testRepoPath);
+      clearMainBranchCandidatesCache(testRepoPath);
+      setupOriginHead('main');
+      const candidates = await getMainBranchCandidates(testRepoPath);
+      assert.deepStrictEqual(candidates, ['main']);
+    });
+  });
+
   suite('getMergeBaseCommit', () => {
     test('returns empty string when currentBranch is undefined', async () => {
       commitFile('README.md', '# Test', 'Initial commit');
@@ -139,8 +222,8 @@ suite('Git Utils Test Suite', () => {
 
     test('returns HEAD commit when on main branch', async () => {
       commitFile('README.md', '# Test', 'Initial commit');
+      renameBranch('main');
       const commitSha = getHeadCommit();
-      createBranch('main');
 
       const result = await testMergeBase('main', commitSha);
 

--- a/src/test/suite/git-utils.test.ts
+++ b/src/test/suite/git-utils.test.ts
@@ -163,7 +163,8 @@ suite('Git Utils Test Suite', () => {
       assert.strictEqual(result, mainCommitSha);
     });
 
-    test('getMainBranchCandidates uses baseline_branch from config', async () => {
+    test('getMainBranchCandidates uses baseline_branch from config', async function () {
+      this.timeout(20000);
       createBranchWithCommit('develop');
       createFeatureBranch('feature-on-develop');
       writeBaselineConfig('develop');
@@ -196,6 +197,22 @@ suite('Git Utils Test Suite', () => {
       setupOriginHead('main');
       const candidates = await getMainBranchCandidates(testRepoPath);
       assert.deepStrictEqual(candidates, ['main']);
+    });
+
+    test('clearMainBranchCandidatesCache clears entire cache when no path given', async function () {
+      this.timeout(20000);
+      createBranchWithCommit('main');
+      await getMainBranchCandidates(testRepoPath);
+      clearMainBranchCandidatesCache();
+
+      setupOriginHead('main');
+      const candidates = await getMainBranchCandidates(testRepoPath);
+      assert.deepStrictEqual(candidates, ['main']);
+    });
+
+    test('getDefaultBranch returns undefined when origin/HEAD is missing', async () => {
+      createBranchWithCommit('main');
+      assert.strictEqual(await getDefaultBranch(testRepoPath), undefined);
     });
   });
 


### PR DESCRIPTION
## Summary
- Resolve delta baseline branch via \.codescene/config.json\ \aseline_branch\, then \origin/HEAD\, then the static fallback list
- Watch \.codescene/config.json\ to clear main-branch cache and refresh merge-base baselines, git monitor reviews, and open editor reviews
- Port behavior from codescene-vs PR #279 for consistent baseline detection across IDE extensions

## Test plan
- [x] Unit tests for \codescene-repo-config\ and extended \git-utils\ (origin/HEAD, config override, cache clear)
- [x] ESLint on touched files
- [x] CodeScene \nalyze_change_set\ quality gates passed
- [x] Manual: repo with \origin/HEAD\ → \main\ and local \master\ uses only \main\ for merge-base
- [x] Manual: \aseline_branch: develop\ in \.codescene/config.json\ overrides \origin/HEAD\
- [x] Manual: editing \config.json\ while VS Code is open refreshes delta baseline

Made with [Cursor](https://cursor.com)