### PR TITLE
fix: hide ACE ad in docs when no auth token (CS-11347)

### DIFF
--- a/src/codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper.ts
+++ b/src/codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper.ts
@@ -18,11 +18,13 @@ export function getAceAcknowledgeData(request: RefactoringRequest): AceAcknowled
 }
 
 export function getAutoRefactorConfig(): AutoRefactorConfig {
-  const data = {
-    disabled: !getAuthToken(),
-    activated: CsExtensionState.acknowledgedAceUsage === true,
+  const hasToken = !!getAuthToken()?.trim();
+  const acknowledged = CsExtensionState.acknowledgedAceUsage === true;
+  const activated = !(!acknowledged && hasToken);
+
+  return {
+    disabled: !hasToken,
+    activated,
     visible: CsExtensionState.stateProperties.features.ace.state === 'enabled',
   };
-
-  return data;
 }

--- a/src/test/suite/ace-acknowledgement-mapper.test.ts
+++ b/src/test/suite/ace-acknowledgement-mapper.test.ts
@@ -1,0 +1,81 @@
+import * as assert from 'assert';
+import * as configModule from '../../configuration';
+import * as csExtensionState from '../../cs-extension-state';
+import { getAutoRefactorConfig } from '../../codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper';
+
+suite('AceAcknowledgementMapper Test Suite', () => {
+  let originalGetAuthToken: typeof configModule.getAuthToken;
+
+  function mockToken(token: string) {
+    (configModule as any).getAuthToken = () => token;
+  }
+
+  function mockAcknowledged(acknowledged: boolean | undefined) {
+    Object.defineProperty(csExtensionState.CsExtensionState, 'acknowledgedAceUsage', {
+      get: () => acknowledged,
+      configurable: true,
+    });
+  }
+
+  setup(() => {
+    originalGetAuthToken = configModule.getAuthToken;
+    Object.defineProperty(csExtensionState.CsExtensionState, 'stateProperties', {
+      get: () => ({
+        features: { ace: { state: 'enabled' } },
+      }),
+      configurable: true,
+    });
+  });
+
+  teardown(() => {
+    (configModule as any).getAuthToken = originalGetAuthToken;
+  });
+
+  test('activated true when acknowledged and token present', () => {
+    mockToken('secret');
+    mockAcknowledged(true);
+    assert.strictEqual(getAutoRefactorConfig().activated, true);
+  });
+
+  test('activated true when acknowledged and no token', () => {
+    mockToken('');
+    mockAcknowledged(true);
+    assert.strictEqual(getAutoRefactorConfig().activated, true);
+  });
+
+  test('activated false when unacknowledged and token present', () => {
+    mockToken('secret');
+    mockAcknowledged(false);
+    assert.strictEqual(getAutoRefactorConfig().activated, false);
+  });
+
+  test('activated true when unacknowledged and no token', () => {
+    mockToken('');
+    mockAcknowledged(false);
+    assert.strictEqual(getAutoRefactorConfig().activated, true);
+  });
+
+  test('disabled is true when token not configured', () => {
+    mockToken('');
+    mockAcknowledged(false);
+    assert.strictEqual(getAutoRefactorConfig().disabled, true);
+  });
+
+  test('disabled is false when token configured', () => {
+    mockToken('secret');
+    mockAcknowledged(false);
+    assert.strictEqual(getAutoRefactorConfig().disabled, false);
+  });
+
+  test('visible follows ace feature state', () => {
+    mockToken('secret');
+    mockAcknowledged(true);
+    Object.defineProperty(csExtensionState.CsExtensionState, 'stateProperties', {
+      get: () => ({
+        features: { ace: { state: 'disabled' } },
+      }),
+      configurable: true,
+    });
+    assert.strictEqual(getAutoRefactorConfig().visible, false);
+  });
+});


### PR DESCRIPTION
## Summary
- Hide ACE activation ad in code smell docs (and other CWF views) unless user has auth token and has not acknowledged ACE
- Port JetBrains PR #153 logic: set `activated` only false when token present and unacknowledged
- Add unit tests mirroring JetBrains truth table

## Test plan
- [x] Unit tests for all four token/acknowledgement combinations pass
- [x] Fresh install without token: open refactorable code smell docs — no ACE ad
- [x] With token, unacknowledged: ACE ad shown
- [ ] With token, acknowledged: no ACE ad

Made with [Cursor](https://cursor.com)