### PR TITLE
fix: replace Math.random() nonce with crypto.randomBytes (CS-11189)

### DIFF
--- a/src/test/suite/cwf-html-utils.test.ts
+++ b/src/test/suite/cwf-html-utils.test.ts
@@ -46,9 +46,9 @@ suite('cwf-html-utils Test Suite', () => {
     assert.ok(html.includes('<!DOCTYPE html>'));
     assert.ok(html.includes('Content-Security-Policy'));
     assert.ok(html.includes("default-src 'none';"));
-    assert.ok(/nonce="[A-Za-z0-9]+"/.test(html));
+    assert.ok(/nonce="[A-Za-z0-9+/=]+"/.test(html));
     // Verify nonce is consistent across script tags
-    const nonces = html.match(/nonce="([A-Za-z0-9]+)"/g)!;
+    const nonces = html.match(/nonce="([A-Za-z0-9+/=]+)"/g)!;
     assert.ok(nonces.length >= 2);
     assert.strictEqual(nonces[0], nonces[1]);
   });

--- a/src/webview-utils.ts
+++ b/src/webview-utils.ts
@@ -1,13 +1,9 @@
+import { randomBytes } from 'crypto';
 import { Uri, Webview } from 'vscode';
 import { CsExtensionState } from './cs-extension-state';
 
 export function nonce() {
-  let text = '';
-  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+  return randomBytes(16).toString('base64');
 }
 
 export function getUri(webView: Webview, ...pathSegments: string[]) {


### PR DESCRIPTION
## Overview
Replaces the predictable `Math.random()`-based webview nonce generator with 
cryptographically secure `crypto.randomBytes()`. Addresses medium-severity 
security finding from SECURITY_REVIEW_VSCODE.md (M3).

## Changes
- **`src/webview-utils.ts`:** Replace the custom character-picking loop with 
  `randomBytes(16).toString('base64')` — a single-line CSPRNG-based implementation.
- **`src/test/suite/cwf-html-utils.test.ts`:** Update nonce regex assertions 
  from `[A-Za-z0-9]+` to `[A-Za-z0-9+/=]+` to match base64 output charset.

## Security Impact
`Math.random()` is not cryptographically secure and its output can be predicted. 
While no active exploit exists today (current CSP doesn't use nonce-based policies), 
this change is defense-in-depth preparation for when CSP is tightened to 
`'nonce-<value>'` mode (planned in H2). A predictable nonce would completely 
defeat nonce-based CSP.

## Testing
- ✅ All existing webview/CWF tests pass with updated assertions
- ✅ TypeScript compiles cleanly
- ✅ Build succeeds
- No behavior change to consumers — `nonce()` still returns a string suitable 
  for HTML `nonce="..."` attributes and CSP `'nonce-...'` directives