### PR TITLE
fix: escape HTML in webview component interpolations (CS-11188)

### DIFF
--- a/src/codescene-tab/webview/components.ts
+++ b/src/codescene-tab/webview/components.ts
@@ -1,6 +1,7 @@
 import { basename } from 'path';
 import { commands, Position } from 'vscode';
 import { isDefined } from '../../utils';
+import { escapeHtml } from './utils';
 
 /**
  * Note - need to implement expanding collapsing toggle in each webview script,
@@ -20,7 +21,7 @@ export function collapsibleContent(title: string, containerContent?: string, isC
         data-cs-title="${classCompatibleTitle}" 
         class="${classCompatibleTitle}-header clickable">
       <span class="codicon codicon-chevron-down expand-indicator ${isCollapsed ? 'rotated' : ''}"></span>
-      ${title}
+      ${escapeHtml(title)}
     </h3>
     <div data-cs-type="collapsible-container" 
          data-cs-title="${classCompatibleTitle}" 
@@ -43,12 +44,12 @@ export function functionLocationContent({
 }) {
   const fnNameHtml = fnName
     ? `<span class="codicon codicon-symbol-method"></span>
-       <span class="${isStale ? 'strikeout' : ''}">${fnName}</span>`
+       <span class="${isStale ? 'strikeout' : ''}">${escapeHtml(fnName)}</span>`
     : '';
 
   return /*html*/ `
     <div id="function-location" class="flex-row">
-      <span class="codicon codicon-file"></span><span class="file-name">${basename(filePath)}</span>
+      <span class="codicon codicon-file"></span><span class="file-name">${escapeHtml(basename(filePath))}</span>
       ${fnNameHtml}
       <span class="line-no ${isStale ? 'strikeout' : ''}">
       ${position ? `[Ln ${position.line + 1}]` : ''}

--- a/src/codescene-tab/webview/refactoring-components.ts
+++ b/src/codescene-tab/webview/refactoring-components.ts
@@ -3,7 +3,7 @@ import { getEffectiveToken } from '../../devtools-api';
 import { Confidence, FnToRefactor, RefactorResponse } from '../../devtools-api/refactor-models';
 import { CodeWithLangId, decorateCode } from '../../refactoring/utils';
 import { collapsibleContent, markdownAsCollapsible } from './components';
-import { readRawMarkdownDocs } from './utils';
+import { escapeHtml, readRawMarkdownDocs } from './utils';
 
 export function refactoringSummary(confidence: Confidence) {
   const {
@@ -18,17 +18,17 @@ export function summaryHeader(level: number, levelClass: string, action: string)
   if (level >= 3) {
     return `<div class="refactoring-summary-header ${levelClass}">Refactoring improves Code Health</div>`;
   }
-  return `<div class="refactoring-summary-header ${levelClass}">${action}</div>`;
+  return `<div class="refactoring-summary-header ${levelClass}">${escapeHtml(action)}</div>`;
 }
 
 export function summaryDetails(level: number, actionDetails: string) {
   switch (true) {
     case level === -2:
-      return `<span>${actionDetails}</span>`;
+      return `<span>${escapeHtml(actionDetails)}</span>`;
     case level < 1:
       return '<span>The LLM failed to improve Code Health. The refactoring might still offer a structural step in the right direction - inspect and decide!</span>';
     default:
-      return level < 3 ? `<span>${actionDetails}</span>` : '';
+      return level < 3 ? `<span>${escapeHtml(actionDetails)}</span>` : '';
   }
 }
 
@@ -94,8 +94,8 @@ async function autoRefactorContent(response: RefactorResponse, code: CodeWithLan
           await codeContainerContent(
             { content: response.declarations, languageId: code.languageId },
             false,
-            'copy-declarations-to-clipboard-button'
-          )
+            'copy-declarations-to-clipboard-button',
+          ),
         )
       : '';
 
@@ -105,7 +105,7 @@ async function autoRefactorContent(response: RefactorResponse, code: CodeWithLan
         ${declarationsSection}
         ${collapsibleContent(
           'Refactored code',
-          await codeContainerContent(code, true, 'copy-code-to-clipboard-button')
+          await codeContainerContent(code, true, 'copy-code-to-clipboard-button'),
         )}
     `;
   return content;
@@ -117,7 +117,7 @@ function reasonsContent(response: RefactorResponse) {
     confidence: { 'review-header': reviewHeader, level },
   } = response;
 
-  const reasonListItems = reasons.map((reason) => `<li>${reason.summary}</li>`);
+  const reasonListItems = reasons.map((reason) => `<li>${escapeHtml(reason.summary)}</li>`);
   let reasonsText = reasonListItems.length > 0 ? `<ul>${reasonListItems.join('\n')}</ul>` : null;
 
   // ReviewHeader is optional in the API, but is always present for confidence > 1  (i.e. autoRefactorContent)
@@ -143,7 +143,7 @@ async function codeContainerContent(code: CodeWithLangId, showDiff = true, copyB
   // Use built in  markdown extension for rendering code
   const mdRenderedCode = await commands.executeCommand(
     'markdown.api.render',
-    '```' + code.languageId + '\n' + code.content + '\n```'
+    '```' + code.languageId + '\n' + code.content + '\n```',
   );
 
   const diffButton = showDiff
@@ -175,7 +175,7 @@ async function unverifiedRefactoring(response: RefactorResponse, code: CodeWithL
     ${reasonsContent(response)}
     ${collapsibleContent(
       'Refactored code (unverified)',
-      await codeContainerContent(code, false, 'copy-code-to-clipboard-button')
+      await codeContainerContent(code, false, 'copy-code-to-clipboard-button'),
     )}
   `;
 }

--- a/src/codescene-tab/webview/utils.ts
+++ b/src/codescene-tab/webview/utils.ts
@@ -5,6 +5,15 @@ import { CsExtensionState } from '../../cs-extension-state';
 import { categoryToDocsCode } from '../../documentation/commands';
 import { getUri, nonce } from '../../webview-utils';
 
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 export interface HtmlTemplateParams {
   title: string;
   bodyContent: string | string[];
@@ -29,7 +38,7 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
     cssTag(webView, ['assets', 'markdown-languages.css']),
     cssTag(webView, ['assets', 'highlight.css']),
     cssTag(webView, ['out', 'codescene-tab', 'webview', 'styles.css']),
-    cssTag(webView, ['out', 'codicons', 'codicon.css'], 'vscode-codicon-stylesheet') // NOTE - vscode-elements needs an id for the stylesheet tag ¯\_(ツ)_/¯
+    cssTag(webView, ['out', 'codicons', 'codicon.css'], 'vscode-codicon-stylesheet'), // NOTE - vscode-elements needs an id for the stylesheet tag ¯\_(ツ)_/¯
   );
 
   cssPaths?.forEach((path) => cssTags.push(cssTag(webView, path)));
@@ -47,8 +56,8 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
         <meta
           http-equiv="Content-Security-Policy"
           content="default-src 'none'; img-src data: ${webView.cspSource}; script-src ${webView.cspSource}; font-src ${
-    webView.cspSource
-  };
+            webView.cspSource
+          };
           style-src 'unsafe-inline' ${webView.cspSource};"
         />
         ${cssTags.join('\n')}
@@ -56,7 +65,7 @@ export function renderHtmlTemplate(webViewPanel: WebviewPanel, params: HtmlTempl
 
     <body>
         ${scriptTags.join('\n')}
-        <h2>${title}</h2>
+        <h2>${escapeHtml(title)}</h2>
         ${Array.isArray(bodyContent) ? bodyContent.join('\n') : bodyContent}
     </body>
 

--- a/src/test/suite/components.test.ts
+++ b/src/test/suite/components.test.ts
@@ -1,8 +1,5 @@
 import * as assert from 'assert';
-import {
-  collapsibleContent,
-  functionLocationContent,
-} from '../../codescene-tab/webview/components';
+import { collapsibleContent, functionLocationContent } from '../../codescene-tab/webview/components';
 
 suite('Webview components HTML escaping', () => {
   suite('collapsibleContent', () => {

--- a/src/test/suite/components.test.ts
+++ b/src/test/suite/components.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+import {
+  collapsibleContent,
+  functionLocationContent,
+} from '../../codescene-tab/webview/components';
+
+suite('Webview components HTML escaping', () => {
+  suite('collapsibleContent', () => {
+    test('escapes title when content is provided', () => {
+      const html = collapsibleContent('<img src=x>', '<div>body</div>');
+      assert.ok(html.includes('&lt;img src=x&gt;'));
+      // body content is intentionally passed through as raw HTML
+      assert.ok(html.includes('<div>body</div>'));
+    });
+
+    test('returns empty string when content is undefined', () => {
+      assert.strictEqual(collapsibleContent('Title', undefined), '');
+    });
+
+    test('renders header with classCompatibleTitle derived from raw title', () => {
+      const html = collapsibleContent('My Title', '<div></div>');
+      assert.ok(html.includes('data-cs-title="my-title"'));
+      assert.ok(html.includes('class="my-title-header clickable"'));
+    });
+
+    test('applies collapsed/rotated classes when isCollapsed is true', () => {
+      const html = collapsibleContent('Title', '<div></div>', true);
+      assert.ok(html.includes('rotated'));
+      assert.ok(html.includes('collapsed'));
+    });
+  });
+
+  suite('functionLocationContent', () => {
+    test('escapes fnName', () => {
+      const html = functionLocationContent({
+        filePath: '/repo/src/file.ts',
+        fnName: '<script>alert(1)</script>',
+      });
+      assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+      assert.ok(!html.includes('<script>alert'));
+    });
+
+    test('escapes basename of filePath', () => {
+      const html = functionLocationContent({
+        filePath: '/repo/<img src=x>.ts',
+      });
+      assert.ok(html.includes('&lt;img src=x&gt;.ts'));
+      assert.ok(!html.includes('<img src=x>.ts'));
+    });
+
+    test('omits fnName block when fnName is undefined', () => {
+      const html = functionLocationContent({ filePath: '/repo/file.ts' });
+      assert.ok(html.includes('file.ts'));
+      assert.ok(!html.includes('codicon-symbol-method'));
+    });
+
+    test('renders line number when position is provided', () => {
+      const html = functionLocationContent({
+        filePath: '/repo/file.ts',
+        position: { line: 9, character: 0 } as any,
+      });
+      assert.ok(html.includes('[Ln 10]'));
+    });
+
+    test('applies strikeout class when isStale is true', () => {
+      const html = functionLocationContent({
+        filePath: '/repo/file.ts',
+        fnName: 'foo',
+        isStale: true,
+      });
+      assert.ok(html.includes('strikeout'));
+    });
+  });
+});

--- a/src/test/suite/escape-html.test.ts
+++ b/src/test/suite/escape-html.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import { escapeHtml } from '../../codescene-tab/webview/utils';
+
+suite('escapeHtml', () => {
+  test('escapes ampersands', () => {
+    assert.strictEqual(escapeHtml('a & b'), 'a &amp; b');
+  });
+
+  test('escapes less-than', () => {
+    assert.strictEqual(escapeHtml('<script>'), '&lt;script&gt;');
+  });
+
+  test('escapes greater-than', () => {
+    assert.strictEqual(escapeHtml('a > b'), 'a &gt; b');
+  });
+
+  test('escapes double quotes', () => {
+    assert.strictEqual(escapeHtml('"hello"'), '&quot;hello&quot;');
+  });
+
+  test('escapes single quotes', () => {
+    assert.strictEqual(escapeHtml("it's"), 'it&#039;s');
+  });
+
+  test('escapes all special characters together', () => {
+    assert.strictEqual(
+      escapeHtml('<img src="x" onerror=\'alert(&)\'>'),
+      '&lt;img src=&quot;x&quot; onerror=&#039;alert(&amp;)&#039;&gt;'
+    );
+  });
+
+  test('returns empty string unchanged', () => {
+    assert.strictEqual(escapeHtml(''), '');
+  });
+
+  test('returns safe string unchanged', () => {
+    assert.strictEqual(escapeHtml('hello world 123'), 'hello world 123');
+  });
+});

--- a/src/test/suite/refactoring-components.test.ts
+++ b/src/test/suite/refactoring-components.test.ts
@@ -1,9 +1,5 @@
 import * as assert from 'assert';
-import {
-  reasonsContent,
-  summaryDetails,
-  summaryHeader,
-} from '../../codescene-tab/webview/refactoring-components';
+import { reasonsContent, summaryDetails, summaryHeader } from '../../codescene-tab/webview/refactoring-components';
 import { RefactorResponse } from '../../devtools-api/refactor-models';
 
 const code = 'function foo() {}\n';
@@ -88,4 +84,3 @@ suite('Refactor panel components Test Suite', () => {
     });
   });
 });
-

--- a/src/test/suite/refactoring-components.test.ts
+++ b/src/test/suite/refactoring-components.test.ts
@@ -1,5 +1,9 @@
 import * as assert from 'assert';
-import { reasonsContent } from '../../codescene-tab/webview/refactoring-components';
+import {
+  reasonsContent,
+  summaryDetails,
+  summaryHeader,
+} from '../../codescene-tab/webview/refactoring-components';
 import { RefactorResponse } from '../../devtools-api/refactor-models';
 
 const code = 'function foo() {}\n';
@@ -25,4 +29,63 @@ suite('Refactor panel components Test Suite', () => {
     const content = reasonsContent(response);
     assert.equal(content, '');
   });
+
+  suite('summaryHeader HTML escaping', () => {
+    test('escapes action text for low confidence', () => {
+      const html = summaryHeader(1, 'level-1', '<img src=x onerror=alert(1)>');
+      assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'));
+      assert.ok(!html.includes('<img'));
+    });
+
+    test('returns hardcoded text for high confidence (no interpolation)', () => {
+      const html = summaryHeader(4, 'level-4', '<script>evil</script>');
+      assert.ok(html.includes('Refactoring improves Code Health'));
+      assert.ok(!html.includes('<script>evil'));
+    });
+  });
+
+  suite('summaryDetails HTML escaping', () => {
+    test('escapes actionDetails for level -2', () => {
+      const html = summaryDetails(-2, '<img src=x>');
+      assert.strictEqual(html, '<span>&lt;img src=x&gt;</span>');
+    });
+
+    test('returns fixed message for level 0 (no interpolation)', () => {
+      const html = summaryDetails(0, '<script>evil</script>');
+      assert.ok(html.includes('The LLM failed to improve Code Health'));
+      assert.ok(!html.includes('<script>'));
+    });
+
+    test('escapes actionDetails for level 1-2', () => {
+      const html = summaryDetails(2, '"quoted" & <tag>');
+      assert.strictEqual(html, '<span>&quot;quoted&quot; &amp; &lt;tag&gt;</span>');
+    });
+
+    test('returns empty string for level >= 3', () => {
+      const html = summaryDetails(3, '<img src=x>');
+      assert.strictEqual(html, '');
+    });
+  });
+
+  suite('reasonsContent HTML escaping', () => {
+    test('escapes reason.summary in list items', () => {
+      const response: RefactorResponse = {
+        code,
+        reasons: [{ summary: '<script>alert(1)</script>' }],
+        'refactoring-properties': { 'added-code-smells': [], 'removed-code-smells': [] },
+        confidence: {
+          level: 2,
+          title: 'Refactoring suggestion',
+          'recommended-action': { description: 'Inspect', details: 'Inspect' },
+          'review-header': 'Reasons',
+        },
+        metadata: {},
+        'trace-id': 'trace-id',
+      };
+      const html = reasonsContent(response);
+      assert.ok(html.includes('&lt;script&gt;alert(1)&lt;/script&gt;'));
+      assert.ok(!html.includes('<script>alert'));
+    });
+  });
 });
+


### PR DESCRIPTION
## Overview
Prevents markup injection in the legacy refactoring/docs webview panels by
HTML-escaping all variables interpolated into HTML strings. Addresses
medium-severity security finding from SECURITY_REVIEW_VSCODE.md (M2).

## Changes
- **`src/codescene-tab/webview/utils.ts`:** Add `escapeHtml()` helper —
  escapes `& < > " '` to their HTML entity equivalents.
- **`src/codescene-tab/webview/components.ts`:** Apply `escapeHtml()` to
  `fnName`, `basename(filePath)`, and the collapsible section `title`.
- **`src/codescene-tab/webview/refactoring-components.ts`:** Apply
  `escapeHtml()` to `action`, `actionDetails`, and `reason.summary`.
- **`src/test/suite/escape-html.test.ts`:** Add 8 unit tests covering all
  five escaped characters individually, combined injection payload, empty
  input, and safe passthrough.

## Security Impact
Raw variable interpolation into HTML allowed attacker-controlled strings
(e.g. crafted function names, file paths, or server-returned reason text)
to inject arbitrary markup. In the legacy panel this enables phishing-style
UI (fake auth prompts, malicious `<a href>` links). In CWF panels with
weaker CSP the same injection would escalate to JS execution.

## Testing
- ✅ `escapeHtml` unit tests pass (8 cases)
- ✅ TypeScript compiles cleanly
- ✅ Build succeeds

## Acceptance Criteria
- [x] All interpolated variables in affected components are HTML-escaped
- [x] No raw user/server-controlled content reaches the DOM
- [x] Tests cover the escaping utility