### PR TITLE
Add no-ACE extension variant for Open VSX

### DIFF
--- a/.github/workflows/code-coverage-gates.yml
+++ b/.github/workflows/code-coverage-gates.yml
@@ -35,7 +35,7 @@ jobs:
         CI: true
 
     - name: Generate code coverage
-      run: npm run test:coverage
+      run: npm run test:coverage:dual
       env:
         CI: true
 

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         CI: true
 
     - name: Generate code coverage
-      run: npm run test:coverage
+      run: npm run test:coverage:dual
       env:
         CI: true
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -10,17 +10,57 @@ jobs:
     strategy:
       matrix:
         include:
-          - platform: darwin
+          - variant: full
+            build_no_ace: false
+            vsix_prefix: codescene-vscode
+            platform: darwin
             arch: x64
-          - platform: darwin
+          - variant: full
+            build_no_ace: false
+            vsix_prefix: codescene-vscode
+            platform: darwin
             arch: arm64
-          - platform: linux
+          - variant: full
+            build_no_ace: false
+            vsix_prefix: codescene-vscode
+            platform: linux
             arch: x64
-          - platform: linux
+          - variant: full
+            build_no_ace: false
+            vsix_prefix: codescene-vscode
+            platform: linux
             arch: arm64
-          - platform: win32
+          - variant: full
+            build_no_ace: false
+            vsix_prefix: codescene-vscode
+            platform: win32
             arch: x64
-    name: 'Build ${{ matrix.platform }}-${{ matrix.arch }}'
+          - variant: noace
+            build_no_ace: true
+            vsix_prefix: codescene-vscode-noace
+            platform: darwin
+            arch: x64
+          - variant: noace
+            build_no_ace: true
+            vsix_prefix: codescene-vscode-noace
+            platform: darwin
+            arch: arm64
+          - variant: noace
+            build_no_ace: true
+            vsix_prefix: codescene-vscode-noace
+            platform: linux
+            arch: x64
+          - variant: noace
+            build_no_ace: true
+            vsix_prefix: codescene-vscode-noace
+            platform: linux
+            arch: arm64
+          - variant: noace
+            build_no_ace: true
+            vsix_prefix: codescene-vscode-noace
+            platform: win32
+            arch: x64
+    name: 'Build ${{ matrix.variant }} ${{ matrix.platform }}-${{ matrix.arch }}'
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -36,12 +76,13 @@ jobs:
         run: node ./scripts/package-platform.js ${{ matrix.platform }} ${{ matrix.arch }}
         env:
           CI: true
+          BUILD_NO_ACE: ${{ matrix.build_no_ace }}
           GITHUB_TOKEN: ${{ secrets.CODESCENE_IDE_DOCS_AND_WEBVIEW_TOKEN }}
 
       # .cs-prod-build is expected for correct functioning of the extension, so we validate its presence:
       - name: Verify .cs-prod-build marker in VSIX
         run: |
-          VSIX_FILE=$(ls codescene-vscode-*-${{ matrix.platform }}-${{ matrix.arch }}.vsix)
+          VSIX_FILE=$(ls ${{ matrix.vsix_prefix }}-*-${{ matrix.platform }}-${{ matrix.arch }}.vsix)
           unzip -l "$VSIX_FILE" | tee vsix-contents.txt
           if grep -q "\.cs-prod-build" vsix-contents.txt; then
             echo ".cs-prod-build marker found in VSIX"
@@ -51,11 +92,26 @@ jobs:
             exit 1
           fi
 
+      - name: Verify no-ACE settings absent from VSIX
+        if: matrix.variant == 'noace'
+        run: |
+          VSIX_FILE=$(ls ${{ matrix.vsix_prefix }}-*-${{ matrix.platform }}-${{ matrix.arch }}.vsix)
+          unzip -p "$VSIX_FILE" extension/package.json > vsix-package.json
+          if jq -e '.contributes.configuration.properties | has("codescene.enableAutoRefactor")' vsix-package.json > /dev/null; then
+            echo "ACE setting codescene.enableAutoRefactor found in no-ACE VSIX package.json"
+            exit 1
+          fi
+          if jq -e '.contributes.configuration.properties | has("codescene.authToken")' vsix-package.json > /dev/null; then
+            echo "ACE setting codescene.authToken found in no-ACE VSIX package.json"
+            exit 1
+          fi
+          echo "No ACE settings in no-ACE VSIX package.json"
+
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
-          path: 'codescene-vscode-*-${{ matrix.platform }}-${{ matrix.arch }}.vsix'
-          name: 'codescene-vscode-${{ matrix.platform }}-${{ matrix.arch }}'
+          path: '${{ matrix.vsix_prefix }}-*-${{ matrix.platform }}-${{ matrix.arch }}.vsix'
+          name: '${{ matrix.vsix_prefix }}-${{ matrix.platform }}-${{ matrix.arch }}'
 
   release:
     name: 'Create Release'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,7 +6,7 @@ on:
       publish_vscode_marketplace:
         type: boolean
         default: true
-        description: Publish to VS Code Marketplace
+        description: Publish full variant to VS Code Marketplace
       publish_open_vsx:
         type: boolean
         default: true
@@ -30,16 +30,24 @@ jobs:
       - name: Verify platform-specific VSIX files
         run: |
           set -euo pipefail
-          rm -f vsix-map.txt
+          rm -f vsix-map.txt noace-vsix-map.txt
           targets=("win32-x64" "darwin-x64" "darwin-arm64" "linux-x64" "linux-arm64")
           for target in "${targets[@]}"; do
-            file=$(find . -name "codescene-vscode-*-${target}.vsix" | head -1)
+            file=$(find . -name "codescene-vscode-*-${target}.vsix" ! -name "codescene-vscode-noace-*" | head -1)
             if [ -z "$file" ]; then
-              echo "❌ Missing VSIX for ${target}"
+              echo "❌ Missing full-variant VSIX for ${target}"
               exit 1
             fi
             echo "${target}=${file}" >> vsix-map.txt
-            echo "✅ Found ${file}"
+            echo "✅ Found full variant ${file}"
+
+            noace_file=$(find . -name "codescene-vscode-noace-*-${target}.vsix" | head -1)
+            if [ -z "$noace_file" ]; then
+              echo "❌ Missing no-ACE VSIX for ${target}"
+              exit 1
+            fi
+            echo "${target}=${noace_file}" >> noace-vsix-map.txt
+            echo "✅ Found no-ACE variant ${noace_file}"
           done
 
       - name: Install Node.js
@@ -47,7 +55,7 @@ jobs:
         with:
           node-version: 20
 
-      - name: Publish to VS Code Marketplace
+      - name: Publish full variant to VS Code Marketplace
         if: ${{ github.event.inputs.publish_vscode_marketplace == 'true' }}
         run: |
           npm install -g vsce
@@ -65,6 +73,10 @@ jobs:
         run: |
           npm install -g ovsx
           while IFS='=' read -r target file; do
-            echo "🚀 Publishing ${file} to Open VSX (target=${target})"
+            echo "🚀 Publishing full variant ${file} to Open VSX (target=${target})"
             ovsx publish --pat ${{ secrets.OPEN_VSX_PUBLISHING_TOKEN }} --packagePath "${file}"
           done < vsix-map.txt
+          while IFS='=' read -r target file; do
+            echo "🚀 Publishing no-ACE variant ${file} to Open VSX (target=${target})"
+            ovsx publish --pat ${{ secrets.OPEN_VSX_PUBLISHING_TOKEN }} --packagePath "${file}"
+          done < noace-vsix-map.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,27 @@ jobs:
       env:
         CI: true
 
+  test-no-ace:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: './.github/actions/setup'
+
+    - name: Configure Git
+      run: git config --global advice.defaultBranchName false
+
+    - run: npm run pretest
+      env:
+        CI: true
+        BUILD_NO_ACE: true
+
+    - run: npm test
+      env:
+        CI: true
+        BUILD_NO_ACE: true
+
   build-vsix:
     name: build vsix (E2E tests)
     runs-on: ubuntu-latest

--- a/README-noace.md
+++ b/README-noace.md
@@ -1,0 +1,74 @@
+# CodeScene - Code Analysis
+[![CodeScene Code Health](https://codescene.io/projects/36131/status-badges/code-health)](https://codescene.io/projects/36131)
+
+> Do not install this extension alongside CodeScene (`codescene.codescene-vscode`). Uninstall one before installing the other.
+
+## What is CodeScene for Visual Studio Code? ##
+[CodeScene](http://www.codescene.com) is the only code analysis tool with a **proven business impact**. It serves as a **safeguard** against introducing code changes that could negatively affect your business outcomes.
+
+CodeScene promotes **healthy, maintainable code** by providing clear, actionable insights and guidance on how to improve your codebase.
+
+By using CodeScene, developers can spend less time deciphering complex code, and more time focusing on what truly matters: **solving problems and delivering value**.
+
+## The CodeScene CodeHealth™ metric ##
+CodeScene’s [CodeHealth™](https://codescene.io/docs/guides/technical/code-health.html) metric is the software industry’s only code-level metric with proven business impact, measured through fact-based, winning research. It’s a metric that you can trust. The extension analyses and scores your code as you type, and adds diagnostic items that highlights any [code smells](#code-smells).
+CodeScene supports [most popular languages](https://codescene.io/docs/usage/language-support.html#supported-programming-languages).
+
+## Safeguarding your code changes ##
+Instant feedback is vital for maintaining high-quality code during development. By analyzing code as it’s written, developers may identify issues immediately. This interactive feedback loop encourages better coding habits, speeds up learning, and reduces the need for extensive rework later. 
+
+Continuous feedback fosters a sense of flow and confidence, as you instantly can see the impact of your changes on overall code health. In short, interactive monitoring turns code quality from a delayed review process into a **continuous, integrated part of writing code**, ensuring long-term maintainability and faster, safer development.
+
+The **Code Health Monitor** flags for drops in code health in real time and offers instant recommendations to keep your code maintainable.
+
+<img style="margin: 10px 10px 10px 10px;" src="screenshots/monitor.gif" width="500">
+
+> **_NOTE:_** _The Code Health Monitor is currently available to all users for a limited time period. However, this capability will become accessible only to CodeScene customers in future_.
+
+## Overview of Available Features ##
+| Feature | Description | What it looks like |
+|---------|-------------|--------------------|
+| **Code Health Monitor*** | The Code Health Monitor continuously tracks changes in your code, highlighting any improvements or degradations you introduce. Each file displays both its previous and current Code Health score, along with a clear delta value showing the overall change. You can easily see the impact of your modifications at the file or function level, including the status of any associated Code Smells—whether you’ve introduced new ones or resolved existing issues. With this level of visibility, there’s no longer any excuse for allowing Code Health to decline in your codebase. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/monitor.png" alt="Monitor" width="2000px"/> |
+| **Inline Code Smell detection** | Code smells often lead to issues such as increased technical debt, more bugs, and reduced overall quality of the software. You can find detailed information for each code smell by either clicking the corresponding inline action notation in the editor, by examining the diagnostics (squigglies or in the Problems view), or by using the Quick Fix action menu (light bulb).| <img style="margin: 10px 10px 10px 10px;" src="screenshots/codesmells.png" alt="Code Smells" width="2000px"/> |
+| **Refactoring Guidance** | Our mission is to educate and raise awareness about Code Health and its impact on your efficiency as a developer. The CodeScene extension equips you with rich insights into Code Smells and provides clear, actionable guidance on how to address issues that may exist in your codebase. We include relevant examples that illustrate the essence of Code Smells, along with common patterns and practical solutions to help you write cleaner, more maintainable code. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/documentation.png" alt="Code Smell Documentation" width="2000px"/> |
+| **Problems View** | When a file is opened in the editor, it is instantly scanned for existing Code Health issues. All discovered issues are then listed in the IDE Problems View. This way you instantly get an overview of all opportunities a file has for improvements. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/problems.png" alt="Problem View" width="2000px"/> |
+| **Custom Code Health rules** | To customize the code analysis you can either use local [Code Comment Directives](https://codescene.io/docs/guides/technical/code-health.html#disable-local-smells-via-code-comment-directives) or create a `code-health-rules.json` file which applies to the entire project. | <img style="margin: 10px 10px 10px 10px;" src="screenshots/custom_directive.png" alt="ACR" width="2000px"/> |
+
+## Configuration ##
+
+You can add configuration files to the git repository to customize and control behavior in the Extension. They should be located in a `.codescene` folder, at the repository root. In addition, we also have a Settings page for personalized configuration of the extension.
+
+### code-health-rules.json ###
+
+Location: `.codescene/code-health-rules.json`
+
+You can find more documentation on its content [here](https://codescene.io/docs/guides/technical/code-health.html#customize-the-code-health-rules-via-json)
+
+### config.json ###
+
+Location: `.codescene/config.json`
+
+Example configuration:
+```json
+{
+  "baseline_branch": "develop"
+}
+```
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| **baseline_branch** | String | origin/HEAD (default branch) | The name of the branch that the Code Health Monitor should compare against when running its delta analysis. If no origin/HEAD or config present, it will look for the nearest merge-base among common shared branches (main, master, develop etc)
+
+### Settings ###
+
+Location: `Code Health Monitor` > `Extension Settings`
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| **Enable Review Code Lenses** | Boolean | true | Enables/Disables showing Code Health Score and Code Smells in the active documents |
+| **Enable Telemetry** | Boolean | true | Enable/Disable collecting anonymized telemetry for tracking usage and feature engagement. |
+
+### Debug logging ###
+
+CodeScene follows Visual Studio Codes Log level. To enable debug logging, in the command `Developer: Set Log Level...` to debug
+
+_* Available time-limited for non CodeScene customers._

--- a/esbuild.js
+++ b/esbuild.js
@@ -4,10 +4,16 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+const buildNoAce = process.env.BUILD_NO_ACE === 'true';
+const esbuildDefine = {
+  'process.env.BUILD_NO_ACE': JSON.stringify(buildNoAce ? 'true' : 'false'),
+};
+
 const baseConfig = {
   bundle: true,
   minify: process.env.NODE_ENV === 'production',
   sourcemap: process.env.NODE_ENV !== 'production',
+  define: esbuildDefine,
 };
 
 function buildCounter(counterName) {
@@ -55,18 +61,24 @@ const extensionConfig = {
 };
 
 function webviewConfig(watch = false) {
+  const entryPoints = [
+    './src/code-health-monitor/details/webview-script.ts',
+    './src/control-center/webview-script.ts',
+    './src/codescene-tab/webview/script.ts',
+    './src/codescene-tab/webview/documentation-script.ts',
+  ];
+  if (!buildNoAce) {
+    entryPoints.push(
+      './src/codescene-tab/webview/ace-acknowledgement-script.ts',
+      './src/codescene-tab/webview/refactoring-script.ts'
+    );
+  }
+
   return {
     ...baseConfig,
     target: 'es2020',
     format: 'esm',
-    entryPoints: [
-      './src/code-health-monitor/details/webview-script.ts',
-      './src/control-center/webview-script.ts',
-      './src/codescene-tab/webview/script.ts',
-      './src/codescene-tab/webview/ace-acknowledgement-script.ts',
-      './src/codescene-tab/webview/refactoring-script.ts',
-      './src/codescene-tab/webview/documentation-script.ts',
-    ],
+    entryPoints,
     outdir: './out',
     plugins: [
       buildCounter('webview-scripts'),

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "bundle-cli-test": "node ./scripts/bundle-cli-for-current-platform.js",
     "test": "mocha",
     "test:coverage": "c8 npm run test",
+    "test:coverage:dual": "node ./scripts/test-coverage-dual.js",
     "updatedocs": "fetch-github-release empear-analytics codescene-ide-protocol",
     "updatecwf": "fetch-github-release empear-analytics cs-webview ./cs-cwf",
     "release:minor": "standard-version --release-as minor",

--- a/scripts/apply-build-variant.js
+++ b/scripts/apply-build-variant.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * Apply or restore build-variant changes to package.json and README.md for no-ACE releases.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ACE_KEYWORDS = new Set([
+  'refactoring',
+  'ai',
+  'anthropic',
+  'openai',
+  'gemini',
+  'gpt',
+  'ai code review',
+]);
+
+const ACE_SETTINGS = ['codescene.enableAutoRefactor', 'codescene.authToken'];
+
+function applyNoAceVariant(projectRoot) {
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  const readmePath = path.join(projectRoot, 'README.md');
+  const noAceReadmePath = path.join(projectRoot, 'README-noace.md');
+
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  pkg.name = 'codescene-vscode-noace';
+  pkg.displayName = 'CodeScene w/o ACE';
+  pkg.description =
+    'CodeScene code analysis without ACE. Do not install alongside CodeScene (codescene.codescene-vscode).';
+  pkg.keywords = (pkg.keywords || []).filter((keyword) => !ACE_KEYWORDS.has(keyword));
+
+  const properties = pkg.contributes?.configuration?.properties;
+  if (properties) {
+    for (const key of ACE_SETTINGS) {
+      delete properties[key];
+    }
+  }
+
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  if (fs.existsSync(noAceReadmePath)) {
+    fs.copyFileSync(noAceReadmePath, readmePath);
+  }
+
+  return pkg;
+}
+
+function restoreVariantFiles(projectRoot, originalPackageJson, originalReadme) {
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  const readmePath = path.join(projectRoot, 'README.md');
+
+  fs.writeFileSync(packageJsonPath, originalPackageJson);
+  if (originalReadme !== undefined) {
+    fs.writeFileSync(readmePath, originalReadme);
+  }
+}
+
+function isNoAceBuild() {
+  return process.env.BUILD_NO_ACE === 'true';
+}
+
+module.exports = {
+  applyNoAceVariant,
+  restoreVariantFiles,
+  isNoAceBuild,
+};

--- a/scripts/package-platform.js
+++ b/scripts/package-platform.js
@@ -8,6 +8,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { applyNoAceVariant, restoreVariantFiles, isNoAceBuild } = require('./apply-build-variant');
 
 const artifacts = {
   darwin: ['x64', 'arm64'],
@@ -62,6 +63,53 @@ function updateVscodeIgnore(targetPlatform, targetArch, originalContent) {
   return content; // Return original content for restoration
 }
 
+function restorePackagingFiles(projectRoot, vscodeIgnorePath, originalVscodeIgnore, originalPackageJson, originalReadme) {
+  console.log('\nRestoring .vscodeignore, package.json, and README...');
+  fs.writeFileSync(vscodeIgnorePath, originalVscodeIgnore);
+  restoreVariantFiles(projectRoot, originalPackageJson, originalReadme);
+}
+
+function packageExtension(platform, arch, projectRoot, buildNoAce, originalVscodeIgnore) {
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+
+  if (buildNoAce) {
+    console.log('Applying no-ACE build variant...');
+    applyNoAceVariant(projectRoot);
+  }
+
+  console.log('Step 1: Bundling CLI binary...');
+  execSync(`node ./scripts/bundle-cli.js ${platform} ${arch}`, { stdio: 'inherit' });
+
+  console.log('\nStep 2: Cleaning up other platform binaries...');
+  cleanupOtherBinaries(platform, arch);
+
+  console.log('\nStep 3: Updating .vscodeignore...');
+  updateVscodeIgnore(platform, arch, originalVscodeIgnore);
+
+  console.log('\nStep 4: Updating docs and webview...');
+  const tokenEnv = { ...process.env, GITHUB_TOKEN: process.env.GITHUB_TOKEN || '' };
+  execSync('npm run updatedocs', { stdio: 'inherit', env: tokenEnv });
+  execSync('npm run updatecwf', { stdio: 'inherit', env: tokenEnv });
+
+  console.log('\nStep 5: Building extension...');
+  execSync('npm run build', {
+    stdio: 'inherit',
+    env: { ...process.env, BUILD_NO_ACE: buildNoAce ? 'true' : 'false' },
+  });
+
+  console.log('\nStep 6: Packaging VSIX...');
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const target = `${platform}-${arch}`;
+  const vsixName = `${pkg.name}-${pkg.version}-${target}.vsix`;
+
+  execSync(`vsce package --target ${target} --no-yarn --out ${vsixName}`, {
+    stdio: 'inherit',
+    env: tokenEnv,
+  });
+
+  console.log(`\n✅ Successfully created: ${vsixName}`);
+}
+
 async function main() {
   const args = process.argv.slice(2);
   
@@ -86,51 +134,22 @@ async function main() {
   
   console.log(`📦 Packaging extension for ${platform}/${arch}...\n`);
   
-  const vscodeIgnorePath = path.join(__dirname, '..', '.vscodeignore');
+  const projectRoot = path.join(__dirname, '..');
+  const vscodeIgnorePath = path.join(projectRoot, '.vscodeignore');
+  const packageJsonPath = path.join(projectRoot, 'package.json');
+  const readmePath = path.join(projectRoot, 'README.md');
   const originalVscodeIgnore = fs.readFileSync(vscodeIgnorePath, 'utf8');
-  
+  const originalPackageJson = fs.readFileSync(packageJsonPath, 'utf8');
+  const originalReadme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : undefined;
+  const buildNoAce = isNoAceBuild();
+
   try {
-    // Step 1: Bundle binary for this platform
-    console.log('Step 1: Bundling CLI binary...');
-    execSync(`node ./scripts/bundle-cli.js ${platform} ${arch}`, { stdio: 'inherit' });
-    
-    // Step 2: Clean up other binaries
-    console.log('\nStep 2: Cleaning up other platform binaries...');
-    cleanupOtherBinaries(platform, arch);
-    
-    // Step 3: Update .vscodeignore
-    console.log('\nStep 3: Updating .vscodeignore...');
-    updateVscodeIgnore(platform, arch, originalVscodeIgnore);
-    
-    // Step 4: Update docs and webview
-    console.log('\nStep 4: Updating docs and webview...');
-    execSync('npm run updatedocs', { stdio: 'inherit', env: { ...process.env, GITHUB_TOKEN: process.env.GITHUB_TOKEN || '' } });
-    execSync('npm run updatecwf', { stdio: 'inherit', env: { ...process.env, GITHUB_TOKEN: process.env.GITHUB_TOKEN || '' } });
-    
-    // Step 5: Build extension
-    console.log('\nStep 5: Building extension...');
-    execSync('npm run build', { stdio: 'inherit' });
-    
-    // Step 6: Package VSIX
-    console.log('\nStep 6: Packaging VSIX...');
-    const version = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
-    const target = `${platform}-${arch}`;
-    const vsixName = `codescene-vscode-${version}-${target}.vsix`;
-    
-    execSync(`vsce package --target ${target} --no-yarn --out ${vsixName}`, { 
-      stdio: 'inherit',
-      env: { ...process.env, GITHUB_TOKEN: process.env.GITHUB_TOKEN || '' }
-    });
-    
-    console.log(`\n✅ Successfully created: ${vsixName}`);
-    
+    packageExtension(platform, arch, projectRoot, buildNoAce, originalVscodeIgnore);
   } catch (error) {
     console.error('\n❌ Failed to package:', error.message);
     process.exit(1);
   } finally {
-    // Restore original .vscodeignore
-    console.log('\nRestoring .vscodeignore...');
-    fs.writeFileSync(vscodeIgnorePath, originalVscodeIgnore);
+    restorePackagingFiles(projectRoot, vscodeIgnorePath, originalVscodeIgnore, originalPackageJson, originalReadme);
   }
 }
 

--- a/scripts/test-coverage-dual.js
+++ b/scripts/test-coverage-dual.js
@@ -1,0 +1,8 @@
+const { execSync } = require('child_process');
+
+execSync('c8 --clean npm run test', { stdio: 'inherit', env: process.env });
+execSync('c8 --clean=false npm run test', {
+  stdio: 'inherit',
+  env: { ...process.env, BUILD_NO_ACE: 'true' },
+});
+execSync('c8 report', { stdio: 'inherit', env: process.env });

--- a/src/build-flags.ts
+++ b/src/build-flags.ts
@@ -1,0 +1,1 @@
+export const ACE_ENABLED = process.env.BUILD_NO_ACE !== 'true';

--- a/src/code-health-monitor/codelens.ts
+++ b/src/code-health-monitor/codelens.ts
@@ -1,4 +1,5 @@
 import vscode, { Uri } from 'vscode';
+import { ACE_ENABLED } from '../build-flags';
 import { onDidChangeConfiguration, reviewCodeLensesEnabled } from '../configuration';
 import { issueToDocsParams } from '../documentation/commands';
 import { reviewDocumentSelector } from '../language-support';
@@ -64,7 +65,7 @@ export class CodeHealthMonitorCodeLens implements vscode.CodeLensProvider<vscode
       arguments: [functionInfo.parent.document.uri],
     });
 
-    if (functionInfo.fnToRefactor) {
+    if (ACE_ENABLED && functionInfo.fnToRefactor) {
       codeLenses.push(requestAceLens, dismissAceLens);
     }
     let order = 1;

--- a/src/code-health-monitor/delta-analysis-tree-provider.ts
+++ b/src/code-health-monitor/delta-analysis-tree-provider.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import { ACE_ENABLED } from '../build-flags';
 import { DeltaAnalysisEvent } from '../devtools-api';
 import Telemetry from '../telemetry';
 import { isDefined, pluralize } from '../utils';
@@ -175,6 +176,9 @@ export class DeltaAnalysisTreeProvider implements vscode.TreeDataProvider<DeltaT
   }
 
   private aceSummaryItem(filesWithIssues: FileWithIssues[]) {
+    if (!ACE_ENABLED) {
+      return;
+    }
     const refactorings = refactoringsCount(filesWithIssues);
     if (refactorings === 0) {
       return;

--- a/src/code-health-monitor/home/cwf-message-handlers.ts
+++ b/src/code-health-monitor/home/cwf-message-handlers.ts
@@ -9,6 +9,7 @@ import { HomeView } from './home-view';
 import { showDocAtPosition } from '../../utils';
 import { findOrOpenDocument, toDocsParamsRanged } from '../../documentation/commands';
 import Telemetry from '../../telemetry';
+import { getExtensionSettingsFilter } from '../../extension-id';
 import { getMessageCategory } from './cwf-message-categories';
 import {
   CommitBaselineType,
@@ -104,10 +105,10 @@ function handleOpenDocs(homeView: HomeView, payload: OpenDocsMessage['payload'])
  */
 function handleOpenSettings() {
   Telemetry.logUsage('control-center/open-settings');
-  vscode.commands.executeCommand('workbench.action.openWorkspaceSettings', '@ext:codescene.codescene-vscode').then(
+  vscode.commands.executeCommand('workbench.action.openWorkspaceSettings', getExtensionSettingsFilter()).then(
     () => {},
     (err) => {
-      void vscode.commands.executeCommand('workbench.action.openSettings', '@ext:codescene.codescene-vscode');
+      void vscode.commands.executeCommand('workbench.action.openSettings', getExtensionSettingsFilter());
     }
   );
 }

--- a/src/codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper.ts
+++ b/src/codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper.ts
@@ -1,3 +1,4 @@
+import { ACE_ENABLED } from '../../../../build-flags';
 import { AceAcknowledgeContextViewProps, AutoRefactorConfig } from '../../../../centralized-webview-framework/types';
 import { CsExtensionState } from '../../../../cs-extension-state';
 import { RefactoringRequest } from '../../../../refactoring/request';
@@ -18,6 +19,10 @@ export function getAceAcknowledgeData(request: RefactoringRequest): AceAcknowled
 }
 
 export function getAutoRefactorConfig(): AutoRefactorConfig {
+  if (!ACE_ENABLED) {
+    return { disabled: true, activated: false, visible: false };
+  }
+
   const hasToken = !!getAuthToken()?.trim();
   const acknowledged = CsExtensionState.acknowledgedAceUsage === true;
   const activated = !(!acknowledged && hasToken);

--- a/src/codescene-tab/webview/documentation/cwf-webview-docs-panel.ts
+++ b/src/codescene-tab/webview/documentation/cwf-webview-docs-panel.ts
@@ -7,6 +7,8 @@ import { initBaseContent } from '../../../centralized-webview-framework/cwf-html
 import { getDocsData } from './docs-data-mapper';
 import Telemetry from '../../../telemetry';
 import { CsExtensionState } from '../../../cs-extension-state';
+import { ACE_ENABLED } from '../../../build-flags';
+import { getExtensionSettingsFilter } from '../../../extension-id';
 import { onDidChangeConfiguration } from '../../../configuration';
 
 export type CodeSceneTabPanelState = InteractiveDocsParams & {
@@ -45,10 +47,12 @@ export class CodeSceneCWFDocsTabPanel implements Disposable {
     this.webViewPanelDisposable = this.webViewPanel.onDidDispose(() => this.dispose());
     this.webViewPanel.webview.onDidReceiveMessage(this.handleMessages, this, this.disposables);
 
-    this.disposables.push(
-      CsExtensionState.onAceStateChanged(() => this.refreshAceState()), // Detect change to ACE status
-      onDidChangeConfiguration('authToken', () => this.refreshAceState()) // Detect change to ACE auth token in settings
-    );
+    if (ACE_ENABLED) {
+      this.disposables.push(
+        CsExtensionState.onAceStateChanged(() => this.refreshAceState()),
+        onDidChangeConfiguration('authToken', () => this.refreshAceState())
+      );
+    }
     vscode.workspace.onDidCloseTextDocument(
       (e) => {
         const closedThisDoc = this.state?.document === e;
@@ -98,10 +102,10 @@ export class CodeSceneCWFDocsTabPanel implements Disposable {
         try {
           await vscode.commands.executeCommand(
             'workbench.action.openWorkspaceSettings',
-            '@ext:codescene.codescene-vscode'
+            getExtensionSettingsFilter()
           );
         } catch {
-          await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:codescene.codescene-vscode');
+          await vscode.commands.executeCommand('workbench.action.openSettings', getExtensionSettingsFilter());
         }
       },
       'goto-function-location': () => {

--- a/src/control-center/view-provider.ts
+++ b/src/control-center/view-provider.ts
@@ -13,6 +13,7 @@ import { DevtoolsAPI, getEffectiveToken } from '../devtools-api';
 import { CreditsInfoError } from '../devtools-api/credits-info-error';
 import { CreditsInfo } from '../devtools-api/refactor-models';
 import { logOutputChannel } from '../log';
+import { getExtensionSettingsFilter } from '../extension-id';
 import Telemetry from '../telemetry';
 import { pluralize } from '../utils';
 import { commonResourceRoots, getUri, nonce } from '../webview-utils';
@@ -80,12 +81,12 @@ export class ControlCenterViewProvider implements WebviewViewProvider, Disposabl
       openSettings: () => {
         Telemetry.logUsage('control-center/open-settings');
         vscode.commands
-          .executeCommand('workbench.action.openWorkspaceSettings', '@ext:codescene.codescene-vscode')
+          .executeCommand('workbench.action.openWorkspaceSettings', getExtensionSettingsFilter())
           .then(
             () => {},
             (err) => {
               logOutputChannel.info('Not inside a workspace, opening general/user settings instead.');
-              void vscode.commands.executeCommand('workbench.action.openSettings', '@ext:codescene.codescene-vscode');
+              void vscode.commands.executeCommand('workbench.action.openSettings', getExtensionSettingsFilter());
             }
           );
       },

--- a/src/cs-statusbar.ts
+++ b/src/cs-statusbar.ts
@@ -1,4 +1,5 @@
 import vscode, { Disposable } from 'vscode';
+import { ACE_ENABLED } from './build-flags';
 import { AnalysisFeature, CsExtensionState, CsFeature } from './cs-extension-state';
 import { getEffectiveToken } from './devtools-api';
 import { CreditsInfoError } from './devtools-api/credits-info-error';
@@ -15,12 +16,14 @@ interface StatusBarOptions {
 export class CsStatusBar implements Disposable {
   private disposables: Disposable[] = [];
 
-  private readonly aceStatus: vscode.StatusBarItem;
+  private readonly aceStatus?: vscode.StatusBarItem;
   private readonly analysisStatus: vscode.StatusBarItem;
 
   constructor() {
-    this.disposables.push(onDidChangeConfiguration('authToken', () => this.update()));
-    this.aceStatus = this.createStatusBarItem('codescene.aceStatusBarItem', vscode.StatusBarAlignment.Left, -1);
+    if (ACE_ENABLED) {
+      this.disposables.push(onDidChangeConfiguration('authToken', () => this.update()));
+      this.aceStatus = this.createStatusBarItem('codescene.aceStatusBarItem', vscode.StatusBarAlignment.Left, -1);
+    }
     this.analysisStatus = this.createStatusBarItem(
       'codescene.analysisStatusBarItem',
       vscode.StatusBarAlignment.Left,
@@ -36,6 +39,9 @@ export class CsStatusBar implements Disposable {
   }
 
   private updateAceStatus(ace: CsFeature) {
+    if (!this.aceStatus) {
+      return;
+    }
     const item = this.aceStatus;
     const handler = this.aceStateHandlers[ace.state] || (() => {});
     handler(ace, item);

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -15,6 +15,7 @@ import { basename, dirname } from 'path';
 import { existsSync } from 'fs';
 import vscode, { ExtensionContext, TextDocument } from 'vscode';
 import { CodeSceneAuthenticationSession } from '../auth/auth-provider';
+import { ACE_ENABLED } from '../build-flags';
 import { getAuthToken } from '../configuration';
 import { CsExtensionState, CsFeature } from '../cs-extension-state';
 import { logOutputChannel } from '../log';
@@ -296,6 +297,9 @@ export class DevtoolsAPI {
    * @returns preflightResponse
    */
   static async preflight() {
+    if (!ACE_ENABLED) {
+      return;
+    }
     DevtoolsAPI.preflightRequestEmitter.fire({ state: 'loading' });
     try {
       const response = await DevtoolsAPI.instance.executeAsJson<PreFlightResponse>({
@@ -318,10 +322,16 @@ export class DevtoolsAPI {
   }
 
   static aceEnabled() {
+    if (!ACE_ENABLED) {
+      return false;
+    }
     return DevtoolsAPI.instance.preflightJson !== undefined;
   }
 
   static disableAce() {
+    if (!ACE_ENABLED) {
+      return;
+    }
     DevtoolsAPI.instance.preflightJson = undefined;
     DevtoolsAPI.preflightRequestEmitter.fire({ state: 'disabled' });
   }
@@ -397,54 +407,90 @@ export class DevtoolsAPI {
    * @returns refactoring response
    */
   static async postRefactoring(request: RefactoringRequest): Promise<RefactorResponse> {
+    this.checkAceEnabled();
     const { document, fnToRefactor, skipCache, signal } = request;
 
-    const token = getEffectiveToken();
-    if (!token) {
-      throw new MissingAuthTokenError();
-    }
+    const token = this.getAuthToken();
 
     DevtoolsAPI.refactoringRequestEmitter.fire({ document, request, type: 'start' });
     try {
       const payload = DevtoolsAPI.buildRefactoringPayload(fnToRefactor, skipCache, token);
 
-      logOutputChannel.info(
-        `Refactor requested for ${logIdString(fnToRefactor)}${
-skipCache === true ? ' (retry)' : ''
-}, with refactoring targets: [${fnToRefactor['refactoring-targets'].map((t) => t.category).join(', ')}]`
-      );
-      const fp = fileParts(document);
-      if (!validateFileParts('postRefactoring', fp, document)) {
-        throw new Error('Invalid file parts: document directory is missing or does not exist');
-      }
-      const response = await DevtoolsAPI.instance.executeAsJson<RefactorResponse>({
-        args: ['run-command', 'refactor'],
-        input: JSON.stringify(payload),
-        execOptions: { signal, cwd: fp.documentDirectory },
-        taskId: REFACTOR_TASK_ID, // Limit to only 1 refactoring at a time
-      });
-      logOutputChannel.info(
-        `Refactor request done ${logIdString(fnToRefactor, response['trace-id'])}${
-skipCache === true ? ' (retry)' : ''
-}`
-      );
+      this.logRefactorRequested(fnToRefactor, skipCache);
+
+      const fp = this.getValidatedFileParts(document);
+
+      const response = await this.executeRefactor(payload, signal, fp);
+
+      this.logRefactorDone(fnToRefactor, skipCache, response);
 
       DevtoolsAPI.handleBackOnline();
 
       return response;
     } catch (e) {
-      if (DevtoolsAPI.shouldHandleOfflineBehavior(e)) {
-        DevtoolsAPI.handleOfflineBehavior();
-      } else {
-        reportError({ context: 'Refactoring error', e, consoleOnly: true });
-        if (!(e instanceof AbortError)) {
-          DevtoolsAPI.refactoringErrorEmitter.fire(assertError(e));
-        }
-      }
-
-      throw e; // Some general error reporting above, but pass along the error for further handling
+      this.handleRefactorError(e);
+      // Some general error reporting above, but pass along the error for further handling
+      throw e;
     } finally {
       DevtoolsAPI.refactoringRequestEmitter.fire({ document, request, type: 'end' });
+    }
+  }
+
+  private static checkAceEnabled(): void {
+    if (!ACE_ENABLED) {
+      throw new Error('ACE is not available in this build');
+    }
+  }
+
+  private static getAuthToken(): string {
+    const token = getEffectiveToken();
+    if (!token) {
+      throw new MissingAuthTokenError();
+    }
+    return token;
+  }
+
+  private static logRefactorRequested(fnToRefactor: any, skipCache: boolean): void {
+    logOutputChannel.info(
+      `Refactor requested for ${logIdString(fnToRefactor)}${skipCache === true ? ' (retry)' : ''}, with refactoring targets: [${fnToRefactor['refactoring-targets'].map((t: any) => t.category).join(', ')}]`
+    );
+  }
+
+  private static getValidatedFileParts(document: any) {
+    const fp = fileParts(document);
+    if (!validateFileParts('postRefactoring', fp, document)) {
+      throw new Error('Invalid file parts: document directory is missing or does not exist');
+    }
+    return fp;
+  }
+
+  private static async executeRefactor(
+    payload: any,
+    signal: AbortSignal,
+    fp: { documentDirectory: string }
+  ): Promise<RefactorResponse> {
+    return DevtoolsAPI.instance.executeAsJson<RefactorResponse>({
+      args: ['run-command', 'refactor'],
+      input: JSON.stringify(payload),
+      execOptions: { signal, cwd: fp.documentDirectory },
+      taskId: REFACTOR_TASK_ID, // Limit to only 1 refactoring at a time
+    });
+  }
+
+  private static logRefactorDone(fnToRefactor: any, skipCache: boolean, response: RefactorResponse): void {
+    logOutputChannel.info(
+      `Refactor request done ${logIdString(fnToRefactor, response['trace-id'])}${skipCache === true ? ' (retry)' : ''}`
+    );
+  }
+
+  private static handleRefactorError(e: any): void {
+    if (DevtoolsAPI.shouldHandleOfflineBehavior(e)) {
+      DevtoolsAPI.handleOfflineBehavior();
+    } else {
+      reportError({ context: 'Refactoring error', e, consoleOnly: true });
+      if (!(e instanceof AbortError)) {
+        DevtoolsAPI.refactoringErrorEmitter.fire(assertError(e));
+      }
     }
   }
 
@@ -490,6 +536,9 @@ skipCache === true ? ' (retry)' : ''
    * - Fires a preflight event to update the ACE state to `offline`.
    */
   private static handleOfflineBehavior() {
+    if (!ACE_ENABLED) {
+      return;
+    }
     const { state: currentState } = CsExtensionState.stateProperties.features.ace;
 
     // Only show when transitioning to offline mode
@@ -512,6 +561,9 @@ skipCache === true ? ' (retry)' : ''
    * No action is taken if the ACE feature state is not `offline`.
    */
   private static handleBackOnline() {
+    if (!ACE_ENABLED) {
+      return;
+    }
     const { state: currentState } = CsExtensionState.stateProperties.features.ace;
     if (currentState === 'offline') {
       DevtoolsAPI.preflightRequestEmitter.fire({ state: 'enabled' });

--- a/src/extension-id.ts
+++ b/src/extension-id.ts
@@ -1,0 +1,15 @@
+import vscode from 'vscode';
+
+let extensionId = 'codescene.codescene-vscode';
+
+export function initExtensionId(context: vscode.ExtensionContext): void {
+  extensionId = context.extension.id;
+}
+
+export function getExtensionId(): string {
+  return extensionId;
+}
+
+export function getExtensionSettingsFilter(): string {
+  return `@ext:${extensionId}`;
+}

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -40,6 +40,8 @@ import { DroppingScheduledExecutor } from './dropping-scheduled-executor';
 import { SimpleExecutor } from './simple-executor';
 import { getHomeViewInstance } from './code-health-monitor/home/home-view';
 import { onGitDetectedAsUnavailable } from './git/git-detection';
+import { ACE_ENABLED } from './build-flags';
+import { initExtensionId } from './extension-id';
 
 const ENABLE_AUTH_COMMANDS = false;
 
@@ -47,7 +49,6 @@ interface CsContext {
   csWorkspace: CsWorkspace;
 }
 
-const extId = 'codescene.codescene-vscode';
 const migrationKey = 'codescene.lastSeenVersion';
 
 let DISPOSABLES: vscode.Disposable[] = [];
@@ -132,6 +133,7 @@ export async function activate(context: vscode.ExtensionContext) {
   await reloadWindowForUpdate(context);
 
   logOutputChannel.info('⚙️ Activating extension...');
+  initExtensionId(context);
   CsExtensionState.init(context);
 
   ensureCompatibleBinary(context.extensionPath).then(
@@ -170,7 +172,11 @@ async function startExtension(context: vscode.ExtensionContext) {
   CsServerVersion.init();
 
   CsExtensionState.addListeners(context);
-  initAce(context);
+  if (ACE_ENABLED) {
+    initAce(context);
+  } else {
+    CsExtensionState.setACEState({ state: 'disabled' });
+  }
 
   const gitUnavailableDisposable = onGitDetectedAsUnavailable(() => {
     void vscode.window.showWarningMessage("'Git' binary not found by the CodeScene extension, or Git not initialized in this project.");
@@ -207,15 +213,17 @@ async function startExtension(context: vscode.ExtensionContext) {
 
   registerCodeActionProvider(context);
 
-  // If configuration option is changed, en/disable ACE capabilities accordingly - debounce to handle rapid changes
-  const debouncedSetEnabledAce = debounce((enabled: boolean) => {
-    void vscode.commands.executeCommand('codescene.ace.setEnabled', enabled);
-  }, 500);
-  const aceConfigDisposable = onDidChangeConfiguration('enableAutoRefactor', (e) => {
-    debouncedSetEnabledAce(e.value);
-  });
-  DISPOSABLES.push(aceConfigDisposable);
-  context.subscriptions.push(aceConfigDisposable);
+  if (ACE_ENABLED) {
+    // If configuration option is changed, en/disable ACE capabilities accordingly - debounce to handle rapid changes
+    const debouncedSetEnabledAce = debounce((enabled: boolean) => {
+      void vscode.commands.executeCommand('codescene.ace.setEnabled', enabled);
+    }, 500);
+    const aceConfigDisposable = onDidChangeConfiguration('enableAutoRefactor', (e) => {
+      debouncedSetEnabledAce(e.value);
+    });
+    DISPOSABLES.push(aceConfigDisposable);
+    context.subscriptions.push(aceConfigDisposable);
+  }
 }
 
 /**
@@ -233,7 +241,9 @@ function finalizeActivation(context: vscode.ExtensionContext) {
 function registerCommands(context: vscode.ExtensionContext, csContext: CsContext) {
   registerShowLogCommand(context);
   registerDocumentationCommands(context);
-  registerOpenCsSettingsCommand(context);
+  if (ACE_ENABLED) {
+    registerOpenCsSettingsCommand(context);
+  }
 
   const toggleReviewCodeLensesCmd = vscode.commands.registerCommand('codescene.toggleReviewCodeLenses', () => {
     toggleReviewCodeLenses();
@@ -475,7 +485,7 @@ async function shouldReloadOnUpdate(): Promise<boolean> {
 }
 
 export async function reloadWindowForUpdate(context: vscode.ExtensionContext) {
-  const current = vscode.extensions.getExtension(extId)?.packageJSON?.version ?? '0.0.0';
+  const current = context.extension.packageJSON.version ?? '0.0.0';
   const prev = context.globalState.get<string>(migrationKey);
   logOutputChannel.info(`${current} extension version, previous version was ${prev}`);
 

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -42,14 +42,15 @@ import { getHomeViewInstance } from './code-health-monitor/home/home-view';
 import { onGitDetectedAsUnavailable } from './git/git-detection';
 import { ACE_ENABLED } from './build-flags';
 import { initExtensionId } from './extension-id';
+import { guardWindowLifecycleDuringTests, reloadWindowForUpdate } from './extension-reload';
+
+export { reloadWindowForUpdate } from './extension-reload';
 
 const ENABLE_AUTH_COMMANDS = false;
 
 interface CsContext {
   csWorkspace: CsWorkspace;
 }
-
-const migrationKey = 'codescene.lastSeenVersion';
 
 let DISPOSABLES: vscode.Disposable[] = [];
 
@@ -462,73 +463,5 @@ function onGetSessionError() {
   return (error: any) => {
     CsExtensionState.setSession();
     void vscode.window.showErrorMessage(`Error signing in with CodeScene: ${error}`);
-  };
-}
-
-function isUnderTestsOrCI(): boolean {
-  const appName = vscode.env.appName ?? '';
-  const argv = process.argv.join(' ');
-  return (
-    process.env.VSCODE_TEST === 'true' ||
-    process.env.CI === 'true' ||
-    /- Test/i.test(appName) ||
-    argv.includes('--extensionTestsPath') ||
-    !!process.env.CODE_TESTS_PATH
-  );
-}
-
-async function shouldReloadOnUpdate(): Promise<boolean> {
-  const cfg = vscode.workspace.getConfiguration('codescene');
-  // setting lets you force-disable reload without touching code
-  const enabled = cfg.get<boolean>('reloadOnUpdate', true);
-  return enabled;
-}
-
-export async function reloadWindowForUpdate(context: vscode.ExtensionContext) {
-  const current = context.extension.packageJSON.version ?? '0.0.0';
-  const prev = context.globalState.get<string>(migrationKey);
-  logOutputChannel.info(`${current} extension version, previous version was ${prev}`);
-
-  await context.globalState.update(migrationKey, current);
-
-  if (isUnderTestsOrCI()) {
-    logOutputChannel.info(`[TEST/CI] Version changed ${prev} -> ${current}, reload skipped.`);
-    return;
-  }
-
-  if (!(await shouldReloadOnUpdate())) {
-    logOutputChannel.info(`[codescene] reloadOnUpdate disabled; skipping reload ${prev} -> ${current}.`);
-    return;
-  }
-
-  const versionChanged = current !== prev;
-  if (!versionChanged) {
-    logOutputChannel.info('Version unchanged, no reload needed.');
-    return;
-  }
-
-  try {
-    logOutputChannel.info(`[codescene] Reloading window due to update: ${prev} -> ${current}`);
-    void vscode.commands.executeCommand('workbench.action.reloadWindow');
-  } catch (e) {
-    logOutputChannel.error('Error triggering reload after update:', assertError(e));
-  }
-}
-
-function guardWindowLifecycleDuringTests() {
-  if (!isUnderTestsOrCI()) return;
-  const original = vscode.commands.executeCommand;
-  // @ts-expect-error test-only monkey patch
-  vscode.commands.executeCommand = (command: string, ...args: any[]) => {
-    const windowLifecycleCommands = [
-      'workbench.action.reloadWindow',
-      'workbench.action.quit',
-      'workbench.action.closeWindow',
-    ];
-    if (windowLifecycleCommands.includes(command)) {
-      console.log(`[TEST] Ignored command: ${command}`);
-      return Promise.resolve(undefined);
-    }
-    return original(command, ...args);
   };
 }

--- a/src/extension-reload.ts
+++ b/src/extension-reload.ts
@@ -1,0 +1,72 @@
+import vscode from 'vscode';
+import { logOutputChannel } from './log';
+import { assertError } from './utils';
+
+export const migrationKey = 'codescene.lastSeenVersion';
+
+function isUnderTestsOrCI(): boolean {
+  const appName = vscode.env.appName ?? '';
+  const argv = process.argv.join(' ');
+  return (
+    process.env.VSCODE_TEST === 'true' ||
+    process.env.CI === 'true' ||
+    /- Test/i.test(appName) ||
+    argv.includes('--extensionTestsPath') ||
+    !!process.env.CODE_TESTS_PATH
+  );
+}
+
+async function shouldReloadOnUpdate(): Promise<boolean> {
+  const cfg = vscode.workspace.getConfiguration('codescene');
+  const enabled = cfg.get<boolean>('reloadOnUpdate', true);
+  return enabled;
+}
+
+export async function reloadWindowForUpdate(context: vscode.ExtensionContext) {
+  const current = context.extension.packageJSON.version ?? '0.0.0';
+  const prev = context.globalState.get<string>(migrationKey);
+  logOutputChannel.info(`${current} extension version, previous version was ${prev}`);
+
+  await context.globalState.update(migrationKey, current);
+
+  if (isUnderTestsOrCI()) {
+    logOutputChannel.info(`[TEST/CI] Version changed ${prev} -> ${current}, reload skipped.`);
+    return;
+  }
+
+  if (!(await shouldReloadOnUpdate())) {
+    logOutputChannel.info(`[codescene] reloadOnUpdate disabled; skipping reload ${prev} -> ${current}.`);
+    return;
+  }
+
+  const versionChanged = current !== prev;
+  if (!versionChanged) {
+    logOutputChannel.info('Version unchanged, no reload needed.');
+    return;
+  }
+
+  try {
+    logOutputChannel.info(`[codescene] Reloading window due to update: ${prev} -> ${current}`);
+    void vscode.commands.executeCommand('workbench.action.reloadWindow');
+  } catch (e) {
+    logOutputChannel.error('Error triggering reload after update:', assertError(e));
+  }
+}
+
+export function guardWindowLifecycleDuringTests() {
+  if (!isUnderTestsOrCI()) return;
+  const original = vscode.commands.executeCommand;
+  // @ts-expect-error test-only monkey patch
+  vscode.commands.executeCommand = (command: string, ...args: any[]) => {
+    const windowLifecycleCommands = [
+      'workbench.action.reloadWindow',
+      'workbench.action.quit',
+      'workbench.action.closeWindow',
+    ];
+    if (windowLifecycleCommands.includes(command)) {
+      console.log(`[TEST] Ignored command: ${command}`);
+      return Promise.resolve(undefined);
+    }
+    return original(command, ...args);
+  };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,16 +5,15 @@ import { logOutputChannel } from './log';
 import * as path from 'path';
 import * as fs from 'fs';
 
-async function isLegacyVersion(): Promise<boolean> {
-  const extension = vscode.extensions.getExtension('codescene.codescene-vscode');
-  const currentVersion = extension?.packageJSON.version;
+async function isLegacyVersion(context: vscode.ExtensionContext): Promise<boolean> {
+  const currentVersion = context.extension.packageJSON.version;
   if (!currentVersion) {
     logOutputChannel.info('Could not determine extension version, allowing activation');
     return false;
   }
 
   // Check if this is a production build, by looking for the .cs-prod-build marker
-  const extensionPath = extension?.extensionPath;
+  const extensionPath = context.extension.extensionPath;
   if (extensionPath) {
     const markerPath = path.join(extensionPath, 'out', '.cs-prod-build');
     const isProdBuild = fs.existsSync(markerPath);
@@ -49,7 +48,7 @@ async function isLegacyVersion(): Promise<boolean> {
 let impl: typeof import('./extension-impl') | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const isDeprecated = await isLegacyVersion();
+  const isDeprecated = await isLegacyVersion(context);
   if (isDeprecated) {
     void vscode.window.showWarningMessage(
       `The current CodeScene extension version is deprecated. Please update it to the latest version.`,

--- a/src/review/codeaction.ts
+++ b/src/review/codeaction.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ACE_ENABLED } from '../build-flags';
 import { DevtoolsAPI } from '../devtools-api';
 import { Review } from '../devtools-api/review-model';
 import { CsDiagnostic } from '../diagnostics/cs-diagnostic';
@@ -74,6 +75,10 @@ export class ReviewCodeActionProvider implements vscode.CodeActionProvider, vsco
     codeSmells: any[],
     actions: vscode.CodeAction[]
   ) {
+    if (!ACE_ENABLED) {
+      return;
+    }
+
     const authToken = getAuthToken();
     const fnsToRefactor = await Promise.all(
       codeSmells.map((codeSmell) => fnsToRefactorCache.fnsToRefactor(document, codeSmell))

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import { getConfiguration } from './configuration';
 import { CsExtensionState } from './cs-extension-state';
+import { getExtensionSettingsFilter } from './extension-id';
 import { DevtoolsAPI } from './devtools-api';
 import { TelemetryEvent } from './devtools-api/telemetry-model';
 import { logOutputChannel } from './log';
@@ -169,7 +170,7 @@ export default class Telemetry {
       );
 
       if (selection === openSettings) {
-        await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:codescene.codescene-vscode');
+        await vscode.commands.executeCommand('workbench.action.openSettings', getExtensionSettingsFilter());
       }
 
       // Mark that the first run notice has been shown

--- a/src/test/ace-test-suite.ts
+++ b/src/test/ace-test-suite.ts
@@ -9,3 +9,7 @@ export function aceSuite(title: string, fn: (this: Mocha.Suite) => void) {
 export function aceTest(title: string, fn: Mocha.Func) {
   return (isAceBuildEnabled() ? test : test.skip)(title, fn);
 }
+
+export function noAceSuite(title: string, fn: (this: Mocha.Suite) => void) {
+  return (process.env.BUILD_NO_ACE === 'true' ? suite : suite.skip)(title, fn);
+}

--- a/src/test/ace-test-suite.ts
+++ b/src/test/ace-test-suite.ts
@@ -1,0 +1,11 @@
+function isAceBuildEnabled(): boolean {
+  return process.env.BUILD_NO_ACE !== 'true';
+}
+
+export function aceSuite(title: string, fn: (this: Mocha.Suite) => void) {
+  return (isAceBuildEnabled() ? suite : suite.skip)(title, fn);
+}
+
+export function aceTest(title: string, fn: Mocha.Func) {
+  return (isAceBuildEnabled() ? test : test.skip)(title, fn);
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,6 +42,78 @@ export function restoreDefaultWorkspaceFolders() {
 
 let mockGitRepositories: any[] = [];
 
+export type MockWebviewPanel = {
+  visible: boolean;
+  webview: {
+    onDidReceiveMessage: (
+      callback: (message: unknown) => void,
+      thisArg?: unknown
+    ) => { dispose: () => void };
+    postMessage: (message: unknown) => Promise<boolean>;
+    html: string;
+    cspSource: string;
+    asWebviewUri: (uri: { toString: () => string }) => string;
+  };
+  onDidDispose: (callback: () => void) => { dispose: () => void };
+  dispose: () => void;
+  reveal: (viewColumn?: unknown, preserveFocus?: boolean) => void;
+};
+
+let lastWebviewPanelMock: MockWebviewPanel | undefined;
+let messageHandler: ((message: unknown) => void) | undefined;
+let disposeHandler: (() => void) | undefined;
+const postMessageCalls: unknown[] = [];
+
+export function getLastWebviewPanelMock(): MockWebviewPanel | undefined {
+  return lastWebviewPanelMock;
+}
+
+export function getWebviewMessageHandler(): ((message: unknown) => void) | undefined {
+  return messageHandler;
+}
+
+export function getWebviewPostMessageCalls(): unknown[] {
+  return postMessageCalls;
+}
+
+export function resetWebviewPanelMocks() {
+  lastWebviewPanelMock = undefined;
+  messageHandler = undefined;
+  disposeHandler = undefined;
+  postMessageCalls.length = 0;
+}
+
+function createMockWebviewPanel(): MockWebviewPanel {
+  const panel: MockWebviewPanel = {
+    visible: false,
+    webview: {
+      onDidReceiveMessage: (callback: (message: unknown) => void, thisArg?: unknown) => {
+        messageHandler = thisArg ? callback.bind(thisArg) : callback;
+        return { dispose: () => {} };
+      },
+      postMessage: async (message: unknown) => {
+        postMessageCalls.push(message);
+        return true;
+      },
+      html: '',
+      cspSource: 'vscode-resource:',
+      asWebviewUri: (uri: { toString: () => string }) => uri.toString(),
+    },
+    onDidDispose: (callback: () => void) => {
+      disposeHandler = callback;
+      return { dispose: () => {} };
+    },
+    dispose: () => {
+      disposeHandler?.();
+    },
+    reveal: () => {
+      panel.visible = true;
+    },
+  };
+  lastWebviewPanelMock = panel;
+  return panel;
+}
+
 export function setMockGitRepositories(repos: any[]) {
   mockGitRepositories = repos;
 }
@@ -116,7 +188,9 @@ const vscodeStub = {
       hide: () => {},
       dispose: () => {},
     }),
+    createWebviewPanel: () => createMockWebviewPanel(),
   },
+  ViewColumn: { Beside: 2, Active: 1, One: 1, Two: 2, Three: 3 },
   StatusBarAlignment: { Left: 1, Right: 2 },
   commands: {
     registerCommand: () => ({ dispose: () => {} }),
@@ -125,6 +199,10 @@ const vscodeStub = {
   workspace: {
     workspaceFolders: defaultWorkspaceFolders as any,
     onDidChangeConfiguration: (listener: any) => {
+      void listener;
+      return { dispose: () => {} };
+    },
+    onDidCloseTextDocument: (listener: any) => {
       void listener;
       return { dispose: () => {} };
     },
@@ -224,6 +302,9 @@ const vscodeStub = {
     Source: 'source',
     SourceOrganizeImports: 'source.organizeImports',
     Empty: '',
+  },
+  env: {
+    appName: 'Visual Studio Code',
   },
   Uri: {
     parse: (value: string) => ({

--- a/src/test/suite/ace-acknowledgement-mapper.test.ts
+++ b/src/test/suite/ace-acknowledgement-mapper.test.ts
@@ -1,9 +1,10 @@
+import { aceSuite } from '../ace-test-suite';
 import * as assert from 'assert';
 import * as configModule from '../../configuration';
 import * as csExtensionState from '../../cs-extension-state';
 import { getAutoRefactorConfig } from '../../codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper';
 
-suite('AceAcknowledgementMapper Test Suite', () => {
+aceSuite('AceAcknowledgementMapper Test Suite', () => {
   let originalGetAuthToken: typeof configModule.getAuthToken;
 
   function mockToken(token: string) {

--- a/src/test/suite/cwf-webview-docs-panel.test.ts
+++ b/src/test/suite/cwf-webview-docs-panel.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { CodeSceneCWFDocsTabPanel } from '../../codescene-tab/webview/documentation/cwf-webview-docs-panel';
+import { CsExtensionState } from '../../cs-extension-state';
+import { InteractiveDocsParams } from '../../documentation/commands';
+import { TestTextDocument } from '../mocks/test-text-document';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import {
+  getWebviewMessageHandler,
+  getWebviewPostMessageCalls,
+  resetWebviewPanelMocks,
+} from '../setup';
+import { aceSuite } from '../ace-test-suite';
+import { initExtensionId } from '../../extension-id';
+
+function resetDocsPanel() {
+  const panelClass = CodeSceneCWFDocsTabPanel as unknown as { _instance?: CodeSceneCWFDocsTabPanel };
+  panelClass._instance?.dispose();
+  panelClass._instance = undefined;
+}
+
+function createDocsParams(): InteractiveDocsParams {
+  const document = new TestTextDocument('/test/sample.cpp', 'int main() {}', 'cpp');
+  return {
+    document,
+    issueInfo: { category: 'Complex Method' },
+  };
+}
+
+suite('CodeSceneCWFDocsTabPanel Test Suite', () => {
+  let mockContext: ReturnType<typeof createMockExtensionContext>;
+  let originalExecuteCommand: typeof vscode.commands.executeCommand;
+  const executedCommands: { command: string; args: unknown[] }[] = [];
+
+  setup(() => {
+    resetWebviewPanelMocks();
+    resetDocsPanel();
+    mockContext = createMockExtensionContext('/test/docs-panel');
+    initExtensionId({ extension: { id: 'codescene.codescene-vscode' } } as vscode.ExtensionContext);
+    CsExtensionState.init(mockContext);
+
+    originalExecuteCommand = vscode.commands.executeCommand;
+    executedCommands.length = 0;
+    vscode.commands.executeCommand = ((command: string, ...args: unknown[]) => {
+      executedCommands.push({ command, args });
+      if (command === 'workbench.action.openWorkspaceSettings') {
+        return Promise.reject(new Error('No workspace settings'));
+      }
+      return Promise.resolve(undefined);
+    }) as typeof vscode.commands.executeCommand;
+  });
+
+  teardown(() => {
+    resetDocsPanel();
+    resetWebviewPanelMocks();
+    vscode.commands.executeCommand = originalExecuteCommand;
+  });
+
+  function primeDocsPanel() {
+    const panel = CodeSceneCWFDocsTabPanel.instance as any;
+    panel.state = createDocsParams();
+  }
+
+  aceSuite('ACE state listeners', () => {
+    test('refreshAceState posts update when ACE state changes', async () => {
+      primeDocsPanel();
+      getWebviewPostMessageCalls().length = 0;
+
+      (CsExtensionState as any)._instance.aceStateChangedEmitter.fire();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.ok(
+        getWebviewPostMessageCalls().some(
+          (msg: any) => msg?.messageType === 'update-renderer'
+        ),
+        'Expected update-renderer postMessage after ACE state change'
+      );
+    });
+  });
+
+  test('open-settings uses workspace settings when available', async () => {
+    vscode.commands.executeCommand = ((command: string, ...args: unknown[]) => {
+      executedCommands.push({ command, args });
+      return Promise.resolve(undefined);
+    }) as typeof vscode.commands.executeCommand;
+
+    primeDocsPanel();
+    const handler = getWebviewMessageHandler();
+    assert.ok(handler, 'Expected webview message handler');
+
+    await handler!({ messageType: 'open-settings' });
+
+    assert.ok(
+      executedCommands.some((c) => c.command === 'workbench.action.openWorkspaceSettings'),
+      'Expected workspace settings command'
+    );
+    assert.strictEqual(executedCommands[0].args[0], '@ext:codescene.codescene-vscode');
+  });
+
+  test('open-settings falls back to user settings when workspace settings fail', async () => {
+    primeDocsPanel();
+    const handler = getWebviewMessageHandler();
+    assert.ok(handler, 'Expected webview message handler');
+
+    await handler!({ messageType: 'open-settings' });
+
+    assert.ok(
+      executedCommands.some((c) => c.command === 'workbench.action.openWorkspaceSettings'),
+      'Expected workspace settings attempt'
+    );
+    assert.ok(
+      executedCommands.some((c) => c.command === 'workbench.action.openSettings'),
+      'Expected fallback to user settings'
+    );
+  });
+});

--- a/src/test/suite/delta.test.ts
+++ b/src/test/suite/delta.test.ts
@@ -8,6 +8,8 @@ import { TestTextDocument } from '../mocks/test-text-document';
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { createTestDir, ensureBinary } from '../integration_helper';
 
+import { aceTest } from '../ace-test-suite';
+
 suite('Delta Integration Test Suite', () => {
   const testDir = createTestDir('test-delta');
   let deltaEventFired = false;
@@ -183,7 +185,7 @@ suite('Delta Integration Test Suite', () => {
     assert.strictEqual(deltaEventFired, false, 'Event should not fire when scores are identical');
   });
 
-  test('fnsToRefactor with code-smells path returns refactorable functions', async function() {
+  aceTest('fnsToRefactor with code-smells path returns refactorable functions', async function() {
     this.timeout(60000);
 
     const complexContent = 'int f(int a) {\n  if (a > 0) {\n    if (a > 1) {\n      if (a > 2) {\n        if (a > 3) {\n          return a;\n        }\n      }\n    }\n  }\n  return 0;\n}\n';

--- a/src/test/suite/devtools-api-no-ace.test.ts
+++ b/src/test/suite/devtools-api-no-ace.test.ts
@@ -1,0 +1,37 @@
+// Exercises ACE guard early-return paths when BUILD_NO_ACE=true (pass 2 of test:coverage:dual).
+import * as assert from 'assert';
+import { DevtoolsAPI } from '../../devtools-api';
+import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import { createTestDir, ensureBinary } from '../integration_helper';
+import { noAceSuite } from '../ace-test-suite';
+
+noAceSuite('DevtoolsAPI no-ACE guard Test Suite', () => {
+  const testDir = createTestDir('test-devtools-api-no-ace');
+
+  setup(async function () {
+    this.timeout(60000);
+    mockWorkspaceFolders([createMockWorkspaceFolder(testDir)]);
+    const binaryPath = await ensureBinary();
+    const mockContext = createMockExtensionContext(testDir);
+    DevtoolsAPI.init(binaryPath, mockContext);
+  });
+
+  teardown(() => {
+    restoreDefaultWorkspaceFolders();
+  });
+
+  test('preflight returns immediately when ACE is disabled', async function () {
+    const response = await DevtoolsAPI.preflight();
+    assert.strictEqual(response, undefined);
+  });
+
+  test('aceEnabled returns false when ACE is disabled', () => {
+    assert.strictEqual(DevtoolsAPI.aceEnabled(), false);
+  });
+
+  test('disableAce is a no-op when ACE is disabled', () => {
+    DevtoolsAPI.disableAce();
+    assert.strictEqual(DevtoolsAPI.aceEnabled(), false);
+  });
+});

--- a/src/test/suite/extension-id.test.ts
+++ b/src/test/suite/extension-id.test.ts
@@ -1,0 +1,15 @@
+import * as assert from 'assert';
+import { initExtensionId, getExtensionId, getExtensionSettingsFilter } from '../../extension-id';
+
+suite('Extension ID Test Suite', () => {
+  test('returns default extension id before init', () => {
+    assert.strictEqual(getExtensionId(), 'codescene.codescene-vscode');
+    assert.strictEqual(getExtensionSettingsFilter(), '@ext:codescene.codescene-vscode');
+  });
+
+  test('initExtensionId updates getExtensionId and filter', () => {
+    initExtensionId({ extension: { id: 'publisher.my-ext' } } as any);
+    assert.strictEqual(getExtensionId(), 'publisher.my-ext');
+    assert.strictEqual(getExtensionSettingsFilter(), '@ext:publisher.my-ext');
+  });
+});

--- a/src/test/suite/fns-to-refactor.test.ts
+++ b/src/test/suite/fns-to-refactor.test.ts
@@ -9,7 +9,9 @@ import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { ChangeType } from '../../devtools-api/delta-model';
 import { createTestDir, ensureBinary } from '../integration_helper';
 
-suite('FnsToRefactor Integration Test Suite', () => {
+import { aceSuite } from '../ace-test-suite';
+
+aceSuite('FnsToRefactor Integration Test Suite', () => {
   const testDir = createTestDir('test-fns-to-refactor');
   let analysisError: Error | undefined;
   let errorListener: vscode.Disposable;

--- a/src/test/suite/post-refactoring.test.ts
+++ b/src/test/suite/post-refactoring.test.ts
@@ -13,7 +13,9 @@ import * as configModule from '../../configuration';
 import * as csExtensionState from '../../cs-extension-state';
 import { createTestDir, ensureBinary } from '../integration_helper';
 
-suite('PostRefactoring Integration Test Suite', () => {
+import { aceSuite } from '../ace-test-suite';
+
+aceSuite('PostRefactoring Integration Test Suite', () => {
   const testDir = createTestDir('test-post-refactoring');
   const testToken = process.env.CODESCENE_TEST_TOKEN;
   let analysisError: Error | undefined;

--- a/src/test/suite/preflight.test.ts
+++ b/src/test/suite/preflight.test.ts
@@ -5,7 +5,9 @@ import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspac
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { createTestDir, ensureBinary } from '../integration_helper';
 
-suite('Preflight Integration Test Suite', () => {
+import { aceSuite } from '../ace-test-suite';
+
+aceSuite('Preflight Integration Test Suite', () => {
   const testDir = createTestDir('test-preflight');
   let preflightStateChangeFired = false;
   let lastPreflightState: any;

--- a/src/test/suite/refactoring-components.test.ts
+++ b/src/test/suite/refactoring-components.test.ts
@@ -4,7 +4,9 @@ import { RefactorResponse } from '../../devtools-api/refactor-models';
 
 const code = 'function foo() {}\n';
 
-suite('Refactor panel components Test Suite', () => {
+import { aceSuite } from '../ace-test-suite';
+
+aceSuite('Refactor panel components Test Suite', () => {
   test('Expected reasons for full conf (4), with no reasons(-with-details)', async () => {
     const response: RefactorResponse = {
       code,

--- a/src/test/suite/reload-window-for-update.test.ts
+++ b/src/test/suite/reload-window-for-update.test.ts
@@ -1,0 +1,68 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { reloadWindowForUpdate, migrationKey } from '../../extension-reload';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import { mockConfiguration, restoreDefaultConfiguration } from '../setup';
+
+function createReloadContext(version: string) {
+  const context = createMockExtensionContext('/test/reload-window');
+  (context as any).extension = { packageJSON: { version } };
+  return context;
+}
+
+suite('reloadWindowForUpdate Test Suite', () => {
+  let originalCI: string | undefined;
+  let originalExecuteCommand: typeof vscode.commands.executeCommand;
+  const executedCommands: string[] = [];
+
+  setup(() => {
+    originalCI = process.env.CI;
+    process.env.CI = 'true';
+    executedCommands.length = 0;
+    originalExecuteCommand = vscode.commands.executeCommand;
+    vscode.commands.executeCommand = ((command: string) => {
+      executedCommands.push(command);
+      return Promise.resolve(undefined);
+    }) as typeof vscode.commands.executeCommand;
+  });
+
+  teardown(() => {
+    if (originalCI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCI;
+    }
+    vscode.commands.executeCommand = originalExecuteCommand;
+    restoreDefaultConfiguration();
+  });
+
+  test('stores version in globalState without reload under CI', async () => {
+    const context = createReloadContext('2.0.0');
+
+    await reloadWindowForUpdate(context);
+
+    assert.strictEqual(context.globalState.get<string>(migrationKey), '2.0.0');
+    assert.ok(!executedCommands.includes('workbench.action.reloadWindow'));
+  });
+
+  test('skips reload when version unchanged outside CI', async () => {
+    delete process.env.CI;
+    const context = createReloadContext('2.0.0');
+    await context.globalState.update(migrationKey, '2.0.0');
+
+    await reloadWindowForUpdate(context);
+
+    assert.ok(!executedCommands.includes('workbench.action.reloadWindow'));
+  });
+
+  test('skips reload when reloadOnUpdate is disabled', async () => {
+    delete process.env.CI;
+    mockConfiguration('codescene', { reloadOnUpdate: false });
+    const context = createReloadContext('2.0.0');
+    await context.globalState.update(migrationKey, '1.0.0');
+
+    await reloadWindowForUpdate(context);
+
+    assert.ok(!executedCommands.includes('workbench.action.reloadWindow'));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `BUILD_NO_ACE` build variant that strips ACE from runtime, extension settings, and bundled webview scripts
- Packages a second extension (`codescene.codescene-vscode-noace`, display name **CodeScene w/o ACE**) alongside the full build on each `v*` release
- Publishes the no-ACE variant to **Open VSX only**; full variant continues to VS Marketplace + Open VSX
- Documents mutual exclusivity in the no-ACE README and Open VSX description

## Test plan
- [x] Verify `npm run build` and `npm test` pass on default build
- [x] Verify `BUILD_NO_ACE=true` CI job skips ACE-specific tests
- [x] Package no-ACE VSIX locally and confirm `codescene.enableAutoRefactor` / `codescene.authToken` are absent from `package.json`
- [x] Dry-run release workflow matrix (10 VSIXes: 5 platforms x 2 variants)
- [x] Register `codescene.codescene-vscode-noace` on Open VSX before first publish
