### PR TITLE
CS-11199: TOCTOU on existsSync(cwd)

### DIFF
--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -15,7 +15,6 @@ import {
 } from './refactor-models';
 
 import { basename, dirname } from 'path';
-import { existsSync } from 'fs';
 import vscode, { ExtensionContext, TextDocument } from 'vscode';
 import { CodeSceneAuthenticationSession } from '../auth/auth-provider';
 import { getAuthToken } from '../configuration';
@@ -117,13 +116,7 @@ export class DevtoolsAPIImpl {
     cwd: string
   ): string {
     // IMPORTANT: keep stderr as part of the `msg`, so that network errors can be detected as such.
-    let cwdExists;
-    try {
-      cwdExists = existsSync(cwd);
-    } catch {
-      cwdExists = undefined;
-    }
-    const message = `devtools exit(${exitCode}) '${args.join(' ')}': ${errorMessage} - stdout: '${stdout}', stderr: '${stderr}', cwd: '${cwd} (exists: ${cwdExists})'`;
+    const message = `devtools exit(${exitCode}) '${args.join(' ')}': ${errorMessage} - stdout: '${stdout}', stderr: '${stderr}', cwd: '${cwd}'`;
     logOutputChannel.debug(message);
     return message;
   }


### PR DESCRIPTION
## Summary

This PR removes the TOCTOU-style cwd existence probe from devtools error-message construction. The change eliminates `existsSync(cwd)` from diagnostic logging while preserving stderr and cwd in the emitted message so existing network-error detection behavior remains intact.

## Ticket

https://app.clickup.com/t/9015696197/CS-11199

## Changes

- Updated `src/devtools-api/devtools-api-impl.ts`.
- Removed the unused `existsSync` import from `fs`.
- Removed the `cwdExists` try/catch block in `fullErrorMessage`.
- Kept stderr and cwd in the error message, but dropped the `(exists: ...)` suffix.

## Testing

- Ran `npm run test` (331 passing).
- Ran `npm run build` (tsc + lint + build successful).

## Acceptance Criteria

- [x] `existsSync` is no longer called in `devtools-api/devtools-api-impl.ts`
- [x] Error/log messages still include the `cwd` path for diagnostics
- [x] No functional behaviour changes
