### PR TITLE
feat: skip periodic GitChangeLister if VSCode is in the background

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+All commands for building, testing, linting etc are maintained at the Makefile. Do favor those over `npm` or `npx` commands.
+
+Use `make test1='<test name>'` to run a single test.
+
+If a linting issue is found, you must prioritize fixing it before resuming your previous intent.
+
+Don't add comments to any code you add, however keep any existing comments you find.

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -15,6 +15,7 @@ import { logOutputChannel } from '../log';
 import { SimpleExecutor } from '../simple-executor';
 import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
+import { isVSCodeWindowFocused } from '../extension-impl';
 
 let gitApi: API | undefined;
 let gitChangeListerInstance: GitChangeLister | undefined;
@@ -23,6 +24,16 @@ const clearTreeEmitter = new vscode.EventEmitter<void>();
 export const onTreeDataCleared = clearTreeEmitter.event;
 
 let ALL_DISPOSABLES: vscode.Disposable[] = [];
+
+export async function runScheduledGitChangeReview(): Promise<void> {
+  if (!isVSCodeWindowFocused()) {
+    logOutputChannel.debug('Skipping scheduled git change review: window not focused');
+    return;
+  }
+  if (!isGitAvailable()) return;
+  logOutputChannel.info('Starting scheduled git change review');
+  await gitChangeListerInstance!.start();
+}
 
 export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker) {
   if (!savedFilesTracker) {
@@ -46,11 +57,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
     .filter((repo) => repo?.state)
     .map((repo) => repo.state.onDidChange(() => void onRepoStateChange(repo)));
 
-  const baselineChangedListener = CsExtensionState.onBaselineChanged(async () => {
-    for (const repo of gitApi!.repositories) {
-      await setBaseline(repo);
-    }
-  });
+  const baselineChangedListener = CsExtensionState.onBaselineChanged(refreshMergeBaseBaselines);
 
   // Review all changed/added files every 9 seconds.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
@@ -58,11 +65,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
   gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
   const scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
 
-  void scheduledExecutor.executeTask(async () => {
-    if (!isGitAvailable()) return;
-    logOutputChannel.info('Starting scheduled git change review');
-    await gitChangeListerInstance!.start();
-  });
+  void scheduledExecutor.executeTask(runScheduledGitChangeReview);
 
   const codeHealthMonitorHelpCommand = vscode.commands.registerCommand('codescene.codeHealthMonitorHelp', () => {
     const params: InteractiveDocsParams = {

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -58,6 +58,7 @@ const codeHealthFileVersion = new Map<string, number>();
 
 let savedFilesTrackerInstance: SavedFilesTracker;
 let openFilesObserverInstance: OpenFilesObserver | undefined;
+let isWindowFocused: boolean = true;
 
 const onCodeHealthFileVersionChange = debounce(() => {
   if (!openFilesObserverInstance) {
@@ -108,8 +109,55 @@ const onCodesceneConfigChange = debounce((uri: vscode.Uri) => {
   });
 }, 350);
 
+function handleWindowStateChange(state: vscode.WindowState): void {
+  const previousState = isWindowFocused;
+  isWindowFocused = state.focused;
+
+  if (state.focused && !previousState) {
+    logOutputChannel.debug('VSCode window gained focus');
+  } else if (!state.focused && previousState) {
+    logOutputChannel.debug('VSCode window lost focus');
+  }
+}
+
+async function updateCodeHealthRulesVersion(uri: vscode.Uri): Promise<void> {
+  try {
+    const document = await vscode.workspace.openTextDocument(uri);
+    codeHealthFileVersion.set(document.fileName, document.version);
+    onCodeHealthFileVersionChange();
+  } catch (e) {
+    logOutputChannel.warn(`Failed to update code-health-rules.json version: ${uri.fsPath}`, e);
+  }
+}
+
+async function inspectStaleHomeViewFiles(gitChangeObserver: GitChangeObserver | undefined): Promise<void> {
+  const homeView = getHomeViewInstance();
+  if (!homeView) return;
+
+  const filenames = Array.from(homeView.getFileIssueMap().keys());
+
+  for (const filePath of filenames) {
+    try {
+      await access(filePath);
+    } catch {
+      fireFileDeletedFromGit(filePath);
+      if (gitChangeObserver) {
+        gitChangeObserver.removeFromTracker(filePath);
+      }
+    }
+  }
+}
+
 export function getCodeHealthFileVersions(): Map<string, number> {
   return codeHealthFileVersion;
+}
+
+export function isVSCodeWindowFocused(): boolean {
+  return isWindowFocused;
+}
+
+export function setWindowFocusedForTesting(focused: boolean): void {
+  isWindowFocused = focused;
 }
 
 async function initializeCodeHealthFileVersions() {
@@ -277,6 +325,12 @@ function addReviewListeners(context: vscode.ExtensionContext) {
   DISPOSABLES.push(openFilesObserverInstance);
   context.subscriptions.push(openFilesObserverInstance);
 
+  isWindowFocused = vscode.window.state.focused;
+
+  const windowStateListener = vscode.window.onDidChangeWindowState(handleWindowStateChange);
+  DISPOSABLES.push(windowStateListener);
+  context.subscriptions.push(windowStateListener);
+
   // Watch for discrete Git file changes (create, modify, delete)
   const gitApi = acquireGitApi();
   let gitChangeObserver: GitChangeObserver | undefined;
@@ -289,49 +343,15 @@ function addReviewListeners(context: vscode.ExtensionContext) {
 
   // Remove CHM stale files
   const filenameInspectorExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
-  void filenameInspectorExecutor.executeTask(async () => {
-    const homeView = getHomeViewInstance();
-    if (homeView) {
-      const filenames = Array.from(homeView.getFileIssueMap().keys());
-
-      // Check each file and fire deletion event for files that don't exist
-      for (const filePath of filenames) {
-        try {
-          await access(filePath);
-        } catch {
-          fireFileDeletedFromGit(filePath);
-          if (gitChangeObserver) {
-            gitChangeObserver.removeFromTracker(filePath);
-          }
-        }
-      }
-    }
-  });
+  void filenameInspectorExecutor.executeTask(() => inspectStaleHomeViewFiles(gitChangeObserver));
   DISPOSABLES.push(filenameInspectorExecutor);
   context.subscriptions.push(filenameInspectorExecutor);
 
   // Use a file system watcher to rerun diagnostics when .codescene/code-health-rules.json changes.
   const rulesFileWatcher = vscode.workspace.createFileSystemWatcher('**/.codescene/code-health-rules.json');
 
-  rulesFileWatcher.onDidChange(async (uri: vscode.Uri) => {
-    try {
-      const document = await vscode.workspace.openTextDocument(uri);
-      codeHealthFileVersion.set(document.fileName, document.version);
-      onCodeHealthFileVersionChange();
-    } catch (e) {
-      logOutputChannel.warn(`Failed to update code-health-rules.json version: ${uri.fsPath}`, e);
-    }
-  });
-
-  rulesFileWatcher.onDidCreate(async (uri: vscode.Uri) => {
-    try {
-      const document = await vscode.workspace.openTextDocument(uri);
-      codeHealthFileVersion.set(document.fileName, document.version);
-      onCodeHealthFileVersionChange();
-    } catch (e) {
-      logOutputChannel.warn(`Failed to add code-health-rules.json version: ${uri.fsPath}`, e);
-    }
-  });
+  rulesFileWatcher.onDidChange(updateCodeHealthRulesVersion);
+  rulesFileWatcher.onDidCreate(updateCodeHealthRulesVersion);
 
   rulesFileWatcher.onDidDelete((uri: vscode.Uri) => {
     codeHealthFileVersion.delete(uri.fsPath);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,6 +7,7 @@ import { PositionStub } from './stubs/position-stub';
 import { SelectionStub } from './stubs/selection-stub';
 import { WorkspaceEditStub } from './stubs/workspace-edit-stub';
 import { CodeActionStub } from './stubs/code-action-stub';
+import { CodeLensStub } from './stubs/code-lens-stub';
 import { ThemeColorStub } from './stubs/theme-color-stub';
 import { ThemeIconStub } from './stubs/theme-icon-stub';
 import { TreeItemStub } from './stubs/tree-item-stub';
@@ -149,6 +150,13 @@ const vscodeStub = {
     },
   },
   window: {
+    state: {
+      focused: true,
+    },
+    onDidChangeWindowState: (listener: any) => {
+      void listener;
+      return { dispose: () => {} };
+    },
     createOutputChannel: (name: string) => ({
       append: (text: string) => enableTestLogging && process.stdout.write(`[${name}] ${text}`),
       appendLine: (text: string) => enableTestLogging && console.log(`[${name}] ${text}`),
@@ -283,6 +291,7 @@ const vscodeStub = {
   Selection: SelectionStub,
   WorkspaceEdit: WorkspaceEditStub,
   CodeAction: CodeActionStub,
+  CodeLens: CodeLensStub,
   DiagnosticSeverity: {
     Error: 0,
     Warning: 1,

--- a/src/test/stubs/code-lens-stub.ts
+++ b/src/test/stubs/code-lens-stub.ts
@@ -1,0 +1,13 @@
+import { RangeStub } from './range-stub';
+
+export class CodeLensStub {
+  range: any;
+  command?: any;
+  isResolved: boolean;
+
+  constructor(range: any, command?: any) {
+    this.range = range || new RangeStub(0, 0, 0, 0);
+    this.command = command;
+    this.isResolved = command !== undefined;
+  }
+}

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -6,12 +6,14 @@ import {
   deactivate as deactivateCodeHealthMonitor,
   refreshMergeBaseBaselines,
   runGitChangeLister,
+  runScheduledGitChangeReview,
 } from '../../code-health-monitor/addon';
 import { CsExtensionState } from '../../cs-extension-state';
 import { DevtoolsAPI } from '../../devtools-api';
 import Reviewer from '../../review/reviewer';
 import { GitChangeLister } from '../../git/git-change-lister';
 import { markGitAsUnavailable, resetGitAvailability } from '../../git/git-detection';
+import { setWindowFocusedForTesting } from '../../extension-impl';
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { setMockGitRepositories, clearMockGitRepositories, mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
 import { ensureBinary } from '../integration_helper';
@@ -137,5 +139,33 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
     assert.strictEqual(startCalled, false);
     GitChangeLister.prototype.start = originalStart;
+  });
+
+  [
+    { focused: false, expectStartCalled: false, description: 'skips when window is not focused' },
+    { focused: true,  expectStartCalled: true , description: 'proceeds when window is focused' },
+  ].forEach(({ focused, expectStartCalled, description }) => {
+    test(`runScheduledGitChangeReview ${description}`, async function () {
+      this.timeout(20000);
+      setMockGitRepositories([createMockRepo()]);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+
+      setWindowFocusedForTesting(focused);
+
+      let startCalled = false;
+      const originalStart = GitChangeLister.prototype.start;
+      GitChangeLister.prototype.start = async function () {
+        startCalled = true;
+        return originalStart.call(this);
+      };
+
+      await runScheduledGitChangeReview();
+
+      assert.strictEqual(startCalled, expectStartCalled);
+      GitChangeLister.prototype.start = originalStart;
+      if (!focused) {
+        setWindowFocusedForTesting(true);
+      }
+    });
   });
 });


### PR DESCRIPTION
This can be a considered a performance improvement, with little downside.

I tested out that it works:

<img width="649" height="112" alt="image" src="https://github.com/user-attachments/assets/19fa1d68-8305-432e-9b6e-10c26732c798" />
