### PR TITLE
feat: dynamically increase GitChangeLister period based on execution time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,7 @@ Use `make test1='<test name>'` to run a single test.
 If a linting issue is found, you must prioritize fixing it before resuming your previous intent.
 
 Don't add comments to any code you add, however keep any existing comments you find.
+
+When writing tests, when possible express multiple test cases as a single array of objects to iterate on.
+
+Validate your work using `make lint`.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ tsc:
 lint:
 	npx commitlint --from main --to HEAD --verbose
 	npm run lint
+	@(command -v cs >/dev/null 2>&1 && cs delta main) || true
 
 watch:
 	npm run watch

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -17,8 +17,11 @@ import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
 import { isVSCodeWindowFocused } from '../extension-impl';
 
+const GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS = 9;
+
 let gitApi: API | undefined;
 let gitChangeListerInstance: GitChangeLister | undefined;
+let scheduledExecutorInstance: DroppingScheduledExecutor | undefined;
 
 const clearTreeEmitter = new vscode.EventEmitter<void>();
 export const onTreeDataCleared = clearTreeEmitter.event;
@@ -32,7 +35,22 @@ export async function runScheduledGitChangeReview(): Promise<void> {
   }
   if (!isGitAvailable()) return;
   logOutputChannel.info('Starting scheduled git change review');
+
+  const startTime = Date.now();
   await gitChangeListerInstance!.start();
+  const elapsedMs = Date.now() - startTime;
+  const elapsedSeconds = Math.ceil(elapsedMs / 1000);
+
+  logOutputChannel.debug(`Scheduled git change review completed in ${elapsedSeconds}s`);
+
+  if (elapsedSeconds > GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS && scheduledExecutorInstance) {
+    const newPeriod = GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS * 2 + elapsedSeconds;
+    const currentPeriod = scheduledExecutorInstance.getIntervalSeconds();
+    if (newPeriod > currentPeriod) {
+      scheduledExecutorInstance.setInterval(newPeriod);
+      logOutputChannel.info(`Git change review took ${elapsedSeconds}s, increased period to ${newPeriod}s`);
+    }
+  }
 }
 
 export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker) {
@@ -59,13 +77,13 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
 
   const baselineChangedListener = CsExtensionState.onBaselineChanged(refreshMergeBaseBaselines);
 
-  // Review all changed/added files every 9 seconds.
+  // Review all changed/added files periodically.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
   // because `CsDiagnostics.review` has built-in caching.
   gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
-  const scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
+  scheduledExecutorInstance = new DroppingScheduledExecutor(new SimpleExecutor(), GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS);
 
-  void scheduledExecutor.executeTask(runScheduledGitChangeReview);
+  void scheduledExecutorInstance.executeTask(runScheduledGitChangeReview);
 
   const codeHealthMonitorHelpCommand = vscode.commands.registerCommand('codescene.codeHealthMonitorHelp', () => {
     const params: InteractiveDocsParams = {
@@ -78,7 +96,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
   ALL_DISPOSABLES = [
     clearTreeEmitter,
     codeHealthMonitorView,
-    scheduledExecutor,
+    scheduledExecutorInstance,
     baselineChangedListener,
     codeHealthMonitorHelpCommand,
     ...repoStateListeners,
@@ -151,5 +169,10 @@ export function deactivate() {
   ALL_DISPOSABLES.forEach((disposable) => disposable.dispose());
   ALL_DISPOSABLES = [];
   gitChangeListerInstance = undefined;
+  scheduledExecutorInstance = undefined;
   gitApi = undefined;
+}
+
+export function getScheduledExecutorForTesting(): DroppingScheduledExecutor | undefined {
+  return scheduledExecutorInstance;
 }

--- a/src/dropping-scheduled-executor.ts
+++ b/src/dropping-scheduled-executor.ts
@@ -9,7 +9,7 @@ import { logOutputChannel } from './log';
  */
 export class DroppingScheduledExecutor implements Executor {
   private readonly executor: Executor;
-  private readonly intervalMs: number;
+  private intervalMs: number;
   private intervalHandle: NodeJS.Timeout | null = null;
   private isRunning = false;
   private scheduledTask: (() => Promise<any>) | null = null;
@@ -68,6 +68,21 @@ export class DroppingScheduledExecutor implements Executor {
   }
 
   abortAllTasks(): void {
+  }
+
+  getIntervalSeconds(): number {
+    return this.intervalMs / 1000;
+  }
+
+  setInterval(newIntervalSeconds: number): void {
+    this.intervalMs = newIntervalSeconds * 1000;
+
+    if (this.intervalHandle !== null) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = setInterval(() => {
+        this.runScheduledTask().catch(() => {});
+      }, this.intervalMs);
+    }
   }
 
   private async runScheduledTask(): Promise<any> {

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -7,6 +7,7 @@ import {
   refreshMergeBaseBaselines,
   runGitChangeLister,
   runScheduledGitChangeReview,
+  getScheduledExecutorForTesting,
 } from '../../code-health-monitor/addon';
 import { CsExtensionState } from '../../cs-extension-state';
 import { DevtoolsAPI } from '../../devtools-api';
@@ -167,5 +168,71 @@ suite('Code Health Monitor Addon Test Suite', () => {
         setWindowFocusedForTesting(true);
       }
     });
+  });
+
+  test('runScheduledGitChangeReview increases period when git operations exceed base period', async function () {
+    this.timeout(20000);
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    setWindowFocusedForTesting(true);
+
+    const executor = getScheduledExecutorForTesting();
+    assert.ok(executor, 'Scheduled executor should exist');
+    const initialPeriod = executor.getIntervalSeconds();
+    assert.strictEqual(initialPeriod, 9);
+
+    const originalStart = GitChangeLister.prototype.start;
+    GitChangeLister.prototype.start = async function () {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    };
+
+    const originalDateNow = Date.now;
+    let callCount = 0;
+    Date.now = () => {
+      callCount++;
+      if (callCount === 1) return 0;
+      return 15000;
+    };
+
+    await runScheduledGitChangeReview();
+
+    const newPeriod = executor.getIntervalSeconds();
+    assert.strictEqual(newPeriod, 9 * 2 + Math.ceil(15));
+
+    Date.now = originalDateNow;
+    GitChangeLister.prototype.start = originalStart;
+  });
+
+  test('runScheduledGitChangeReview does not decrease period', async function () {
+    this.timeout(20000);
+    setMockGitRepositories([createMockRepo()]);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    setWindowFocusedForTesting(true);
+
+    const executor = getScheduledExecutorForTesting();
+    assert.ok(executor, 'Scheduled executor should exist');
+
+    executor.setInterval(50);
+    assert.strictEqual(executor.getIntervalSeconds(), 50);
+
+    const originalStart = GitChangeLister.prototype.start;
+    GitChangeLister.prototype.start = async function () {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    };
+
+    const originalDateNow = Date.now;
+    let callCount = 0;
+    Date.now = () => {
+      callCount++;
+      if (callCount === 1) return 0;
+      return 15000;
+    };
+
+    await runScheduledGitChangeReview();
+
+    assert.strictEqual(executor.getIntervalSeconds(), 50);
+
+    Date.now = originalDateNow;
+    GitChangeLister.prototype.start = originalStart;
   });
 });

--- a/src/test/suite/dropping-scheduled-executor.test.ts
+++ b/src/test/suite/dropping-scheduled-executor.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import { DroppingScheduledExecutor } from '../../dropping-scheduled-executor';
+import { SimpleExecutor } from '../../simple-executor';
+
+suite('DroppingScheduledExecutor Test Suite', () => {
+  test('getIntervalSeconds returns the initial interval', () => {
+    const executor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
+    assert.strictEqual(executor.getIntervalSeconds(), 9);
+    executor.dispose();
+  });
+
+  test('setInterval updates the interval', () => {
+    const executor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
+    executor.setInterval(20);
+    assert.strictEqual(executor.getIntervalSeconds(), 20);
+    executor.dispose();
+  });
+
+  test('setInterval can set a smaller interval', () => {
+    const executor = new DroppingScheduledExecutor(new SimpleExecutor(), 9);
+    executor.setInterval(5);
+    assert.strictEqual(executor.getIntervalSeconds(), 5);
+    executor.dispose();
+  });
+
+  test('setInterval updates running scheduler', async () => {
+    const executor = new DroppingScheduledExecutor(new SimpleExecutor(), 1);
+    let callCount = 0;
+
+    void executor.executeTask(async () => {
+      callCount++;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.strictEqual(callCount, 1);
+
+    executor.setInterval(10);
+    assert.strictEqual(executor.getIntervalSeconds(), 10);
+
+    executor.dispose();
+  });
+
+  test('runs task periodically and handles period changes without dropping work', async function() {
+    this.timeout(15000);
+
+    const executor = new DroppingScheduledExecutor(new SimpleExecutor(), 0.3);
+    const executions: number[] = [];
+    const startTime = Date.now();
+
+    void executor.executeTask(async () => {
+      executions.push(Date.now() - startTime);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    assert.ok(executions.length >= 3, `Expected at least 3 executions at 300ms interval, got ${executions.length}`);
+    const initialCount = executions.length;
+
+    for (let i = 1; i < Math.min(4, executions.length); i++) {
+      const spacing = executions[i] - executions[i - 1];
+      assert.ok(spacing >= 150 && spacing <= 600, `Execution spacing ${spacing}ms outside expected range 150-600ms`);
+    }
+
+    executor.setInterval(1.5);
+
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    const countAfterChange = executions.length;
+    assert.ok(countAfterChange > initialCount, `Expected more executions after period change, got ${countAfterChange} (was ${initialCount})`);
+
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    const finalCount = executions.length;
+
+    const newExecutions = finalCount - initialCount;
+    assert.ok(newExecutions >= 2 && newExecutions <= 8, `Expected 2-8 new executions at 1500ms interval over 6000ms, got ${newExecutions}`);
+
+    for (let i = initialCount + 1; i < finalCount; i++) {
+      const spacing = executions[i] - executions[i - 1];
+      assert.ok(spacing >= 800 && spacing <= 2500, `Post-change execution spacing ${spacing}ms outside expected range 800-2500ms`);
+    }
+
+    executor.dispose();
+  });
+});


### PR DESCRIPTION
When GitChangeLister calls take longer than the base period (9s), the scheduler now dynamically increases its period to prevent excessive resource consumption.

I verified that it works with some artificial delays and logging:

<img width="722" height="225" alt="image" src="https://github.com/user-attachments/assets/7452e7ce-c37f-4a98-ad7a-c09873f8314b" />
