### PR TITLE
feat: skip GitChangeLister when analyses are running

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 All commands for building, testing, linting etc are maintained at the Makefile. Do favor those over `npm` or `npx` commands.
 
-Use `make test1='<test name>'` to run a single test.
+Use `make test1 TEST='<test name>'` to run a single test.
 
 If a linting issue is found, you must prioritize fixing it before resuming your previous intent.
 

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -34,6 +34,10 @@ export async function runScheduledGitChangeReview(): Promise<void> {
     return;
   }
   if (!isGitAvailable()) return;
+  if (DevtoolsAPI.isAnalysisRunning) {
+    logOutputChannel.info('Skipping scheduled git change review: analysis in progress');
+    return;
+  }
   logOutputChannel.info('Starting scheduled git change review');
 
   const startTime = Date.now();

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -106,6 +106,12 @@ export class DevtoolsAPI {
   /** Emits events when review or delta analysis state changes (running/idle?) */
   public static readonly onDidAnalysisStateChange = DevtoolsAPI.analysisStateEmitter.event;
   private static analysesRunning = 0;
+  public static get isAnalysisRunning(): boolean {
+    return DevtoolsAPI.analysesRunning > 0;
+  }
+  public static setAnalysesRunningForTesting(count: number): void {
+    DevtoolsAPI.analysesRunning = count;
+  }
   public static jobs = new Set<string>(); // Keep track of the filename of current jobs
   private static readonly analysisErrorEmitter = new vscode.EventEmitter<Error>();
   public static readonly onDidAnalysisFail = DevtoolsAPI.analysisErrorEmitter.event;

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -170,6 +170,35 @@ suite('Code Health Monitor Addon Test Suite', () => {
     });
   });
 
+  [
+    { analysesRunning: 0, expectStartCalled: true,  description: 'proceeds when no analysis is running' },
+    { analysesRunning: 1, expectStartCalled: false, description: 'skips when analysis is running' },
+  ].forEach(({ analysesRunning, expectStartCalled, description }) => {
+    test(`runScheduledGitChangeReview ${description}`, async function () {
+      this.timeout(20000);
+      setMockGitRepositories([createMockRepo()]);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+
+      setWindowFocusedForTesting(true);
+      DevtoolsAPI.setAnalysesRunningForTesting(analysesRunning);
+
+      let startCalled = false;
+      const originalStart = GitChangeLister.prototype.start;
+      GitChangeLister.prototype.start = async function () {
+        startCalled = true;
+        return originalStart.call(this);
+      };
+
+      try {
+        await runScheduledGitChangeReview();
+        assert.strictEqual(startCalled, expectStartCalled);
+      } finally {
+        GitChangeLister.prototype.start = originalStart;
+        DevtoolsAPI.setAnalysesRunningForTesting(0);
+      }
+    });
+  });
+
   test('runScheduledGitChangeReview increases period when git operations exceed base period', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);


### PR DESCRIPTION
Add skip condition to `runScheduledGitChangeReview` that prevents periodic GitChangeLister runs when DevtoolsAPI analyses are in progress, reducing load.

I verified that reviews can be dropped (first line in screenshot) and then re-taken (last line):

<img width="704" height="304" alt="image" src="https://github.com/user-attachments/assets/25da7223-ca1d-4813-8161-cbfbafa20066" />
