### PR TITLE
feat: skip GitChangeLister and GitChangeObserver on default branch

### DIFF
--- a/.claude/TESTING.md
+++ b/.claude/TESTING.md
@@ -1,0 +1,19 @@
+## General guidelines
+
+When writing tests, when possible express multiple test cases as a single array of objects to iterate on.
+
+## Mocking
+
+Always prefer existing mocks from `src/test/mocks/` and `src/test/setup.ts` over creating bespoke mocks. Never create inline object literals mimicking VSCode types when established mocks exist.
+
+For unit tests, import from `src/test/mocks/vscode.ts` to get lightweight mocks of Position, Range, Selection, Uri, and command tracking via `executedCommands`/`resetExecutedCommands()`.
+For integration tests, use `createTestDir()` and `ensureBinary()` from `integration_helper.ts`.
+
+## Dealing with failing tests
+
+Generally, tests that you write and then fail should be fixed. Do not delete them or fundamentally change their approach.
+
+The prefered course of action for failing tests is:
+
+- add `console.log` statements to gather fact-based feedback
+- or, if no solution is found, ask the user for the preferred solution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,6 @@ If a linting issue is found, you must prioritize fixing it before resuming your 
 
 Don't add comments to any code you add, however keep any existing comments you find.
 
-When writing tests, when possible express multiple test cases as a single array of objects to iterate on.
+Testing practices: see [TESTING.md](.claude/TESTING.md).
 
 Validate your work using `make lint`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,4 +8,6 @@ Don't add comments to any code you add, however keep any existing comments you f
 
 Testing practices: see [TESTING.md](.claude/TESTING.md).
 
-Validate your work using `make lint`.
+Validate your work using `make lint`. Satifying all linter faults is mandatory - they must be addressed before proceeding with other work.
+
+If you find an issue at any stage, you must fix it immediately, regardless of whether you think it's pre-existing.

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -16,6 +16,7 @@ import { SimpleExecutor } from '../simple-executor';
 import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
 import { isVSCodeWindowFocused } from '../extension-impl';
+import { DefaultBranchGate } from '../git/default-branch-gate';
 
 const GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS = 9;
 
@@ -57,9 +58,12 @@ export async function runScheduledGitChangeReview(): Promise<void> {
   }
 }
 
-export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker) {
+export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate | undefined) {
   if (!savedFilesTracker) {
     throw new Error('SavedFilesTracker must be provided to activate Code Health Monitor');
+  }
+  if (!defaultBranchGate) {
+    throw new Error('DefaultBranchGate must be provided to activate Code Health Monitor');
   }
 
   gitApi = acquireGitApi();
@@ -84,7 +88,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
   // Review all changed/added files periodically.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
   // because `CsDiagnostics.review` has built-in caching.
-  gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
+  gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker, defaultBranchGate);
   scheduledExecutorInstance = new DroppingScheduledExecutor(new SimpleExecutor(), GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS);
 
   void scheduledExecutorInstance.executeTask(runScheduledGitChangeReview);
@@ -179,4 +183,8 @@ export function deactivate() {
 
 export function getScheduledExecutorForTesting(): DroppingScheduledExecutor | undefined {
   return scheduledExecutorInstance;
+}
+
+export function setGitApiForTesting(api: API | undefined): void {
+  gitApi = api;
 }

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -35,6 +35,7 @@ import { registerCopyDeviceIdCommand } from './device-id';
 import { GitChangeObserver } from './git/git-change-observer';
 import { OpenFilesObserver } from './review/open-files-observer';
 import { acquireGitApi, clearMainBranchCandidatesCache, deactivate as deactivateGitUtils, fireFileDeletedFromGit } from './git-utils';
+import { DefaultBranchGate } from './git/default-branch-gate';
 import { gitRootFromCodesceneConfigUri } from './git/codescene-repo-config';
 import { DroppingScheduledExecutor } from './dropping-scheduled-executor';
 import { SimpleExecutor } from './simple-executor';
@@ -58,6 +59,7 @@ const codeHealthFileVersion = new Map<string, number>();
 
 let savedFilesTrackerInstance: SavedFilesTracker;
 let openFilesObserverInstance: OpenFilesObserver | undefined;
+let defaultBranchGateInstance: DefaultBranchGate | undefined;
 let isWindowFocused: boolean = true;
 
 const onCodeHealthFileVersionChange = debounce(() => {
@@ -211,6 +213,41 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 }
 
+function initializeGitIntegration() {
+  const gitApi = acquireGitApi();
+  if (!gitApi) return;
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  const repo = workspaceFolder ? gitApi.getRepository(workspaceFolder.uri) : undefined;
+  const gitRootPath = repo?.rootUri.fsPath || workspaceFolder?.uri.fsPath || '';
+  defaultBranchGateInstance = new DefaultBranchGate(gitRootPath);
+}
+
+function setupCodeLensProviders(context: vscode.ExtensionContext) {
+  // Add Review CodeLens support
+  const codeLensProvider = new CsReviewCodeLensProvider();
+  DISPOSABLES.push(codeLensProvider);
+  context.subscriptions.push(codeLensProvider);
+  const codeLensProviderRegistration = vscode.languages.registerCodeLensProvider(
+    reviewDocumentSelector(),
+    codeLensProvider
+  );
+  DISPOSABLES.push(codeLensProviderRegistration);
+  context.subscriptions.push(codeLensProviderRegistration);
+}
+
+function setupAceConfiguration(context: vscode.ExtensionContext) {
+  // If configuration option is changed, en/disable ACE capabilities accordingly - debounce to handle rapid changes
+  const debouncedSetEnabledAce = debounce((enabled: boolean) => {
+    void vscode.commands.executeCommand('codescene.ace.setEnabled', enabled);
+  }, 500);
+  const aceConfigDisposable = onDidChangeConfiguration('enableAutoRefactor', (e) => {
+    debouncedSetEnabledAce(e.value);
+  });
+  DISPOSABLES.push(aceConfigDisposable);
+  context.subscriptions.push(aceConfigDisposable);
+}
+
 async function startExtension(context: vscode.ExtensionContext) {
   const csWorkspace = new CsWorkspace(context);
   const csContext: CsContext = {
@@ -247,31 +284,16 @@ async function startExtension(context: vscode.ExtensionContext) {
 
   setupStatsCollector(context);
 
-  activateCHMonitor(context, savedFilesTrackerInstance);
+  initializeGitIntegration();
 
-  // Add Review CodeLens support
-  const codeLensProvider = new CsReviewCodeLensProvider();
-  DISPOSABLES.push(codeLensProvider);
-  context.subscriptions.push(codeLensProvider);
-  const codeLensProviderRegistration = vscode.languages.registerCodeLensProvider(
-    reviewDocumentSelector(),
-    codeLensProvider
-  );
-  DISPOSABLES.push(codeLensProviderRegistration);
-  context.subscriptions.push(codeLensProviderRegistration);
+  activateCHMonitor(context, savedFilesTrackerInstance, defaultBranchGateInstance);
+
+  setupCodeLensProviders(context);
 
   registerCodeActionProvider(context);
 
   if (ACE_ENABLED) {
-    // If configuration option is changed, en/disable ACE capabilities accordingly - debounce to handle rapid changes
-    const debouncedSetEnabledAce = debounce((enabled: boolean) => {
-      void vscode.commands.executeCommand('codescene.ace.setEnabled', enabled);
-    }, 500);
-    const aceConfigDisposable = onDidChangeConfiguration('enableAutoRefactor', (e) => {
-      debouncedSetEnabledAce(e.value);
-    });
-    DISPOSABLES.push(aceConfigDisposable);
-    context.subscriptions.push(aceConfigDisposable);
+    setupAceConfiguration(context);
   }
 }
 
@@ -334,8 +356,8 @@ function addReviewListeners(context: vscode.ExtensionContext) {
   // Watch for discrete Git file changes (create, modify, delete)
   const gitApi = acquireGitApi();
   let gitChangeObserver: GitChangeObserver | undefined;
-  if (gitApi) {
-    gitChangeObserver = new GitChangeObserver(context, DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTrackerInstance, openFilesObserverInstance);
+  if (gitApi && defaultBranchGateInstance) {
+    gitChangeObserver = new GitChangeObserver(context, DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTrackerInstance, openFilesObserverInstance, defaultBranchGateInstance);
     gitChangeObserver.start();
     DISPOSABLES.push(gitChangeObserver);
     context.subscriptions.push(gitChangeObserver);

--- a/src/git/default-branch-gate.ts
+++ b/src/git/default-branch-gate.ts
@@ -1,0 +1,36 @@
+import { Repository } from '../../types/git';
+import { getDefaultBranch } from '../git-utils';
+
+export class DefaultBranchGate {
+  private repoPath: string;
+  private cachedDefaultBranch: string | undefined = undefined;
+  private hasFetched: boolean = false;
+
+  constructor(repoPath: string) {
+    this.repoPath = repoPath;
+  }
+
+  private async fetchDefaultBranch(): Promise<string | undefined> {
+    if (!this.hasFetched) {
+      this.cachedDefaultBranch = await getDefaultBranch(this.repoPath);
+      this.hasFetched = true;
+    }
+    return this.cachedDefaultBranch;
+  }
+
+  async shouldSkipBasedOnDefaultBranch(repo: Repository): Promise<boolean> {
+    const currentBranch = repo.state.HEAD?.name;
+
+    if (!currentBranch) {
+      return false;
+    }
+
+    const defaultBranch = await this.fetchDefaultBranch();
+
+    if (!defaultBranch) {
+      return false;
+    }
+
+    return currentBranch.localeCompare(defaultBranch, undefined, { sensitivity: 'accent' }) === 0;
+  }
+}

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -10,6 +10,7 @@ import { getRepo } from '../code-health-monitor/addon';
 import { getCommittedChanges, getStatusChanges } from './git-diff-utils';
 import { getWorkspaceFolder } from '../utils';
 import { SavedFilesTracker } from '../saved-files-tracker';
+import { DefaultBranchGate } from './default-branch-gate';
 
 /**
  * Lists all changed files exhaustively from Git status, and Git diff vs. merge-base.
@@ -17,13 +18,18 @@ import { SavedFilesTracker } from '../saved-files-tracker';
 export class GitChangeLister {
   private executor: Executor;
   private savedFilesTracker: SavedFilesTracker;
+  private defaultBranchGate: DefaultBranchGate;
 
-  constructor(executor: Executor, savedFilesTracker: SavedFilesTracker) {
+  constructor(executor: Executor, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate) {
     if (!savedFilesTracker) {
       throw new Error('SavedFilesTracker must be provided to GitChangeLister');
     }
+    if (!defaultBranchGate) {
+      throw new Error('DefaultBranchGate must be provided to GitChangeLister');
+    }
     this.executor = executor;
     this.savedFilesTracker = savedFilesTracker;
+    this.defaultBranchGate = defaultBranchGate;
   }
 
   // NOTE:
@@ -37,6 +43,12 @@ export class GitChangeLister {
       const workspacePath = getWorkspacePath(workspaceFolder);
       const repo = getRepo(workspaceFolder.uri);
       const gitRootPath = repo?.rootUri.fsPath || workspacePath;
+
+      if (repo && await this.defaultBranchGate.shouldSkipBasedOnDefaultBranch(repo)) {
+        logOutputChannel.debug('GitChangeLister: skipping processing, current branch matches default branch');
+        return;
+      }
+
       const allChangedFiles = await this.getAllChangedFiles(gitRootPath, workspacePath);
       this.reviewFiles(allChangedFiles);
     }

--- a/src/git/git-change-observer.ts
+++ b/src/git/git-change-observer.ts
@@ -15,6 +15,7 @@ import { SavedFilesTracker } from '../saved-files-tracker';
 import { DroppingScheduledExecutor } from '../dropping-scheduled-executor';
 import { SimpleExecutor } from '../simple-executor';
 import { OpenFilesObserver } from '../review/open-files-observer';
+import { DefaultBranchGate } from './default-branch-gate';
 
 /**
  * Observes discrete Git file changes in real-time, filtering them against the Git merge-base.
@@ -26,6 +27,7 @@ export class GitChangeObserver {
   private context: vscode.ExtensionContext;
   private savedFilesTracker: SavedFilesTracker;
   private openFilesObserver: OpenFilesObserver;
+  private defaultBranchGate: DefaultBranchGate;
 
   // Tracks the files that have been added though this Observer.
   // We need this because deletion events are tricky:
@@ -36,34 +38,46 @@ export class GitChangeObserver {
 
   private eventQueue: Array<{type: 'create' | 'change' | 'delete', uri: vscode.Uri}> = [];
 
-  constructor(context: vscode.ExtensionContext, executor: Executor, savedFilesTracker: SavedFilesTracker, openFilesObserver: OpenFilesObserver) {
+  constructor(context: vscode.ExtensionContext, executor: Executor, savedFilesTracker: SavedFilesTracker, openFilesObserver: OpenFilesObserver, defaultBranchGate: DefaultBranchGate) {
+    this.validateDependencies(savedFilesTracker, openFilesObserver, defaultBranchGate);
+
+    this.context = context;
+    this.executor = executor;
+    this.savedFilesTracker = savedFilesTracker;
+    this.openFilesObserver = openFilesObserver;
+    this.defaultBranchGate = defaultBranchGate;
+    this.scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 1);
+    this.fileWatcher = this.createWatcher('**/*');
+
+    this.initializeTracker(executor, savedFilesTracker, defaultBranchGate);
+  }
+
+  private validateDependencies(savedFilesTracker: SavedFilesTracker, openFilesObserver: OpenFilesObserver, defaultBranchGate: DefaultBranchGate): void {
     if (!savedFilesTracker) {
       throw new Error('SavedFilesTracker must be provided to GitChangeObserver');
     }
     if (!openFilesObserver) {
       throw new Error('OpenFilesObserver must be provided to GitChangeObserver');
     }
-
-    this.context = context;
-    this.executor = executor;
-    this.savedFilesTracker = savedFilesTracker;
-    this.openFilesObserver = openFilesObserver;
-    this.scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 1);
-    this.fileWatcher = this.createWatcher('**/*');
-
-    // Initially fill the tracker - this ensures `handleFileDelete` works well
-    const lister = new GitChangeLister(executor, savedFilesTracker);
-    const workspaceFolder = getWorkspaceFolder();
-    if (workspaceFolder) {
-      const workspacePath = getWorkspacePath(workspaceFolder);
-      const repo = getRepo(workspaceFolder.uri);
-      const gitRootPath = repo?.rootUri.fsPath || workspacePath;
-      void lister.collectFilesFromRepoState(gitRootPath, workspacePath).then(files => {
-        for (const file of files) {
-          this.tracker.add(file);
-        }
-      });
+    if (!defaultBranchGate) {
+      throw new Error('DefaultBranchGate must be provided to GitChangeObserver');
     }
+  }
+
+  private initializeTracker(executor: Executor, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate): void {
+    // Initially fill the tracker - this ensures `handleFileDelete` works well
+    const lister = new GitChangeLister(executor, savedFilesTracker, defaultBranchGate);
+    const workspaceFolder = getWorkspaceFolder();
+    if (!workspaceFolder) return;
+
+    const workspacePath = getWorkspacePath(workspaceFolder);
+    const repo = getRepo(workspaceFolder.uri);
+    const gitRootPath = repo?.rootUri.fsPath || workspacePath;
+    void lister.collectFilesFromRepoState(gitRootPath, workspacePath).then(files => {
+      for (const file of files) {
+        this.tracker.add(file);
+      }
+    });
   }
 
   start(): void {
@@ -82,19 +96,40 @@ export class GitChangeObserver {
     }
 
     const workspaceFolder = getWorkspaceFolder();
+    const repo = workspaceFolder ? getRepo(workspaceFolder.uri) : undefined;
+    const shouldSkip = repo
+      ? await this.defaultBranchGate.shouldSkipBasedOnDefaultBranch(repo)
+      : false;
+
     const changedFiles = await this.getChangedFilesVsBaseline(workspaceFolder);
 
     for (const event of events) {
+      await this.processEvent(event, changedFiles, workspaceFolder, shouldSkip);
+    }
+  }
 
-      // NOTE: we _don't_ need to use gitignore to efficiently determine if a file should be processed,
-      // because we use `getChangedFilesVsBaseline` as the computation basis, which uses `git diff` and `git status`,
-      // which inherently honor gitignore.
+  private async processEvent(
+    event: {type: 'create' | 'change' | 'delete', uri: vscode.Uri},
+    changedFiles: string[],
+    workspaceFolder: vscode.WorkspaceFolder | undefined,
+    shouldSkip: boolean
+  ): Promise<void> {
+    // NOTE: we _don't_ need to use gitignore to efficiently determine if a file should be processed,
+    // because we use `getChangedFilesVsBaseline` as the computation basis, which uses `git diff` and `git status`,
+    // which inherently honor gitignore.
 
-      if (event.type === 'delete' || !this.isFileInChangedList(event.uri.fsPath, changedFiles, workspaceFolder)) {
-        await this.handleFileDelete(event.uri, changedFiles, workspaceFolder);
-      } else {
-        await this.handleFileChange(event.uri, changedFiles, workspaceFolder);
-      }
+    const isDeleteEvent = event.type === 'delete';
+    const isFileNotInChangedList = !this.isFileInChangedList(event.uri.fsPath, changedFiles, workspaceFolder);
+
+    if (isDeleteEvent || isFileNotInChangedList) {
+      await this.handleFileDelete(event.uri, changedFiles, workspaceFolder);
+      return;
+    }
+
+    if (!shouldSkip) {
+      await this.handleFileChange(event.uri, changedFiles, workspaceFolder);
+    } else {
+      logOutputChannel.debug(`GitChangeObserver: skipping file change ${event.uri.fsPath}, current branch matches default branch`);
     }
   }
 

--- a/src/test/mocks/mock-git-api.ts
+++ b/src/test/mocks/mock-git-api.ts
@@ -2,4 +2,9 @@ import { API } from '../../../types/git';
 
 export class MockGitAPI implements Partial<API> {
   repositories: any[] = [];
+
+  getRepository(uri: any) {
+    const fsPath = uri.fsPath || uri.path || '';
+    return this.repositories.find((repo) => fsPath.startsWith(repo.rootUri.fsPath)) || null;
+  }
 }

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -18,9 +18,11 @@ import { setWindowFocusedForTesting } from '../../extension-impl';
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { setMockGitRepositories, clearMockGitRepositories, mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
 import { ensureBinary } from '../integration_helper';
+import { DefaultBranchGate } from '../../git/default-branch-gate';
 
 suite('Code Health Monitor Addon Test Suite', () => {
   let mockContext: ReturnType<typeof createMockExtensionContext>;
+  let mockDefaultBranchGate: DefaultBranchGate;
   const repoRoot = path.join(__dirname, '../../../test-git-repo-addon');
 
   function createMockRepo(rootPath: string = repoRoot) {
@@ -41,6 +43,12 @@ suite('Code Health Monitor Addon Test Suite', () => {
     };
   }
 
+  function createMockDefaultBranchGate(): DefaultBranchGate {
+    return {
+      shouldSkipBasedOnDefaultBranch: async () => false,
+    } as any;
+  }
+
   suiteSetup(async function () {
     this.timeout(60000);
     const binaryPath = await ensureBinary();
@@ -54,6 +62,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     resetGitAvailability();
     clearMockGitRepositories();
     mockWorkspaceFolders([createMockWorkspaceFolder(repoRoot)]);
+    mockDefaultBranchGate = createMockDefaultBranchGate();
   });
 
   teardown(() => {
@@ -73,7 +82,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('refreshMergeBaseBaselines updates review baselines for all repositories', () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
 
     let setBaselineCalls = 0;
     const originalSetBaseline = Reviewer.instance.setBaseline.bind(Reviewer.instance);
@@ -91,7 +100,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runGitChangeLister invokes lister after activation', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
 
     let startCalled = false;
     const originalStart = GitChangeLister.prototype.start;
@@ -108,7 +117,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('runGitChangeLister is a no-op when git is unavailable', async () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
     markGitAsUnavailable();
 
     let startCalled = false;
@@ -126,7 +135,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('deactivate clears git change lister instance', async () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
     deactivateCodeHealthMonitor();
 
     let startCalled = false;
@@ -149,7 +158,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     test(`runScheduledGitChangeReview ${description}`, async function () {
       this.timeout(20000);
       setMockGitRepositories([createMockRepo()]);
-      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
 
       setWindowFocusedForTesting(focused);
 
@@ -177,7 +186,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     test(`runScheduledGitChangeReview ${description}`, async function () {
       this.timeout(20000);
       setMockGitRepositories([createMockRepo()]);
-      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
 
       setWindowFocusedForTesting(true);
       DevtoolsAPI.setAnalysesRunningForTesting(analysesRunning);
@@ -202,7 +211,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runScheduledGitChangeReview increases period when git operations exceed base period', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
     setWindowFocusedForTesting(true);
 
     const executor = getScheduledExecutorForTesting();
@@ -235,7 +244,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runScheduledGitChangeReview does not decrease period', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
     setWindowFocusedForTesting(true);
 
     const executor = getScheduledExecutorForTesting();

--- a/src/test/suite/default-branch-gate.test.ts
+++ b/src/test/suite/default-branch-gate.test.ts
@@ -1,0 +1,236 @@
+import * as assert from 'assert';
+import { execSync } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import { Uri } from 'vscode';
+import { DefaultBranchGate } from '../../git/default-branch-gate';
+import { CODE_SCENE_DIR, CONFIG_FILE_NAME } from '../../git/codescene-repo-config';
+import { clearMainBranchCandidatesCache } from '../../git-utils';
+import { Repository, RepositoryState, Branch, RepositoryUIState } from '../../../types/git';
+
+suite('DefaultBranchGate Test Suite', () => {
+  const testRepoBasePath = path.join(__dirname, '../../../test-git-repo-default-branch-gate');
+  let testRepoPath: string;
+  let testCounter = 0;
+
+  setup(function () {
+    this.timeout(20000);
+
+    testCounter++;
+    testRepoPath = `${testRepoBasePath}-${testCounter}`;
+
+    if (fs.existsSync(testRepoPath)) {
+      fs.rmSync(testRepoPath, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testRepoPath, { recursive: true });
+
+    execSync('git init', { cwd: testRepoPath });
+    execSync('git config user.email "test@example.com"', { cwd: testRepoPath });
+    execSync('git config user.name "Test User"', { cwd: testRepoPath });
+    execSync('git config advice.defaultBranchName false', { cwd: testRepoPath });
+  });
+
+  teardown(function () {
+    this.timeout(20000);
+    const parentDir = path.dirname(testRepoBasePath);
+    if (fs.existsSync(parentDir)) {
+      const files = fs.readdirSync(parentDir);
+      files.forEach((file) => {
+        if (file.startsWith(path.basename(testRepoBasePath))) {
+          const fullPath = path.join(parentDir, file);
+          if (fs.existsSync(fullPath)) {
+            fs.rmSync(fullPath, { recursive: true, force: true });
+          }
+        }
+      });
+    }
+  });
+
+  function createMockRepository(
+    rootPath: string,
+    branchName: string | undefined,
+    commitSha: string | undefined
+  ): Repository {
+    const head: Branch | undefined = branchName
+      ? { type: 0, name: branchName, commit: commitSha }
+      : undefined;
+
+    return {
+      rootUri: Uri.file(rootPath),
+      state: {
+        HEAD: head,
+        refs: [],
+        remotes: [],
+        submodules: [],
+        rebaseCommit: undefined,
+        mergeChanges: [],
+        indexChanges: [],
+        workingTreeChanges: [],
+        untrackedChanges: [],
+        onDidChange: (() => {}) as any,
+      } as RepositoryState,
+      ui: {} as RepositoryUIState,
+      inputBox: {} as any,
+      onDidCommit: (() => {}) as any,
+    } as Repository;
+  }
+
+  function commitFile(filename: string, content: string, message: string): void {
+    fs.writeFileSync(path.join(testRepoPath, filename), content);
+    execSync('git add .', { cwd: testRepoPath });
+    execSync(`git commit -m "${message}"`, { cwd: testRepoPath });
+  }
+
+  function getHeadCommit(): string {
+    return execSync('git rev-parse HEAD', { cwd: testRepoPath }).toString().trim();
+  }
+
+  function setupOriginHead(defaultBranch: string): void {
+    const branchSha = execSync(`git rev-parse ${defaultBranch}`, { cwd: testRepoPath }).toString().trim();
+    execSync(`git update-ref refs/remotes/origin/${defaultBranch} ${branchSha}`, {
+      cwd: testRepoPath,
+      stdio: 'pipe',
+    });
+    execSync(`git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/${defaultBranch}`, {
+      cwd: testRepoPath,
+      stdio: 'pipe',
+    });
+  }
+
+  function writeBaselineConfig(branch: string): void {
+    const codesceneDir = path.join(testRepoPath, CODE_SCENE_DIR);
+    fs.mkdirSync(codesceneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codesceneDir, CONFIG_FILE_NAME),
+      JSON.stringify({ baseline_branch: branch })
+    );
+    clearMainBranchCandidatesCache(testRepoPath);
+  }
+
+  suite('shouldSkipBasedOnDefaultBranch', () => {
+    const testCases = [
+      {
+        name: 'returns true when current branch equals default branch',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+          setupOriginHead('main');
+        },
+        currentBranch: 'main',
+        expected: true,
+      },
+      {
+        name: 'returns false when current branch differs from default branch',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+          setupOriginHead('main');
+          execSync('git checkout -b feature', { cwd: testRepoPath, stdio: 'pipe' });
+        },
+        currentBranch: 'feature',
+        expected: false,
+      },
+      {
+        name: 'returns false when current branch is undefined',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+          setupOriginHead('main');
+        },
+        currentBranch: undefined,
+        expected: false,
+      },
+      {
+        name: 'returns false when default branch is undefined',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+        },
+        currentBranch: 'main',
+        expected: false,
+      },
+      {
+        name: 'returns false when current branch is empty string',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+          setupOriginHead('main');
+        },
+        currentBranch: '',
+        expected: false,
+      },
+      {
+        name: 'comparison is case-insensitive',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+          setupOriginHead('main');
+        },
+        currentBranch: 'MAIN',
+        expected: true,
+      },
+      {
+        name: 'uses baseline_branch from config when available',
+        setup: () => {
+          commitFile('README.md', '# Test', 'Initial commit');
+          execSync('git branch -M develop', { cwd: testRepoPath, stdio: 'pipe' });
+          writeBaselineConfig('develop');
+        },
+        currentBranch: 'develop',
+        expected: true,
+      },
+    ];
+
+    for (const tc of testCases) {
+      test(tc.name, async function () {
+        this.timeout(20000);
+        tc.setup();
+
+        const gate = new DefaultBranchGate(testRepoPath);
+        const repo = createMockRepository(testRepoPath, tc.currentBranch, getHeadCommit());
+
+        const shouldSkip = await gate.shouldSkipBasedOnDefaultBranch(repo);
+        assert.strictEqual(shouldSkip, tc.expected);
+      });
+    }
+
+    test('current branch is computed fresh each call', async function () {
+      this.timeout(20000);
+      commitFile('README.md', '# Test', 'Initial commit');
+      execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+      setupOriginHead('main');
+
+      const gate = new DefaultBranchGate(testRepoPath);
+
+      const repoOnMain = createMockRepository(testRepoPath, 'main', getHeadCommit());
+      const shouldSkip1 = await gate.shouldSkipBasedOnDefaultBranch(repoOnMain);
+      assert.strictEqual(shouldSkip1, true);
+
+      const repoOnFeature = createMockRepository(testRepoPath, 'feature', getHeadCommit());
+      const shouldSkip2 = await gate.shouldSkipBasedOnDefaultBranch(repoOnFeature);
+      assert.strictEqual(shouldSkip2, false);
+    });
+
+    test('caches default branch after first fetch', async function () {
+      this.timeout(20000);
+      commitFile('README.md', '# Test', 'Initial commit');
+      execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+      setupOriginHead('main');
+
+      execSync('git checkout -b develop', { cwd: testRepoPath, stdio: 'pipe' });
+      commitFile('develop.ts', 'export const d = 1;', 'develop commit');
+      execSync('git checkout main', { cwd: testRepoPath, stdio: 'pipe' });
+
+      const gate = new DefaultBranchGate(testRepoPath);
+
+      const repo1 = createMockRepository(testRepoPath, 'main', getHeadCommit());
+      await gate.shouldSkipBasedOnDefaultBranch(repo1);
+
+      setupOriginHead('develop');
+      clearMainBranchCandidatesCache(testRepoPath);
+
+      const repo2 = createMockRepository(testRepoPath, 'main', getHeadCommit());
+      const shouldSkip = await gate.shouldSkipBasedOnDefaultBranch(repo2);
+      assert.strictEqual(shouldSkip, true, 'Should still use cached main, not the new develop');
+    });
+  });
+});

--- a/src/test/suite/filtering-reviewer.test.ts
+++ b/src/test/suite/filtering-reviewer.test.ts
@@ -36,10 +36,12 @@ suite('FilteringReviewer Test Suite', () => {
     testDir = fs.mkdtempSync(path.join(testBaseDir, 'filtering-reviewer-test-'));
   });
 
-  teardown(() => {
+  teardown(async function () {
+    this.timeout(20000);
     if (reviewer) {
       reviewer.dispose();
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
     const gitignorePath = path.join(testDir, '.gitignore');
     if (fs.existsSync(gitignorePath)) {
       fs.unlinkSync(gitignorePath);
@@ -148,7 +150,8 @@ suite('FilteringReviewer Test Suite', () => {
   });
 
   suite('when git is available (uses git check-ignore)', () => {
-    setup(async () => {
+    setup(async function () {
+      this.timeout(20000);
       await initGitRepo(testDir);
       mockWorkspaceFolders([createMockWorkspaceFolder(testDir)]);
       reviewer = new FilteringReviewer();

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -1,18 +1,25 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
+import { Uri, ExtensionContext } from '../mocks/vscode';
 import { GitChangeLister } from '../../git/git-change-lister';
 import { MockExecutor } from '../mocks/mock-executor';
-import { MockGitAPI } from '../mocks/mock-git-api';
 import { API } from '../../../types/git';
+import { DefaultBranchGate } from '../../git/default-branch-gate';
+import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders, setMockGitRepositories, clearMockGitRepositories } from '../setup';
+import { setGitApiForTesting } from '../../code-health-monitor/addon';
+import { MockGitAPI } from '../mocks/mock-git-api';
+import { CsExtensionState } from '../../cs-extension-state';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
 
 suite('GitChangeLister Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo');
   let gitChangeLister: GitChangeLister;
-  let mockGitApi: MockGitAPI;
   let mockExecutor: MockExecutor;
+  let mockDefaultBranchGate: DefaultBranchGate;
 
-  setup(async () => {
+  setup(async function () {
+    this.timeout(20000);
     if (fs.existsSync(testRepoPath)) {
       fs.rmSync(testRepoPath, { recursive: true, force: true });
     }
@@ -28,13 +35,15 @@ suite('GitChangeLister Test Suite', () => {
     execSync('git add README.md', { cwd: testRepoPath });
     execSync('git commit -m "Initial commit"', { cwd: testRepoPath });
 
-    mockGitApi = new MockGitAPI();
     mockExecutor = new MockExecutor();
     const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
-    gitChangeLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker);
+    mockDefaultBranchGate = { shouldSkipBasedOnDefaultBranch: async () => false } as any;
+    gitChangeLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker, mockDefaultBranchGate);
   });
 
-  teardown(() => {
+  teardown(async function () {
+    this.timeout(20000);
+    await new Promise((resolve) => setTimeout(resolve, 100));
     if (fs.existsSync(testRepoPath)) {
       fs.rmSync(testRepoPath, { recursive: true, force: true });
     }
@@ -159,5 +168,67 @@ suite('GitChangeLister Test Suite', () => {
     const fileNames = Array.from(changedFiles).map(f => path.basename(f));
     assert.ok(fileNames.includes('my file.ts'), 'Should include file with spaces: my file.ts');
     assert.ok(fileNames.includes('test file with spaces.js'), 'Should include file with spaces: test file with spaces.js');
+  });
+
+  suite('DefaultBranchGate integration', () => {
+    test('getAllChangedFiles still works when gate returns false', async function () {
+      this.timeout(20000);
+      const newFile = path.join(testRepoPath, 'test.ts');
+      fs.writeFileSync(newFile, 'console.log("test");');
+
+      const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+      assert.ok(Array.from(changedFiles).some(f => f.endsWith('test.ts')));
+    });
+
+    [
+      { gateReturns: true,  expectGetAllChangedFilesCalled: false, description: 'skips review when gate returns true' },
+      { gateReturns: false, expectGetAllChangedFilesCalled: true,  description: 'proceeds with review when gate returns false' },
+    ].forEach(({ gateReturns, expectGetAllChangedFilesCalled, description }) => {
+      test(`start ${description}`, async function () {
+        this.timeout(20000);
+
+        const mockRepo = {
+          rootUri: Uri.file(testRepoPath),
+          state: {
+            HEAD: { name: 'main', commit: 'abc123' },
+            refs: [],
+            remotes: [],
+            submodules: [],
+            onDidChange: () => ({ dispose: () => {} }),
+          },
+        };
+
+        const mockGitApi = new MockGitAPI();
+        mockGitApi.repositories = [mockRepo];
+        setGitApiForTesting(mockGitApi as any);
+
+        const mockContext = createMockExtensionContext(testRepoPath);
+        if (!CsExtensionState.hasInstance) {
+          CsExtensionState.init(mockContext);
+        }
+
+        mockWorkspaceFolders([createMockWorkspaceFolder(testRepoPath)]);
+        setMockGitRepositories([mockRepo]);
+
+        const skipGate = { shouldSkipBasedOnDefaultBranch: async () => gateReturns } as any;
+        const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
+        const skipLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker, skipGate);
+
+        let getAllChangedFilesCalled = false;
+        const originalGetAllChangedFiles = skipLister.getAllChangedFiles.bind(skipLister);
+        skipLister.getAllChangedFiles = async function (...args) {
+          getAllChangedFilesCalled = true;
+          return originalGetAllChangedFiles(...args);
+        };
+
+        await skipLister.start();
+
+        assert.strictEqual(getAllChangedFilesCalled, expectGetAllChangedFilesCalled);
+
+        setGitApiForTesting(undefined);
+        restoreDefaultWorkspaceFolders();
+        clearMockGitRepositories();
+      });
+    });
   });
 });

--- a/src/test/suite/git-change-observer.test.ts
+++ b/src/test/suite/git-change-observer.test.ts
@@ -5,13 +5,17 @@ import * as vscode from 'vscode';
 import { Uri, Disposable, ExtensionContext } from '../mocks/vscode';
 import { GitChangeObserver } from '../../git/git-change-observer';
 import { MockExecutor } from '../mocks/mock-executor';
-import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
+import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders, setMockGitRepositories, clearMockGitRepositories } from '../setup';
+import { setGitApiForTesting } from '../../code-health-monitor/addon';
+import { MockGitAPI } from '../mocks/mock-git-api';
+import { CsExtensionState } from '../../cs-extension-state';
 import { getWorkspaceFolder } from '../../utils';
 import Reviewer from '../../review/reviewer';
 import { ReviewCacheItem } from '../../review/review-cache-item';
 import { CsReview } from '../../review/cs-review';
 import { DevtoolsAPI } from '../../devtools-api';
 import { TestTextDocument } from '../mocks/test-text-document';
+import { DefaultBranchGate } from '../../git/default-branch-gate';
 
 suite('GitChangeObserver Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo-observer');
@@ -19,6 +23,7 @@ suite('GitChangeObserver Test Suite', () => {
   let gitChangeObserver: GitChangeObserver;
   let mockExecutor: MockExecutor;
   let mockContext: ExtensionContext;
+  let mockDefaultBranchGate: DefaultBranchGate;
 
   const execGit = (args: string) => execSync(args, { cwd: testRepoPath, stdio: 'pipe' });
 
@@ -94,11 +99,17 @@ suite('GitChangeObserver Test Suite', () => {
     mockWorkspaceFolders([createMockWorkspaceFolder(testRepoPath)]);
 
     const extensionPath = path.join(__dirname, '../../..');
+    const globalStateStorage = new Map<string, any>();
     mockContext = {
       subscriptions: [] as Disposable[],
       extensionPath: extensionPath,
       extensionUri: Uri.file(extensionPath),
-      globalState: {} as any,
+      globalState: {
+        get: <T>(key: string): T | undefined => globalStateStorage.get(key),
+        update: async (key: string, value: any) => { globalStateStorage.set(key, value); },
+        setKeysForSync: (keys: string[]) => {},
+        keys: () => Array.from(globalStateStorage.keys())
+      } as any,
       workspaceState: {} as any,
       secrets: {} as any,
       storagePath: testRepoPath,
@@ -125,7 +136,8 @@ suite('GitChangeObserver Test Suite', () => {
     mockExecutor = new MockExecutor();
     const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
     const mockOpenFilesObserver = { getAllVisibleFileNames: () => new Set<string>() } as any;
-    gitChangeObserver = new GitChangeObserver(mockContext, mockExecutor, mockSavedFilesTracker, mockOpenFilesObserver);
+    mockDefaultBranchGate = { shouldSkipBasedOnDefaultBranch: async () => false } as any;
+    gitChangeObserver = new GitChangeObserver(mockContext, mockExecutor, mockSavedFilesTracker, mockOpenFilesObserver, mockDefaultBranchGate);
     await new Promise(resolve => setTimeout(resolve, 500));
   });
 
@@ -577,5 +589,100 @@ suite('GitChangeObserver Test Suite', () => {
       vscode.workspace.fs.stat = originalStat;
       DevtoolsAPI.delta = originalDelta;
     }
+  });
+
+  suite('DefaultBranchGate integration', () => {
+    test('processQueuedEvents skips file changes when gate returns true', async function () {
+      this.timeout(20000);
+
+      const mockRepo = {
+        rootUri: Uri.file(testRepoPath),
+        state: {
+          HEAD: { name: 'main', commit: 'abc123' },
+          refs: [],
+          remotes: [],
+          submodules: [],
+          onDidChange: () => ({ dispose: () => {} }),
+        },
+      };
+
+      const mockGitApi = new MockGitAPI();
+      mockGitApi.repositories = [mockRepo];
+      setGitApiForTesting(mockGitApi as any);
+      if (!CsExtensionState.hasInstance) {
+        CsExtensionState.init(mockContext as any);
+      }
+
+      const skipGate = { shouldSkipBasedOnDefaultBranch: async () => true } as any;
+      const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
+      const mockOpenFilesObserver = { getAllVisibleFileNames: () => new Set<string>() } as any;
+      const skipObserver = new GitChangeObserver(mockContext, mockExecutor, mockSavedFilesTracker, mockOpenFilesObserver, skipGate);
+      skipObserver.start();
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const newFile = createFile('skipped.ts', 'export const skipped = true;');
+      const observer = skipObserver as any;
+      observer.tracker.clear();
+      observer.eventQueue.push({ type: 'create', uri: Uri.file(newFile) });
+
+      await observer.processQueuedEvents();
+
+      assert.strictEqual(observer.tracker.has(newFile), false, 'File should not be in tracker when skip is enabled');
+
+      skipObserver.dispose();
+      setGitApiForTesting(undefined);
+    });
+
+    test('processQueuedEvents still handles delete events when gate returns true', async function () {
+      this.timeout(20000);
+
+      const mockRepo = {
+        rootUri: Uri.file(testRepoPath),
+        state: {
+          HEAD: { name: 'main', commit: 'abc123' },
+          refs: [],
+          remotes: [],
+          submodules: [],
+          onDidChange: () => ({ dispose: () => {} }),
+        },
+      };
+
+      const mockGitApi = new MockGitAPI();
+      mockGitApi.repositories = [mockRepo];
+      setGitApiForTesting(mockGitApi as any);
+      if (!CsExtensionState.hasInstance) {
+        CsExtensionState.init(mockContext as any);
+      }
+
+      const skipGate = { shouldSkipBasedOnDefaultBranch: async () => true } as any;
+      const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
+      const mockOpenFilesObserver = { getAllVisibleFileNames: () => new Set<string>() } as any;
+      const skipObserver = new GitChangeObserver(mockContext, mockExecutor, mockSavedFilesTracker, mockOpenFilesObserver, skipGate);
+      skipObserver.start();
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const deletableFile = createFile('deletable.ts', 'export const del = 1;');
+      const observer = skipObserver as any;
+      observer.tracker.add(deletableFile);
+
+      fs.unlinkSync(deletableFile);
+      observer.eventQueue.push({ type: 'delete', uri: Uri.file(deletableFile) });
+
+      await observer.processQueuedEvents();
+
+      assert.strictEqual(observer.tracker.has(deletableFile), false, 'Deleted file should be removed from tracker even when skip is enabled');
+
+      skipObserver.dispose();
+      setGitApiForTesting(undefined);
+    });
+
+    test('processQueuedEvents processes file changes when gate returns false', async function () {
+      this.timeout(20000);
+
+      const newFile = createFile('processed.ts', 'export const processed = true;');
+      await triggerFileChange(newFile);
+
+      assertFileInTracker(newFile, true);
+    });
   });
 });

--- a/src/test/suite/git-diff-utils.test.ts
+++ b/src/test/suite/git-diff-utils.test.ts
@@ -7,7 +7,8 @@ import { getStatusChanges, getCommittedChanges, parseGitStatusFilename, createWo
 suite('Git Diff Utils Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo-diff-utils');
 
-  setup(async () => {
+  setup(async function () {
+    this.timeout(20000);
     if (fs.existsSync(testRepoPath)) {
       fs.rmSync(testRepoPath, { recursive: true, force: true });
     }
@@ -26,7 +27,9 @@ suite('Git Diff Utils Test Suite', () => {
     execSync('git commit -m "Initial commit"', { cwd: testRepoPath });
   });
 
-  teardown(() => {
+  teardown(async function () {
+    this.timeout(20000);
+    await new Promise((resolve) => setTimeout(resolve, 100));
     if (fs.existsSync(testRepoPath)) {
       fs.rmSync(testRepoPath, { recursive: true, force: true });
     }

--- a/src/test/suite/git-ignore-checker.test.ts
+++ b/src/test/suite/git-ignore-checker.test.ts
@@ -36,10 +36,12 @@ suite('GitIgnoreChecker Test Suite', () => {
     testDir = fs.mkdtempSync(path.join(testBaseDir, 'git-ignore-checker-test-'));
   });
 
-  teardown(() => {
+  teardown(async function () {
+    this.timeout(20000);
     if (checker) {
       checker.dispose();
     }
+    await new Promise((resolve) => setTimeout(resolve, 100));
     const gitignorePath = path.join(testDir, '.gitignore');
     if (fs.existsSync(gitignorePath)) {
       fs.unlinkSync(gitignorePath);
@@ -130,7 +132,8 @@ suite('GitIgnoreChecker Test Suite', () => {
   });
 
   suite('when git is available (uses git check-ignore)', () => {
-    setup(async () => {
+    setup(async function () {
+      this.timeout(20000);
       await initGitRepo(testDir);
       mockWorkspaceFolders([createMockWorkspaceFolder(testDir)]);
       checker = new GitIgnoreChecker();


### PR DESCRIPTION
## Description

When the current branch equals the repository's default branch,
`GitChangeLister` and `GitChangeObserver` now skip processing file changes.
This avoids unnecessary computational work since diff-based analysis
against the default branch produces no useful results (they won't possibly show up in the Code Health Monitor).

Introduces `DefaultBranchGate` class that:
- Lazily fetches and caches the default branch name
- Computes current branch fresh on each check (not cached)
- Returns false (don't skip) when either branch is undefined/empty
- Uses case-insensitive comparison matching existing branchesEqual logic

Integration points:
- `GitChangeLister.start()` checks once before processing the batch
- `GitChangeObserver.processQueuedEvents()` checks once per batch
  - File deletions are exempt from skip logic to ensure proper cleanup.

## QA plan

I verified the feature like this:

* Enable debug logging
* Clone https://github.com/mongodb/mongo
* `git reset --hard HEAD~100`
  * all analysis skipped
* `git pull`
  * all analysis skipped
* `git reset --hard HEAD~100`, branch off to `foo`, `git merge origin/master foo`
  * work is now performed