### PR TITLE
feat: cache getDefaultBranch to reduce git process spawns

### DIFF
--- a/src/git-utils.ts
+++ b/src/git-utils.ts
@@ -65,13 +65,17 @@ export function getWorkspacePath(workspaceFolder: vscode.WorkspaceFolder): strin
 }
 
 const mainBranchCandidatesCache = new Map<string, string[]>();
+const defaultBranchCache = new Map<string, string | undefined>();
 
 export function clearMainBranchCandidatesCache(gitRootPath?: string): void {
   if (!gitRootPath) {
     mainBranchCandidatesCache.clear();
+    defaultBranchCache.clear();
     return;
   }
-  mainBranchCandidatesCache.delete(path.normalize(gitRootPath));
+  const normalizedPath = path.normalize(gitRootPath);
+  mainBranchCandidatesCache.delete(normalizedPath);
+  defaultBranchCache.delete(normalizedPath);
 }
 
 /**
@@ -80,8 +84,13 @@ export function clearMainBranchCandidatesCache(gitRootPath?: string): void {
 export async function getDefaultBranch(repoPath: string): Promise<string | undefined> {
   const normalizedPath = path.normalize(repoPath);
 
+  if (defaultBranchCache.has(normalizedPath)) {
+    return defaultBranchCache.get(normalizedPath);
+  }
+
   const configured = getBaselineBranch(normalizedPath);
   if (configured) {
+    defaultBranchCache.set(normalizedPath, configured);
     return configured;
   }
 
@@ -92,16 +101,21 @@ export async function getDefaultBranch(repoPath: string): Promise<string | undef
     );
 
     if (exitCode !== 0) {
+      defaultBranchCache.set(normalizedPath, undefined);
       return undefined;
     }
 
     const target = stdout.trim();
     if (target.startsWith(ORIGIN_REMOTE_PREFIX)) {
-      return target.substring(ORIGIN_REMOTE_PREFIX.length);
+      const result = target.substring(ORIGIN_REMOTE_PREFIX.length);
+      defaultBranchCache.set(normalizedPath, result);
+      return result;
     }
 
+    defaultBranchCache.set(normalizedPath, undefined);
     return undefined;
   } catch {
+    defaultBranchCache.set(normalizedPath, undefined);
     return undefined;
   }
 }

--- a/src/test/suite/git-utils.test.ts
+++ b/src/test/suite/git-utils.test.ts
@@ -215,6 +215,33 @@ suite('Git Utils Test Suite', () => {
       createBranchWithCommit('main');
       assert.strictEqual(await getDefaultBranch(testRepoPath), undefined);
     });
+
+    test('getDefaultBranch caches the result', async function () {
+      this.timeout(20000);
+      createBranchWithCommit('main');
+      setupOriginHead('main');
+      clearMainBranchCandidatesCache(testRepoPath);
+
+      assert.strictEqual(await getDefaultBranch(testRepoPath), 'main');
+
+      execSync('git symbolic-ref -d refs/remotes/origin/HEAD', { cwd: testRepoPath, stdio: 'pipe' });
+
+      assert.strictEqual(await getDefaultBranch(testRepoPath), 'main');
+    });
+
+    test('clearMainBranchCandidatesCache also clears getDefaultBranch cache', async function () {
+      this.timeout(20000);
+      createBranchWithCommit('main');
+      setupOriginHead('main');
+      clearMainBranchCandidatesCache(testRepoPath);
+
+      assert.strictEqual(await getDefaultBranch(testRepoPath), 'main');
+
+      execSync('git symbolic-ref -d refs/remotes/origin/HEAD', { cwd: testRepoPath, stdio: 'pipe' });
+      clearMainBranchCandidatesCache(testRepoPath);
+
+      assert.strictEqual(await getDefaultBranch(testRepoPath), undefined);
+    });
   });
 
   suite('getMergeBaseCommit', () => {


### PR DESCRIPTION
`getDefaultBranch` was being called without caching through the call chain: `ReviewCache.add/setBaseline` → `getBaselineCommit` → `getMergeBaseCommit` → `isMainBranch` → `getDefaultBranch`. This spawned a new `git symbolic-ref` process for every file added to the review cache or baseline update.

Add a module-level `defaultBranchCache` that stores the result per repo path. The cache is cleared alongside `mainBranchCandidatesCache` in `clearMainBranchCandidatesCache` to ensure consistency when branch state changes.