### PR TITLE
feat: pass `baselineCommit` as argument to eliminate redundant `git merge-base` calls

### DIFF
--- a/.claude/skills/commit.skill.md
+++ b/.claude/skills/commit.skill.md
@@ -1,0 +1,15 @@
+# commit
+
+Create a git commit using Conventional Commits format.
+
+## Instructions
+
+1. Run `git status` and `git diff` to see what needs to be committed
+2. Run `git add` on specific files as needed
+3. Run `git diff --staged` to see what will be committed
+4. Analyze the changes and draft a Conventional Commits message
+5. Keep the message body concise - explain the what/why, not the how. Don't repeat what's already visible in the diff
+6, Ensure that the message body is wrapped at approximately 80 columns
+7. Surround all code references in backticks
+8. Create the commit
+9. Run `make lint`.

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -125,6 +125,16 @@ export async function getBaselineCommit(fileUri: Uri): Promise<string | undefine
   return await getMergeBaseCommit(repo);
 }
 
+import { getWorkspaceFolder } from '../utils';
+
+export async function getMergeBaseCommitForWorkspace(): Promise<string | undefined> {
+  const workspaceFolder = getWorkspaceFolder();
+  if (!workspaceFolder) return;
+  const repo = getRepo(workspaceFolder.uri);
+  if (!repo) return;
+  return await getMergeBaseCommit(repo);
+}
+
 /**
  * Retrieves the commit point for the HEAD of the current repository for a given file.
  *
@@ -139,29 +149,30 @@ async function getHeadCommit(repo: Repository) {
  * Reacts to changes in the repository's HEAD commit or branch by
  * setting the baseline if either of them changed
  */
-function onRepoStateChange(repo: Repository) {
+async function onRepoStateChange(repo: Repository) {
   const gitStateChange = updateGitState(repo);
 
   if (gitStateChange.branchChanged || gitStateChange.commitChanged) {
-    setBaseline(repo);
+    await setBaseline(repo);
   }
 }
 
-function setBaseline(repo: Repository) {
+async function setBaseline(repo: Repository) {
   const repoPath = getRepoRootPath(repo);
+  const baselineCommit = await getMergeBaseCommit(repo);
   Reviewer.instance.setBaseline((fileUri: Uri) => {
     const r = getRepo(fileUri);
     return r ? getRepoRootPath(r) === repoPath : false;
-  });
+  }, baselineCommit);
 }
 
 /** Refreshes review baselines for all open repositories after main-branch detection changes. */
-export function refreshMergeBaseBaselines(): void {
+export async function refreshMergeBaseBaselines(): Promise<void> {
   if (!gitApi) {
     return;
   }
   for (const repo of gitApi.repositories) {
-    setBaseline(repo);
+    await setBaseline(repo);
   }
 }
 

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -5,6 +5,7 @@ import {
   activate as activateCHMonitor,
   deactivate as deactivateAddon,
   getBaselineCommit,
+  getMergeBaseCommitForWorkspace,
   refreshMergeBaseBaselines,
   runGitChangeLister,
 } from './code-health-monitor/addon';
@@ -62,10 +63,12 @@ let openFilesObserverInstance: OpenFilesObserver | undefined;
 let defaultBranchGateInstance: DefaultBranchGate | undefined;
 let isWindowFocused: boolean = true;
 
-const onCodeHealthFileVersionChange = debounce(() => {
+const onCodeHealthFileVersionChange = debounce(async () => {
   if (!openFilesObserverInstance) {
     return;
   }
+
+  const baselineCommit = await getMergeBaseCommitForWorkspace() ?? '';
 
   // Re-review all currently visible files since code health rules have changed
   const visibleFiles = openFilesObserverInstance.getAllVisibleFileNames();
@@ -73,7 +76,7 @@ const onCodeHealthFileVersionChange = debounce(() => {
     const fileUri = vscode.Uri.file(filePath);
     void vscode.workspace.openTextDocument(fileUri).then(
       (document) => {
-        CsDiagnostics.review(document, { skipMonitorUpdate: true, updateDiagnosticsPane: true });
+        CsDiagnostics.review(document, { baselineCommit, skipMonitorUpdate: true, updateDiagnosticsPane: true });
       },
       (e) => {
         logOutputChannel.warn(`Failed to re-review file after rules change: ${filePath}`, e);
@@ -82,7 +85,7 @@ const onCodeHealthFileVersionChange = debounce(() => {
   });
 }, 350);
 
-const onCodesceneConfigChange = debounce((uri: vscode.Uri) => {
+const onCodesceneConfigChange = debounce(async (uri: vscode.Uri) => {
   const gitRoot = gitRootFromCodesceneConfigUri(uri);
   if (gitRoot) {
     clearMainBranchCandidatesCache(gitRoot);
@@ -90,19 +93,21 @@ const onCodesceneConfigChange = debounce((uri: vscode.Uri) => {
     clearMainBranchCandidatesCache();
   }
 
-  refreshMergeBaseBaselines();
+  void refreshMergeBaseBaselines();
   void runGitChangeLister();
 
   if (!openFilesObserverInstance) {
     return;
   }
 
+  const baselineCommit = await getMergeBaseCommitForWorkspace() ?? '';
+
   const visibleFiles = openFilesObserverInstance.getAllVisibleFileNames();
   visibleFiles.forEach((filePath) => {
     const fileUri = vscode.Uri.file(filePath);
     void vscode.workspace.openTextDocument(fileUri).then(
       (document) => {
-        CsDiagnostics.review(document, { skipMonitorUpdate: true, updateDiagnosticsPane: true });
+        CsDiagnostics.review(document, { baselineCommit, skipMonitorUpdate: true, updateDiagnosticsPane: true });
       },
       (e) => {
         logOutputChannel.warn(`Failed to re-review file after config change: ${filePath}`, e);
@@ -126,7 +131,7 @@ async function updateCodeHealthRulesVersion(uri: vscode.Uri): Promise<void> {
   try {
     const document = await vscode.workspace.openTextDocument(uri);
     codeHealthFileVersion.set(document.fileName, document.version);
-    onCodeHealthFileVersionChange();
+    void onCodeHealthFileVersionChange();
   } catch (e) {
     logOutputChannel.warn(`Failed to update code-health-rules.json version: ${uri.fsPath}`, e);
   }
@@ -193,7 +198,7 @@ export async function activate(context: vscode.ExtensionContext) {
       await Telemetry.init(context);
 
       try {
-        Reviewer.init(context, getBaselineCommit, getCodeHealthFileVersions);
+        Reviewer.init(context, getCodeHealthFileVersions);
         CsExtensionState.setAnalysisState({ state: 'enabled' });
         await startExtension(context);
         finalizeActivation(context);
@@ -377,7 +382,7 @@ function addReviewListeners(context: vscode.ExtensionContext) {
 
   rulesFileWatcher.onDidDelete((uri: vscode.Uri) => {
     codeHealthFileVersion.delete(uri.fsPath);
-    onCodeHealthFileVersionChange();
+    void onCodeHealthFileVersionChange();
   });
 
   DISPOSABLES.push(rulesFileWatcher);

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -49,14 +49,15 @@ export class GitChangeLister {
         return;
       }
 
-      const allChangedFiles = await this.getAllChangedFiles(gitRootPath, workspacePath);
-      this.reviewFiles(allChangedFiles);
+      const baselineCommit = repo ? await getMergeBaseCommit(repo) : '';
+      const allChangedFiles = await this.getAllChangedFiles(gitRootPath, workspacePath, baselineCommit);
+      this.reviewFiles(allChangedFiles, baselineCommit);
     }
   }
 
-  async getAllChangedFiles(gitRootPath: string, workspacePath: string): Promise<Set<string>> {
+  async getAllChangedFiles(gitRootPath: string, workspacePath: string, baselineCommit: string): Promise<Set<string>> {
     const filesFromRepoState = await this.collectFilesFromRepoState(gitRootPath, workspacePath);
-    const filesFromGitDiff = await this.collectFilesFromGitDiff(gitRootPath, workspacePath);
+    const filesFromGitDiff = await this.collectFilesFromGitDiff(gitRootPath, workspacePath, baselineCommit);
     return new Set([...filesFromRepoState, ...filesFromGitDiff]);
   }
 
@@ -77,9 +78,9 @@ export class GitChangeLister {
     return files;
   }
 
-  private async collectFilesFromGitDiff(gitRootPath: string, workspacePath: string): Promise<Set<string>> {
+  private async collectFilesFromGitDiff(gitRootPath: string, workspacePath: string, baselineCommit: string): Promise<Set<string>> {
     const files = new Set<string>();
-    const changedFilesVsMergeBase = await this.getChangedFilesVsMergeBase(gitRootPath, workspacePath);
+    const changedFilesVsMergeBase = await this.getChangedFilesVsMergeBase(gitRootPath, workspacePath, baselineCommit);
 
     for (const relativeFilePath of changedFilesVsMergeBase) {
       const absolutePath = path.join(workspacePath, relativeFilePath);
@@ -93,12 +94,12 @@ export class GitChangeLister {
     return files;
   }
 
-  private reviewFiles(filePaths: Set<string>): void {
+  private reviewFiles(filePaths: Set<string>, baselineCommit: string): void {
     for (const filePath of filePaths) {
       void this.executor.executeTask(async () => {
         try {
           const document = await vscode.workspace.openTextDocument(filePath);
-          CsDiagnostics.review(document, { skipMonitorUpdate: false, updateDiagnosticsPane: false });
+          CsDiagnostics.review(document, { baselineCommit, skipMonitorUpdate: false, updateDiagnosticsPane: false });
         } catch (error) {
           logOutputChannel.error(`Could not review ${filePath}: ${error}`);
         }
@@ -111,16 +112,10 @@ export class GitChangeLister {
     return supportedExtensions.includes(fileExt);
   }
 
-  async getChangedFilesVsMergeBase(gitRootPath: string, workspacePath: string): Promise<Set<string>> {
-    const workspaceFolder = getWorkspaceFolder();
-    if (!workspaceFolder) {
-      return new Set<string>();
-    }
-
-    const repo = getRepo(workspaceFolder.uri);
-    const baseCommit = repo ? await getMergeBaseCommit(repo) : '';
-
-    if (!baseCommit) {
+  async getChangedFilesVsMergeBase(gitRootPath: string, workspacePath: string, baselineCommit: string): Promise<Set<string>> {
+    if (!baselineCommit) {
+      const workspaceFolder = getWorkspaceFolder();
+      const repo = workspaceFolder ? getRepo(workspaceFolder.uri) : undefined;
       const currentBranch = repo?.state.HEAD?.name;
       if (currentBranch){
         const isMain = await isMainBranch(currentBranch, gitRootPath);
@@ -133,9 +128,9 @@ export class GitChangeLister {
     }
 
     try {
-      return await getCommittedChanges(gitRootPath, baseCommit, workspacePath);
+      return await getCommittedChanges(gitRootPath, baselineCommit, workspacePath);
     } catch (error) {
-      logOutputChannel.warn(`Error getting changed files vs merge-base ${baseCommit}: ${error}`);
+      logOutputChannel.warn(`Error getting changed files vs merge-base ${baselineCommit}: ${error}`);
       return new Set<string>();
     }
   }

--- a/src/git/git-change-observer.ts
+++ b/src/git/git-change-observer.ts
@@ -101,10 +101,11 @@ export class GitChangeObserver {
       ? await this.defaultBranchGate.shouldSkipBasedOnDefaultBranch(repo)
       : false;
 
-    const changedFiles = await this.getChangedFilesVsBaseline(workspaceFolder);
+    const baselineCommit = repo ? await getMergeBaseCommit(repo) : '';
+    const changedFiles = await this.getChangedFilesVsBaseline(workspaceFolder, baselineCommit);
 
     for (const event of events) {
-      await this.processEvent(event, changedFiles, workspaceFolder, shouldSkip);
+      await this.processEvent(event, changedFiles, workspaceFolder, shouldSkip, baselineCommit);
     }
   }
 
@@ -112,7 +113,8 @@ export class GitChangeObserver {
     event: {type: 'create' | 'change' | 'delete', uri: vscode.Uri},
     changedFiles: string[],
     workspaceFolder: vscode.WorkspaceFolder | undefined,
-    shouldSkip: boolean
+    shouldSkip: boolean,
+    baselineCommit: string
   ): Promise<void> {
     // NOTE: we _don't_ need to use gitignore to efficiently determine if a file should be processed,
     // because we use `getChangedFilesVsBaseline` as the computation basis, which uses `git diff` and `git status`,
@@ -127,13 +129,13 @@ export class GitChangeObserver {
     }
 
     if (!shouldSkip) {
-      await this.handleFileChange(event.uri, changedFiles, workspaceFolder);
+      await this.handleFileChange(event.uri, changedFiles, workspaceFolder, baselineCommit);
     } else {
       logOutputChannel.debug(`GitChangeObserver: skipping file change ${event.uri.fsPath}, current branch matches default branch`);
     }
   }
 
-  async getChangedFilesVsBaseline(workspaceFolder: vscode.WorkspaceFolder | undefined): Promise<string[]> {
+  async getChangedFilesVsBaseline(workspaceFolder: vscode.WorkspaceFolder | undefined, baselineCommit: string): Promise<string[]> {
     if (!isGitAvailable()){
       return [];
     }
@@ -143,7 +145,6 @@ export class GitChangeObserver {
     }
 
     const repo = getRepo(workspaceFolder.uri);
-    const baseCommit = repo ? await getMergeBaseCommit(repo) : '';
 
     try {
       const workspacePath = getWorkspacePath(workspaceFolder);
@@ -152,7 +153,7 @@ export class GitChangeObserver {
         ...this.savedFilesTracker.getSavedFiles(),
         ...this.openFilesObserver.getAllVisibleFileNames()
       ]);
-      const committedChanges = await getCommittedChanges(gitRootPath, baseCommit, workspacePath);
+      const committedChanges = await getCommittedChanges(gitRootPath, baselineCommit, workspacePath);
       const statusChanges = await getStatusChanges(gitRootPath, workspacePath, filesToExcludeFromHeuristic);
 
       const allChangedFiles = new Set([...committedChanges, ...statusChanges]);
@@ -160,7 +161,7 @@ export class GitChangeObserver {
       const result = Array.from(allChangedFiles);
       return result;
     } catch (error) {
-      logOutputChannel.warn(`Error getting changed files vs base commit ${baseCommit}: ${error}`);
+      logOutputChannel.warn(`Error getting changed files vs base commit ${baselineCommit}: ${error}`);
       return [];
     }
   }
@@ -184,11 +185,11 @@ export class GitChangeObserver {
     return true;
   }
 
-  private async reviewFile(filePath: string): Promise<void> {
+  private async reviewFile(filePath: string, baselineCommit: string): Promise<void> {
     try {
       // Load the file as a TextDocument (doesn't open in editor UI)
       const document = await vscode.workspace.openTextDocument(filePath);
-      CsDiagnostics.review(document, { skipMonitorUpdate: false, updateDiagnosticsPane: false });
+      CsDiagnostics.review(document, { baselineCommit, skipMonitorUpdate: false, updateDiagnosticsPane: false });
     } catch (error) {
       logOutputChannel.warn(`Could not load file for review ${filePath}: ${error}`);
     }
@@ -227,7 +228,7 @@ export class GitChangeObserver {
     });
   }
 
-  private async handleFileChange(uri: vscode.Uri, changedFiles: string[], workspaceFolder: vscode.WorkspaceFolder | undefined): Promise<void> {
+  private async handleFileChange(uri: vscode.Uri, changedFiles: string[], workspaceFolder: vscode.WorkspaceFolder | undefined, baselineCommit: string): Promise<void> {
     const filePath = uri.fsPath;
 
     // Don't add directories to the tracker - would make deletion handling work incorrectly
@@ -241,7 +242,7 @@ export class GitChangeObserver {
     }
 
     this.tracker.add(filePath);
-    void this.executor.executeTask(() => this.reviewFile(filePath));
+    void this.executor.executeTask(() => this.reviewFile(filePath, baselineCommit));
   }
 
   private async handleFileDelete(uri: vscode.Uri, changedFiles: string[], workspaceFolder: vscode.WorkspaceFolder | undefined): Promise<void> {

--- a/src/review/caching-reviewer.ts
+++ b/src/review/caching-reviewer.ts
@@ -1,4 +1,4 @@
-import vscode, { Disposable, Uri } from 'vscode';
+import vscode, { Disposable } from 'vscode';
 import { AbortError } from '../devtools-api/abort-error';
 import { logOutputChannel } from '../log';
 import { CsReview } from './cs-review';
@@ -14,10 +14,9 @@ export class CachingReviewer implements Disposable {
   readonly reviewCache: ReviewCache;
 
   constructor(
-    getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>,
     getCodeHealthFileVersions: () => Map<string, number>
   ) {
-    this.reviewCache = new ReviewCache(getBaselineCommit, getCodeHealthFileVersions);
+    this.reviewCache = new ReviewCache(getCodeHealthFileVersions);
     const deleteFileWatcher = vscode.workspace.createFileSystemWatcher('**/*', true, true, false);
     this.disposables.push(
       deleteFileWatcher,
@@ -60,7 +59,7 @@ export class CachingReviewer implements Disposable {
 
     const csReview = new CsReview(document, reviewPromise);
 
-    this.updateOrAdd(document, csReview, skipMonitorUpdateForDelta ?? skipMonitorUpdate, reviewOpts.updateDiagnosticsPane);
+    this.updateOrAdd(document, csReview, skipMonitorUpdateForDelta ?? skipMonitorUpdate, reviewOpts.updateDiagnosticsPane, reviewOpts.baselineCommit);
 
     return csReview;
   }
@@ -69,8 +68,8 @@ export class CachingReviewer implements Disposable {
     this.reviewCache.refreshDeltas();
   }
 
-  setBaseline(fileFilter: (fileUri: Uri) => boolean) {
-    this.reviewCache.setBaseline(fileFilter);
+  setBaseline(fileFilter: (fileUri: vscode.Uri) => boolean, baselineCommit: string) {
+    this.reviewCache.setBaseline(fileFilter, baselineCommit);
   }
 
   /**
@@ -80,7 +79,7 @@ export class CachingReviewer implements Disposable {
    */
   async baselineScore(baselineCommit: string, document: vscode.TextDocument, skipMonitorUpdate: boolean, updateDiagnosticsPane: boolean) {
     return this.reviewer
-      .review(document, { baseline: baselineCommit, skipMonitorUpdate, updateDiagnosticsPane })
+      .review(document, { baseline: baselineCommit, baselineCommit, skipMonitorUpdate, updateDiagnosticsPane })
       .then((reviewResult) => {
         return reviewResult && reviewResult['raw-score'];
       })
@@ -94,9 +93,9 @@ export class CachingReviewer implements Disposable {
    * @param skipMonitorUpdate
    * @param updateDiagnosticsPane
    */
-  updateOrAdd(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean, updateDiagnosticsPane: boolean) {
+  updateOrAdd(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean, updateDiagnosticsPane: boolean, baselineCommit: string) {
     if (!this.reviewCache.update(document, review, skipMonitorUpdate, updateDiagnosticsPane)) {
-      void this.reviewCache.add(document, review, skipMonitorUpdate, updateDiagnosticsPane);
+      this.reviewCache.add(document, review, skipMonitorUpdate, updateDiagnosticsPane, baselineCommit);
     }
   }
 

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -2,6 +2,8 @@ import vscode from 'vscode';
 import { reviewDocumentSelector } from '../language-support';
 import CsDiagnostics from '../diagnostics/cs-diagnostics';
 import { FilteringReviewer } from './filtering-reviewer';
+import { getMergeBaseCommitForWorkspace } from '../code-health-monitor/addon';
+import { logOutputChannel } from '../log';
 
 /**
  * Observes open file events, and triggers reviews accordingly (only meant for Problems, not for the Code Health Monitor).
@@ -24,19 +26,20 @@ export class OpenFilesObserver {
     this.docSelector = reviewDocumentSelector();
   }
 
-  private reviewDocument(document: vscode.TextDocument, skipMonitorUpdateForDelta?: boolean): boolean {
+  private reviewDocument(document: vscode.TextDocument, baselineCommit: string, reason: string, skipMonitorUpdateForDelta?: boolean): boolean {
     if (vscode.languages.match(this.docSelector, document) === 0) {
       return false;
     }
-    void this.filteringReviewer.reviewDiagnostics(document, { skipMonitorUpdate: true, updateDiagnosticsPane: true }, skipMonitorUpdateForDelta);
+    logOutputChannel.debug(`[OpenFilesObserver] Reviewing ${document.fileName} (${reason}, baseline: ${baselineCommit || 'none'})`);
+    void this.filteringReviewer.reviewDiagnostics(document, { baselineCommit, skipMonitorUpdate: true, updateDiagnosticsPane: true }, skipMonitorUpdateForDelta);
     return true;
   }
 
-  private trackAndReviewDocument(document: vscode.TextDocument, reason: string): void {
+  private trackAndReviewDocument(document: vscode.TextDocument, baselineCommit: string, reason: string): void {
     const fileName = document.fileName;
     if (!this.visibleDocuments.has(fileName)) {
       this.visibleDocuments.add(fileName);
-      this.reviewDocument(document);
+      this.reviewDocument(document, baselineCommit, reason);
     }
   }
 
@@ -78,11 +81,14 @@ export class OpenFilesObserver {
     if (allVisibleFileNames.size > 0) {
       this.hasInitialized = true;
 
-      allVisibleFileNames.forEach((filePath) => {
-        const fileUri = vscode.Uri.file(filePath);
-        // Open the document without showing it in UI
-        void vscode.workspace.openTextDocument(fileUri).then((document) => {
-          this.trackAndReviewDocument(document, 'startup - visible file');
+      void getMergeBaseCommitForWorkspace().then((baselineCommit) => {
+        const baseline = baselineCommit ?? '';
+        allVisibleFileNames.forEach((filePath) => {
+          const fileUri = vscode.Uri.file(filePath);
+          // Open the document without showing it in UI
+          void vscode.workspace.openTextDocument(fileUri).then((document) => {
+            this.trackAndReviewDocument(document, baseline, 'startup');
+          });
         });
       });
     } else {
@@ -97,7 +103,9 @@ export class OpenFilesObserver {
         if (!editor) {
           return;
         }
-        this.trackAndReviewDocument(editor.document, 'active editor changed');
+        void getMergeBaseCommitForWorkspace().then((baselineCommit) => {
+          this.trackAndReviewDocument(editor.document, baselineCommit ?? '', 'editor changed');
+        });
       })
     );
 
@@ -145,7 +153,9 @@ export class OpenFilesObserver {
             // The `false` param is for CS-6117 - unsaved changes should show up in the Monitor,
             // but only if they come from a live change (i.e. `onDidChangeTextDocument` callback) -
             // not from merely opening this file at startup.
-            this.reviewDocument(e.document, false);
+            void getMergeBaseCommitForWorkspace().then((baselineCommit) => {
+              this.reviewDocument(e.document, baselineCommit ?? '', 'text changed', false);
+            });
           }, 1000)
         );
       })

--- a/src/review/review-cache.ts
+++ b/src/review/review-cache.ts
@@ -14,7 +14,6 @@ export class ReviewCache {
   private _cache = new Map<string, Map<Map<string, number>, CacheEntry>>();
 
   constructor(
-    private getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>,
     private getCodeHealthFileVersions: () => Map<string, number>
   ) {}
 
@@ -84,7 +83,7 @@ export class ReviewCache {
     return cachedValue === false ? false : newValue;
   }
 
-  async add(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean, updateDiagnosticsPane: boolean) {
+  add(document: vscode.TextDocument, review: CsReview, skipMonitorUpdate: boolean, updateDiagnosticsPane: boolean, baselineCommit: string) {
     const item = new ReviewCacheItem(document, review);
 
     let innerMap = this._cache.get(document.fileName);
@@ -113,7 +112,6 @@ export class ReviewCache {
     innerMap.set(snapshot, { item, skipMonitorUpdate: finalSkipMonitorUpdate });
 
     logOutputChannel.trace(`ReviewCache.add: ${path.basename(document.fileName)}`);
-    const baselineCommit = await this.getBaselineCommit(document.uri);
     if (baselineCommit) {
       item.setBaseline(baselineCommit, finalSkipMonitorUpdate, updateDiagnosticsPane);
     }
@@ -153,11 +151,10 @@ export class ReviewCache {
     this._cache.clear();
   }
 
-  setBaseline(fileFilter: (fileUri: Uri) => boolean) {
+  setBaseline(fileFilter: (fileUri: Uri) => boolean, baselineCommit: string) {
     this._cache.forEach((innerMap) => {
-      innerMap.forEach(async (entry) => {
+      innerMap.forEach((entry) => {
         if (fileFilter(entry.item.document.uri)) {
-          const baselineCommit = await this.getBaselineCommit(entry.item.document.uri);
           if (baselineCommit) {
             void entry.item.setBaseline(baselineCommit, false, false);
           }

--- a/src/review/reviewer.ts
+++ b/src/review/reviewer.ts
@@ -1,4 +1,4 @@
-import vscode, { Uri } from 'vscode';
+import vscode from 'vscode';
 import { logOutputChannel } from '../log';
 
 import { CachingReviewer } from './caching-reviewer';
@@ -7,10 +7,9 @@ export default class Reviewer {
 
   static init(
     context: vscode.ExtensionContext,
-    getBaselineCommit: (fileUri: Uri) => Promise<string | undefined>,
     getCodeHealthFileVersions: () => Map<string, number>
   ): void {
-    Reviewer._instance = new CachingReviewer(getBaselineCommit, getCodeHealthFileVersions);
+    Reviewer._instance = new CachingReviewer(getCodeHealthFileVersions);
     context.subscriptions.push(Reviewer._instance);
     logOutputChannel.info('Code reviewer initialized');
   }
@@ -23,6 +22,7 @@ export default class Reviewer {
 export interface ReviewOpts {
   skipCache?: boolean;
   baseline?: string;
+  baselineCommit: string;
   skipMonitorUpdate: boolean;     // Please set this to true if triggering reviews due to opening files, and to false if triggering reviews due to Git changes.
   //                                 (the reason is that Git changes are always processed anyway, so it's redundant to update the Monitor twice for the same change)
   updateDiagnosticsPane: boolean; // Please set this to true if triggering reviews due to opening files, and to false if triggering reviews due to Git changes.

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -54,7 +54,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     const binaryPath = await ensureBinary();
     mockContext = createMockExtensionContext(repoRoot);
     CsExtensionState.init(mockContext);
-    Reviewer.init(mockContext, async () => undefined, () => new Map());
+    Reviewer.init(mockContext, () => new Map());
     DevtoolsAPI.init(binaryPath, mockContext);
   });
 
@@ -72,26 +72,29 @@ suite('Code Health Monitor Addon Test Suite', () => {
     restoreDefaultWorkspaceFolders();
   });
 
-  test('refreshMergeBaseBaselines is a no-op when git API is unavailable', () => {
-    refreshMergeBaseBaselines();
+  test('refreshMergeBaseBaselines is a no-op when git API is unavailable', async () => {
+    await refreshMergeBaseBaselines();
   });
 
   test('runGitChangeLister is a no-op before code health monitor activation', async () => {
     await runGitChangeLister();
   });
 
-  test('refreshMergeBaseBaselines updates review baselines for all repositories', () => {
+  test('refreshMergeBaseBaselines updates review baselines for all repositories', async () => {
     setMockGitRepositories([createMockRepo()]);
     activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
 
+    // Wait for activation's initial setBaseline call to complete
+    await new Promise(resolve => setTimeout(resolve, 100));
+
     let setBaselineCalls = 0;
     const originalSetBaseline = Reviewer.instance.setBaseline.bind(Reviewer.instance);
-    Reviewer.instance.setBaseline = (fileFilter) => {
+    Reviewer.instance.setBaseline = (fileFilter, baselineCommit) => {
       setBaselineCalls += 1;
-      return originalSetBaseline(fileFilter);
+      return originalSetBaseline(fileFilter, baselineCommit);
     };
 
-    refreshMergeBaseBaselines();
+    await refreshMergeBaseBaselines();
 
     assert.strictEqual(setBaselineCalls, 1);
     Reviewer.instance.setBaseline = originalSetBaseline;

--- a/src/test/suite/cs-diagnostics.test.ts
+++ b/src/test/suite/cs-diagnostics.test.ts
@@ -33,7 +33,7 @@ suite('CsDiagnostics Integration Test Suite', () => {
     originalCollection = (CsDiagnostics as any).collection;
     (CsDiagnostics as any).collection = mockCollection;
     CsDiagnostics.init(mockContext);
-    Reviewer.init(mockContext, async () => undefined, () => new Map());
+    Reviewer.init(mockContext, () => new Map());
   });
 
   teardown(() => {
@@ -59,7 +59,7 @@ suite('CsDiagnostics Integration Test Suite', () => {
     const testFile = path.resolve(testDir, 'gc.cpp');
     fs.writeFileSync(testFile, fileContent);
     const document = new TestTextDocument(testFile, fileContent, 'cpp');
-    const reviewOpts: ReviewOpts = { skipMonitorUpdate: true, updateDiagnosticsPane: true };
+    const reviewOpts: ReviewOpts = { baselineCommit: '', skipMonitorUpdate: true, updateDiagnosticsPane: true };
 
     let analysisError: Error | undefined;
     const errorListener = DevtoolsAPI.onDidAnalysisFail((error) => {
@@ -125,7 +125,7 @@ return 0;
 `;
     fs.writeFileSync(cleanFile, cleanCode);
     const document = new TestTextDocument(cleanFile, cleanCode, 'cpp');
-    const reviewOpts: ReviewOpts = { skipMonitorUpdate: true, updateDiagnosticsPane: true };
+    const reviewOpts: ReviewOpts = { baselineCommit: '', skipMonitorUpdate: true, updateDiagnosticsPane: true };
 
     let analysisError: Error | undefined;
     const errorListener = DevtoolsAPI.onDidAnalysisFail((error) => {
@@ -153,7 +153,7 @@ return 0;
     const code = `int foo() { return 42; }\n`;
     fs.writeFileSync(cppFile, code);
     const document = new TestTextDocument(cppFile, code, 'cpp');
-    const reviewOpts: ReviewOpts = { skipMonitorUpdate: true, updateDiagnosticsPane: true };
+    const reviewOpts: ReviewOpts = { baselineCommit: '', skipMonitorUpdate: true, updateDiagnosticsPane: true };
 
     let analysisError: Error | undefined;
     const errorListener = DevtoolsAPI.onDidAnalysisFail((error) => {
@@ -181,7 +181,7 @@ return 0;
     const content = 'This is just text';
     fs.writeFileSync(txtFile, content);
     const document = new TestTextDocument(txtFile, content, 'plaintext');
-    const reviewOpts: ReviewOpts = { skipMonitorUpdate: true, updateDiagnosticsPane: true };
+    const reviewOpts: ReviewOpts = { baselineCommit: '', skipMonitorUpdate: true, updateDiagnosticsPane: true };
 
     let analysisError: Error | undefined;
     const errorListener = DevtoolsAPI.onDidAnalysisFail((error) => {

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -51,7 +51,7 @@ suite('GitChangeLister Test Suite', () => {
 
   test('getAllChangedFiles returns empty set for clean repository', async function () {
     this.timeout(20000);
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
     assert.strictEqual(changedFiles.size, 0);
   });
 
@@ -62,7 +62,7 @@ suite('GitChangeLister Test Suite', () => {
     const newFile = path.join(testRepoPath, 'test.ts');
     fs.writeFileSync(newFile, 'console.log("test");');
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     assert.ok(changedFiles.size > 0);
     assert.ok(Array.from(changedFiles).some(f => f.endsWith('test.ts')));
@@ -79,7 +79,7 @@ suite('GitChangeLister Test Suite', () => {
 
     fs.writeFileSync(testFile, 'console.log("modified");');
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     assert.ok(changedFiles.size > 0);
     assert.ok(Array.from(changedFiles).some(f => f.endsWith('index.js')));
@@ -93,7 +93,7 @@ suite('GitChangeLister Test Suite', () => {
     fs.writeFileSync(newFile, 'print("hello")');
     execSync('git add script.py', { cwd: testRepoPath });
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     assert.ok(changedFiles.size > 0);
     assert.ok(Array.from(changedFiles).some(f => f.endsWith('script.py')));
@@ -108,7 +108,7 @@ suite('GitChangeLister Test Suite', () => {
     fs.writeFileSync(mdFile, '# Documentation');
     fs.writeFileSync(tsFile, 'export const x = 1;');
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
     const fileNames = Array.from(changedFiles).map(f => path.basename(f));
 
     assert.strictEqual(changedFiles.size, 1, 'Should only include supported file type');
@@ -128,7 +128,7 @@ suite('GitChangeLister Test Suite', () => {
     fs.renameSync(originalFile, renamedFile);
     execSync('git add -A', { cwd: testRepoPath });
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     assert.ok(changedFiles.size > 0);
     assert.ok(Array.from(changedFiles).some(f => f.endsWith('renamed.js')));
@@ -148,7 +148,7 @@ suite('GitChangeLister Test Suite', () => {
     const uncommittedFile = path.join(testRepoPath, 'uncommitted.ts');
     fs.writeFileSync(uncommittedFile, 'export const bar = 2;');
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     const fileNames = Array.from(changedFiles).map(f => path.basename(f));
     assert.ok(fileNames.includes('uncommitted.ts'), 'Should include uncommitted file');
@@ -163,7 +163,7 @@ suite('GitChangeLister Test Suite', () => {
     fs.writeFileSync(fileWithSpaces, 'console.log("has spaces");');
     fs.writeFileSync(anotherFileWithSpaces, 'console.log("also has spaces");');
 
-    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+    const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
 
     const fileNames = Array.from(changedFiles).map(f => path.basename(f));
     assert.ok(fileNames.includes('my file.ts'), 'Should include file with spaces: my file.ts');
@@ -176,7 +176,7 @@ suite('GitChangeLister Test Suite', () => {
       const newFile = path.join(testRepoPath, 'test.ts');
       fs.writeFileSync(newFile, 'console.log("test");');
 
-      const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath);
+      const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
       assert.ok(Array.from(changedFiles).some(f => f.endsWith('test.ts')));
     });
 

--- a/src/test/suite/git-change-observer.test.ts
+++ b/src/test/suite/git-change-observer.test.ts
@@ -58,8 +58,8 @@ suite('GitChangeObserver Test Suite', () => {
   const triggerFileChange = async (filePath: string) => {
     const observer = getObserverInternals();
     const workspaceFolder = getWorkspaceFolder();
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder);
-    await observer.handleFileChange(Uri.file(filePath), changedFiles, workspaceFolder);
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder, '');
+    await observer.handleFileChange(Uri.file(filePath), changedFiles, workspaceFolder, '');
   };
 
   const assertFileInChangedList = (changedFiles: string[], filename: string, shouldExist: boolean = true) => {
@@ -160,14 +160,14 @@ suite('GitChangeObserver Test Suite', () => {
 
   test('getChangedFilesVsBaseline returns empty array for clean repository', async function () {
     this.timeout(20000);
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assert.strictEqual(changedFiles.length, 0);
   });
 
   test('getChangedFilesVsBaseline detects new untracked files', async function () {
     this.timeout(20000);
     createFile('test.ts', 'console.log("test");');
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'test.ts');
   });
 
@@ -175,7 +175,7 @@ suite('GitChangeObserver Test Suite', () => {
     this.timeout(20000);
     const testFile = commitFile('index.js', 'console.log("hello");', 'Add index.js');
     fs.writeFileSync(testFile, 'console.log("modified");');
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'index.js');
   });
 
@@ -183,7 +183,7 @@ suite('GitChangeObserver Test Suite', () => {
     this.timeout(20000);
     createFile('script.py', 'print("hello")');
     execGit('git add script.py');
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'script.py');
   });
 
@@ -193,7 +193,7 @@ suite('GitChangeObserver Test Suite', () => {
     commitFile('committed.ts', 'export const foo = 1;', 'Add committed.ts');
     createFile('uncommitted.ts', 'export const bar = 2;');
 
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'committed.ts');
     assertFileInChangedList(changedFiles, 'uncommitted.ts');
   });
@@ -227,7 +227,7 @@ suite('GitChangeObserver Test Suite', () => {
     assertFileInTracker(newFile);
     fs.unlinkSync(newFile);
     const workspaceFolder = getWorkspaceFolder();
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder);
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder, '');
     await getObserverInternals().handleFileDelete(Uri.file(newFile), changedFiles, workspaceFolder);
     assertFileInTracker(newFile, false);
   });
@@ -250,7 +250,7 @@ suite('GitChangeObserver Test Suite', () => {
 
     fs.rmSync(subDir, { recursive: true, force: true });
     const workspaceFolder = getWorkspaceFolder();
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder);
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder, '');
     await getObserverInternals().handleFileDelete(Uri.file(subDir), changedFiles, workspaceFolder);
     assertFileInTracker(file1, false);
     assertFileInTracker(file2, false);
@@ -260,7 +260,7 @@ suite('GitChangeObserver Test Suite', () => {
     this.timeout(20000);
     const txtFile = createFile('notes.txt', 'Some notes');
     const workspaceFolder = getWorkspaceFolder();
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder);
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder, '');
     const shouldProcess = getObserverInternals().shouldProcessFile(txtFile, changedFiles, workspaceFolder);
     assert.strictEqual(shouldProcess, false, 'Should not process .txt files');
   });
@@ -269,7 +269,7 @@ suite('GitChangeObserver Test Suite', () => {
     this.timeout(20000);
     const tsFile = createFile('code.ts', 'export const x = 1;');
     const workspaceFolder = getWorkspaceFolder();
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder);
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(workspaceFolder, '');
     const shouldProcess = getObserverInternals().shouldProcessFile(tsFile, changedFiles, workspaceFolder);
     assert.strictEqual(shouldProcess, true, 'Should process .ts files');
   });
@@ -279,7 +279,7 @@ suite('GitChangeObserver Test Suite', () => {
     const changedFile = createFile('changed.ts', 'export const x = 1;');
     const committedFile = commitFile('committed.js', 'console.log("committed");', 'Add committed.js');
 
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'changed.ts');
     assertFileInChangedList(changedFiles, 'committed.js', false);
 
@@ -301,7 +301,7 @@ suite('GitChangeObserver Test Suite', () => {
     execGit('git add stale-change.ts');
     execGit('git commit -m "Make stale-change.ts clean"');
 
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'stale-change.ts', false);
 
     const observer = getObserverInternals();
@@ -321,7 +321,7 @@ suite('GitChangeObserver Test Suite', () => {
     const filePath = commitFile(fileName, originalContent, 'Add healthy file');
 
     // 2. Verify file is not in changed list (healthy state)
-    let changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    let changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, fileName, false);
 
     // 3. Modify file at filesystem level (simulating outside process)
@@ -330,7 +330,7 @@ suite('GitChangeObserver Test Suite', () => {
 
     // 4. Trigger change detection and verify file appears in Code Health Monitor
     await triggerFileChange(filePath);
-    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, fileName, true);
     assertFileInTracker(filePath, true);
 
@@ -338,7 +338,7 @@ suite('GitChangeObserver Test Suite', () => {
     fs.writeFileSync(filePath, originalContent);
 
     // 6. Verify file is no longer in changed list after revert
-    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, fileName, false);
 
     // 7. Queue change event and process it to trigger cleanup
@@ -355,7 +355,7 @@ suite('GitChangeObserver Test Suite', () => {
     createFile('my file.ts', 'console.log("has spaces");');
     createFile('test file with spaces.js', 'console.log("also has spaces");');
 
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     const fileNames = changedFiles.map(f => path.basename(f));
     assert.ok(fileNames.includes('my file.ts'), 'Should include file with spaces: my file.ts');
     assert.ok(fileNames.includes('test file with spaces.js'), 'Should include file with spaces: test file with spaces.js');
@@ -368,7 +368,7 @@ suite('GitChangeObserver Test Suite', () => {
 
     const ignoredFile = createFile('secret.ignored', 'export const secret = "hidden";');
 
-    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    const changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'secret.ignored', false);
 
     await triggerFileChange(ignoredFile);
@@ -384,7 +384,7 @@ suite('GitChangeObserver Test Suite', () => {
 
     const ignoredFile = createFile('config.ts', 'export const config = { secret: true };');
 
-    let changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    let changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'config.ts', false);
 
     await triggerFileChange(ignoredFile);
@@ -394,7 +394,7 @@ suite('GitChangeObserver Test Suite', () => {
 
     await new Promise(resolve => setTimeout(resolve, 100));
 
-    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder());
+    changedFiles = await gitChangeObserver.getChangedFilesVsBaseline(getWorkspaceFolder(), '');
     assertFileInChangedList(changedFiles, 'config.ts');
 
     await triggerFileChange(ignoredFile);
@@ -446,9 +446,9 @@ suite('GitChangeObserver Test Suite', () => {
 
     let getChangedFilesCallCount = 0;
     const originalGetChangedFiles = gitChangeObserver.getChangedFilesVsBaseline.bind(gitChangeObserver);
-    gitChangeObserver.getChangedFilesVsBaseline = async function (workspaceFolder) {
+    gitChangeObserver.getChangedFilesVsBaseline = async function (workspaceFolder, baselineCommit) {
       getChangedFilesCallCount++;
-      return originalGetChangedFiles(workspaceFolder);
+      return originalGetChangedFiles(workspaceFolder, baselineCommit);
     };
 
     for (const file of files) {
@@ -472,9 +472,9 @@ suite('GitChangeObserver Test Suite', () => {
 
     let getChangedFilesCallCount = 0;
     const originalGetChangedFiles = gitChangeObserver.getChangedFilesVsBaseline.bind(gitChangeObserver);
-    gitChangeObserver.getChangedFilesVsBaseline = async function (workspaceFolder) {
+    gitChangeObserver.getChangedFilesVsBaseline = async function (workspaceFolder, baselineCommit) {
       getChangedFilesCallCount++;
-      return originalGetChangedFiles(workspaceFolder);
+      return originalGetChangedFiles(workspaceFolder, baselineCommit);
     };
 
     await new Promise(resolve => setTimeout(resolve, 5000));
@@ -500,7 +500,6 @@ suite('GitChangeObserver Test Suite', () => {
     if (!Reviewer.instance) {
       Reviewer.init(
         mockContext,
-        async () => undefined,
         () => new Map()
       );
     }

--- a/src/test/suite/review-cache.test.ts
+++ b/src/test/suite/review-cache.test.ts
@@ -31,25 +31,19 @@ function createMockReview(document: vscode.TextDocument): CsReview {
 suite('ReviewCache Test Suite', () => {
   let reviewCache: ReviewCache;
   let codeHealthFileVersions: Map<string, number>;
-  let baselineCommitMap: Map<string, string>;
 
   setup(() => {
     codeHealthFileVersions = new Map();
-    baselineCommitMap = new Map();
-
-    const getBaselineCommit = async (fileUri: vscode.Uri) => {
-      return baselineCommitMap.get(fileUri.fsPath);
-    };
 
     const getCodeHealthFileVersions = () => {
       return codeHealthFileVersions;
     };
 
-    reviewCache = new ReviewCache(getBaselineCommit, getCodeHealthFileVersions);
+    reviewCache = new ReviewCache(getCodeHealthFileVersions);
   });
 
-  async function addReview(document: vscode.TextDocument): Promise<void> {
-    await reviewCache.add(document, createMockReview(document), false, false);
+  function addReview(document: vscode.TextDocument): void {
+    reviewCache.add(document, createMockReview(document), false, false, '');
   }
 
   function assertCacheHit(document: vscode.TextDocument, message: string): void {
@@ -70,7 +64,7 @@ suite('ReviewCache Test Suite', () => {
 
   test('should add and retrieve review from cache', async () => {
     const document = createMockDocument('/test/file.ts');
-    await addReview(document);
+    addReview(document);
 
     const retrieved = reviewCache.get(document, false);
     assert.ok(retrieved, 'Should retrieve cached review');
@@ -84,7 +78,7 @@ suite('ReviewCache Test Suite', () => {
 
   test('should return exact version only when document version matches', async () => {
     const document = createMockDocument('/test/file.ts', 'content', 1);
-    await addReview(document);
+    addReview(document);
 
     const exactMatch = reviewCache.getExactVersion(document, false);
     assert.ok(exactMatch, 'Should find exact version match');
@@ -96,7 +90,7 @@ suite('ReviewCache Test Suite', () => {
 
   test('should update existing cache entry', async () => {
     const document = createMockDocument('/test/file.ts');
-    await addReview(document);
+    addReview(document);
 
     const updated = reviewCache.update(document, createMockReview(document), false, false);
     assert.strictEqual(updated, true, 'Should successfully update existing entry');
@@ -110,7 +104,7 @@ suite('ReviewCache Test Suite', () => {
 
   test('should delete cache entry by file path', async () => {
     const document = createMockDocument('/test/file.ts');
-    await addReview(document);
+    addReview(document);
     reviewCache.delete(document.fileName);
 
     assertCacheMiss(document, 'Should not find deleted cache entry');
@@ -120,8 +114,8 @@ suite('ReviewCache Test Suite', () => {
     const doc1 = createMockDocument('/test/file1.ts');
     const doc2 = createMockDocument('/test/file2.ts');
 
-    await addReview(doc1);
-    await addReview(doc2);
+    addReview(doc1);
+    addReview(doc2);
     reviewCache.clear();
 
     assertCacheMiss(doc1, 'Should not find first document after clear');
@@ -131,13 +125,13 @@ suite('ReviewCache Test Suite', () => {
   test('should cache entries separately based on code-health-rules versions', async () => {
     const document = createMockDocument('/test/file.ts');
 
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with empty code-health-rules snapshot');
 
     codeHealthFileVersions.set('/project/.codescene/code-health-rules.json', 1);
     assertCacheMiss(document, 'Should not find cache entry with different code-health-rules snapshot');
 
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with new code-health-rules snapshot');
   });
 
@@ -145,13 +139,13 @@ suite('ReviewCache Test Suite', () => {
     const document = createMockDocument('/test/file.ts');
 
     setRulesVersions({ '/project/.codescene/code-health-rules.json': 1 });
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with version 1');
 
     setRulesVersions({ '/project/.codescene/code-health-rules.json': 2 });
     assertCacheMiss(document, 'Should not find cache entry with old code-health-rules version');
 
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with version 2');
   });
 
@@ -162,7 +156,7 @@ suite('ReviewCache Test Suite', () => {
       '/project1/.codescene/code-health-rules.json': 1,
       '/project2/.codescene/code-health-rules.json': 1
     });
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with multiple rules files');
 
     codeHealthFileVersions.set('/project1/.codescene/code-health-rules.json', 2);
@@ -173,7 +167,7 @@ suite('ReviewCache Test Suite', () => {
     const document = createMockDocument('/test/file.ts');
 
     setRulesVersions({ '/project/.codescene/code-health-rules.json': 1 });
-    await addReview(document);
+    addReview(document);
     assertCacheHit(document, 'Should retrieve review with rules file');
 
     codeHealthFileVersions.delete('/project/.codescene/code-health-rules.json');
@@ -186,8 +180,8 @@ suite('ReviewCache Test Suite', () => {
 
     setRulesVersions({ '/project/.codescene/code-health-rules.json': 1 });
 
-    await addReview(doc1);
-    await addReview(doc2);
+    addReview(doc1);
+    addReview(doc2);
 
     assertCacheHit(doc1, 'Should retrieve first document');
     assertCacheHit(doc2, 'Should retrieve second document');
@@ -197,7 +191,7 @@ suite('ReviewCache Test Suite', () => {
     const document = createMockDocument('/test/file.ts');
 
     setRulesVersions({ '/b.json': 1, '/a.json': 1 });
-    await addReview(document);
+    addReview(document);
 
     codeHealthFileVersions.clear();
     setRulesVersions({ '/a.json': 1, '/b.json': 1 });
@@ -208,10 +202,10 @@ suite('ReviewCache Test Suite', () => {
   test('should delete all versions of a file from cache', async () => {
     const document = createMockDocument('/test/file.ts');
 
-    await addReview(document);
+    addReview(document);
 
     setRulesVersions({ '/project/.codescene/code-health-rules.json': 1 });
-    await addReview(document);
+    addReview(document);
 
     reviewCache.delete(document.fileName);
 
@@ -305,24 +299,24 @@ suite('ReviewCache Test Suite', () => {
       return undefined;
     }
 
-    async function testAddBehavior(initial: boolean, second: boolean, expected: boolean): Promise<void> {
+    function testAddBehavior(initial: boolean, second: boolean, expected: boolean): void {
       const document = createMockDocument('/test/file.ts');
 
-      await reviewCache.add(document, createMockReview(document), initial, false);
+      reviewCache.add(document, createMockReview(document), initial, false, '');
       let entry = getCacheEntry(document);
       assert.ok(entry);
       assert.strictEqual(entry.skipMonitorUpdate, initial);
 
-      await reviewCache.add(document, createMockReview(document), second, false);
+      reviewCache.add(document, createMockReview(document), second, false, '');
       entry = getCacheEntry(document);
       assert.ok(entry);
       assert.strictEqual(entry.skipMonitorUpdate, expected);
     }
 
-    async function testUpdateBehavior(initial: boolean, second: boolean, expected: boolean): Promise<void> {
+    function testUpdateBehavior(initial: boolean, second: boolean, expected: boolean): void {
       const document = createMockDocument('/test/file.ts');
 
-      await reviewCache.add(document, createMockReview(document), initial, false);
+      reviewCache.add(document, createMockReview(document), initial, false, '');
       let entry = getCacheEntry(document);
       assert.ok(entry);
       assert.strictEqual(entry.skipMonitorUpdate, initial);
@@ -336,27 +330,27 @@ suite('ReviewCache Test Suite', () => {
     }
 
     test('should override skipMonitorUpdate true with false when adding', async () => {
-      await testAddBehavior(true, false, false);
+      testAddBehavior(true, false, false);
     });
 
     test('should not override skipMonitorUpdate false with true when adding', async () => {
-      await testAddBehavior(false, true, false);
+      testAddBehavior(false, true, false);
     });
 
     test('should override skipMonitorUpdate true with false when updating', async () => {
-      await testUpdateBehavior(true, false, false);
+      testUpdateBehavior(true, false, false);
     });
 
     test('should not override skipMonitorUpdate false with true when updating', async () => {
-      await testUpdateBehavior(false, true, false);
+      testUpdateBehavior(false, true, false);
     });
 
     test('should keep skipMonitorUpdate true when both are true', async () => {
-      await testUpdateBehavior(true, true, true);
+      testUpdateBehavior(true, true, true);
     });
 
     test('should keep skipMonitorUpdate false when both are false', async () => {
-      await testUpdateBehavior(false, false, false);
+      testUpdateBehavior(false, false, false);
     });
   });
 
@@ -500,7 +494,7 @@ suite('ReviewCache Test Suite', () => {
 
     async function addDocumentToCache(filePath: string): Promise<vscode.TextDocument> {
       const document = createMockDocument(filePath);
-      await addReview(document);
+      addReview(document);
       return document;
     }
 
@@ -570,13 +564,13 @@ suite('ReviewCache Test Suite', () => {
       const nonExistentFilePath = createTempFilePath('multi-version.ts');
       const document = createMockDocument(nonExistentFilePath);
 
-      await addReview(document);
+      addReview(document);
 
       setRulesVersions({ '/project/.codescene/code-health-rules.json': 1 });
-      await addReview(document);
+      addReview(document);
 
       setRulesVersions({ '/project/.codescene/code-health-rules.json': 2 });
-      await addReview(document);
+      addReview(document);
 
       let cacheItem = reviewCache.get(document, false);
       assert.ok(cacheItem, 'Cache item should exist before refreshDeltas');


### PR DESCRIPTION
When e.g. 100 files are changed, `git merge-base` was being called 100 times via the `ReviewCache.add()` → `getBaselineCommit()` chain.

Now the merge-base is computed once per batch at the caller level (`GitChangeLister`, `GitChangeObserver`, etc.) and passed down through `ReviewOpts.baselineCommit`.

I could observe via logging that the fix indeed worked.