### PR TITLE
Introduce `CpuUsageBasedExecutor`

### DIFF
--- a/src/cpu-monitor.ts
+++ b/src/cpu-monitor.ts
@@ -1,0 +1,106 @@
+import * as os from 'os';
+
+interface CpuSnapshot {
+  idle: number;
+  total: number;
+}
+
+export type CpuProvider = () => os.CpuInfo[];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+let previousCpuInfo: CpuSnapshot[] = [];
+let cpuProvider: CpuProvider = os.cpus;
+
+export function setCpuProvider(provider: CpuProvider): void {
+  cpuProvider = provider;
+  previousCpuInfo = snapshotCpus();
+}
+
+export function resetCpuProvider(): void {
+  cpuProvider = os.cpus;
+  previousCpuInfo = snapshotCpus();
+}
+
+function snapshotCpus(): CpuSnapshot[] {
+  return cpuProvider().map(cpu => {
+    const total = Object.values(cpu.times).reduce((acc, time) => acc + time, 0);
+    return { idle: cpu.times.idle, total };
+  });
+}
+
+export async function isCpuTooBusy(): Promise<boolean> {
+  const samples = 5;
+  const sampleDelayMs = 12.5;
+  let coreUsageSums: number[] = [];
+  let coreCount = 0;
+
+  for (let i = 0; i < samples; i++) {
+    if (i > 0) {
+      await sleep(sampleDelayMs);
+    }
+
+    const currentCpuInfo = snapshotCpus();
+    if (i === 0) {
+      coreCount = currentCpuInfo.length;
+      coreUsageSums = new Array(coreCount).fill(0);
+    }
+
+    currentCpuInfo.forEach((current, index) => {
+      const prev = previousCpuInfo[index];
+      const idleDiff = current.idle - prev.idle;
+      const totalDiff = current.total - prev.total;
+      const usage = totalDiff > 0 ? 100 - ((100 * idleDiff) / totalDiff) : 0;
+      coreUsageSums[index] += usage;
+    });
+
+    previousCpuInfo = currentCpuInfo;
+  }
+
+  const avgCoreUsages = coreUsageSums.map(sum => sum / samples);
+  const averageUsage = avgCoreUsages.reduce((sum, usage) => sum + usage, 0) / avgCoreUsages.length;
+
+  let threshold: number;
+  if (coreCount >= 8) {
+    threshold = 75;
+  } else if (coreCount >= 4) {
+    threshold = 70;
+  } else {
+    threshold = 65;
+  }
+
+  return averageUsage > threshold;
+}
+
+export async function getCpuUsages(): Promise<number[]> {
+  const samples = 5;
+  const sampleDelayMs = 12.5;
+  let coreUsageSums: number[] = [];
+
+  for (let i = 0; i < samples; i++) {
+    if (i > 0) {
+      await sleep(sampleDelayMs);
+    }
+
+    const currentCpuInfo = snapshotCpus();
+    if (i === 0) {
+      coreUsageSums = new Array(currentCpuInfo.length).fill(0);
+    }
+
+    currentCpuInfo.forEach((current, index) => {
+      const prev = previousCpuInfo[index];
+      const idleDiff = current.idle - prev.idle;
+      const totalDiff = current.total - prev.total;
+      const usage = totalDiff > 0 ? 100 - ((100 * idleDiff) / totalDiff) : 0;
+      coreUsageSums[index] += usage;
+    });
+
+    previousCpuInfo = currentCpuInfo;
+  }
+
+  return coreUsageSums.map(sum => Math.round(sum / samples));
+}
+
+resetCpuProvider();

--- a/src/cpu-monitor.ts
+++ b/src/cpu-monitor.ts
@@ -7,6 +7,16 @@ interface CpuSnapshot {
 
 export type CpuProvider = () => os.CpuInfo[];
 
+/**
+ * CPU usage thresholds by core count. Systems with more cores can tolerate higher
+ * average usage before being considered "too busy" since load is more distributed.
+ */
+const cpuThresholds: Array<{ minCores: number; threshold: number }> = [
+  { minCores: 8, threshold: 75 },
+  { minCores: 4, threshold: 70 },
+  { minCores: 0, threshold: 65 },
+];
+
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -62,14 +72,7 @@ export async function isCpuTooBusy(): Promise<boolean> {
   const avgCoreUsages = coreUsageSums.map(sum => sum / samples);
   const averageUsage = avgCoreUsages.reduce((sum, usage) => sum + usage, 0) / avgCoreUsages.length;
 
-  let threshold: number;
-  if (coreCount >= 8) {
-    threshold = 75;
-  } else if (coreCount >= 4) {
-    threshold = 70;
-  } else {
-    threshold = 65;
-  }
+  const threshold = cpuThresholds.find(t => coreCount >= t.minCores)!.threshold;
 
   return averageUsage > threshold;
 }

--- a/src/cpu-usage-based-executor.ts
+++ b/src/cpu-usage-based-executor.ts
@@ -1,12 +1,13 @@
 import { ExecOptions } from 'child_process';
 import { Command, ExecResult, Executor } from './executor';
 import { isCpuTooBusy as defaultIsCpuTooBusy } from './cpu-monitor';
+import { ConcurrencyLimitingExecutor } from './concurrency-limiting-executor';
 import { logOutputChannel } from './log';
 
 const RETRY_DELAY_MS = 9000;
 
-type SetTimeoutFn = (callback: (...args: any[]) => void, ms: number) => any;
-type IsCpuTooBusyFn = () => Promise<boolean>;
+export type SetTimeoutFn = (callback: (...args: any[]) => void, ms: number) => any;
+export type IsCpuTooBusyFn = () => Promise<boolean>;
 
 export class CpuUsageBasedExecutor implements Executor {
   constructor(
@@ -51,4 +52,16 @@ export class CpuUsageBasedExecutor implements Executor {
       (this.executor as any).dispose();
     }
   }
+}
+
+export function createCpuAwareConcurrencyExecutor(
+  executor: Executor,
+  maxConcurrency?: number,
+  setTimeoutFn?: SetTimeoutFn,
+  isCpuTooBusyFn?: IsCpuTooBusyFn
+): ConcurrencyLimitingExecutor {
+  return new ConcurrencyLimitingExecutor(
+    new CpuUsageBasedExecutor(executor, setTimeoutFn, isCpuTooBusyFn),
+    maxConcurrency
+  );
 }

--- a/src/cpu-usage-based-executor.ts
+++ b/src/cpu-usage-based-executor.ts
@@ -1,0 +1,54 @@
+import { ExecOptions } from 'child_process';
+import { Command, ExecResult, Executor } from './executor';
+import { isCpuTooBusy as defaultIsCpuTooBusy } from './cpu-monitor';
+import { logOutputChannel } from './log';
+
+const RETRY_DELAY_MS = 9000;
+
+type SetTimeoutFn = (callback: (...args: any[]) => void, ms: number) => any;
+type IsCpuTooBusyFn = () => Promise<boolean>;
+
+export class CpuUsageBasedExecutor implements Executor {
+  constructor(
+    private readonly executor: Executor,
+    private readonly setTimeoutFn: SetTimeoutFn = setTimeout,
+    private readonly isCpuTooBusyFn: IsCpuTooBusyFn = defaultIsCpuTooBusy
+  ) {}
+
+  private async waitForCpu(): Promise<void> {
+    while (await this.isCpuTooBusyFn()) {
+      logOutputChannel.info(`CPU too busy, waiting ${RETRY_DELAY_MS}ms before retry`);
+      await new Promise(resolve => this.setTimeoutFn(resolve, RETRY_DELAY_MS));
+    }
+  }
+
+  async execute(command: Command, options: ExecOptions = {}, input?: string): Promise<ExecResult> {
+    await this.waitForCpu();
+    return this.executor.execute(command, options, input);
+  }
+
+  async executeTask<T>(task: () => Promise<T>): Promise<T> {
+    await this.waitForCpu();
+    return this.executor.executeTask(task);
+  }
+
+  logStats(): void {
+    this.executor.logStats();
+  }
+
+  abortAllTasks(): void {
+    this.executor.abortAllTasks();
+  }
+
+  abort(taskId: string): void {
+    if ('abort' in this.executor && typeof (this.executor as any).abort === 'function') {
+      (this.executor as any).abort(taskId);
+    }
+  }
+
+  dispose(): void {
+    if ('dispose' in this.executor && typeof (this.executor as any).dispose === 'function') {
+      (this.executor as any).dispose();
+    }
+  }
+}

--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -22,7 +22,7 @@ import { logOutputChannel } from '../log';
 import { DevtoolsError } from './devtools-error';
 import { CreditsInfoError } from './credits-info-error';
 import { AbortError } from './abort-error';
-import { createCpuAwareConcurrencyExecutor } from '../cpu-usage-based-executor';
+import { createCpuAwareConcurrencyExecutor, IsCpuTooBusyFn } from '../cpu-usage-based-executor';
 
 function presentCommand(obj: Task | Command, cwd: string): string {
   const trimmedObj = {
@@ -37,12 +37,14 @@ export class DevtoolsAPIImpl {
   public simpleExecutor: SimpleExecutor = new SimpleExecutor();
   public abortingSingleTaskExecutor: AbortingSingleTaskExecutor = new AbortingSingleTaskExecutor(this.simpleExecutor);
   public queuedSingleTaskExecutor: QueuedSingleTaskExecutor = new QueuedSingleTaskExecutor(this.simpleExecutor);
-  public concurrencyLimitingExecutor = createCpuAwareConcurrencyExecutor(this.simpleExecutor);
-  public concurrencyLimitingExecutorForDelta = createCpuAwareConcurrencyExecutor(this.simpleExecutor);
+  public concurrencyLimitingExecutor;
+  public concurrencyLimitingExecutorForDelta;
   public preflightJson?: string;
   public networkError: boolean = false;
 
-  constructor(public binaryPath: string, context: ExtensionContext) {
+  constructor(public binaryPath: string, context: ExtensionContext, isCpuTooBusyFn?: IsCpuTooBusyFn) {
+    this.concurrencyLimitingExecutor = createCpuAwareConcurrencyExecutor(this.simpleExecutor, undefined, undefined, isCpuTooBusyFn);
+    this.concurrencyLimitingExecutorForDelta = createCpuAwareConcurrencyExecutor(this.simpleExecutor, undefined, undefined, isCpuTooBusyFn);
     context.subscriptions.push(
       vscode.commands.registerCommand('codescene.printDevtoolsApiStats', () => {
         this.simpleExecutor.logStats();

--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -1,7 +1,6 @@
 import { ExecOptions } from 'child_process';
 import { Command, ExecResult, Task } from '../executor';
 import { SimpleExecutor } from '../simple-executor';
-import { ConcurrencyLimitingExecutor } from '../concurrency-limiting-executor';
 import { AbortingSingleTaskExecutor } from '../aborting-single-task-executor';
 import { QueuedSingleTaskExecutor } from '../queued-single-task-executor';
 import { safeJsonParse, rangeStr, networkErrors } from '../utils';
@@ -23,7 +22,7 @@ import { logOutputChannel } from '../log';
 import { DevtoolsError } from './devtools-error';
 import { CreditsInfoError } from './credits-info-error';
 import { AbortError } from './abort-error';
-import { CpuUsageBasedExecutor } from '../cpu-usage-based-executor';
+import { createCpuAwareConcurrencyExecutor } from '../cpu-usage-based-executor';
 
 function presentCommand(obj: Task | Command, cwd: string): string {
   const trimmedObj = {
@@ -38,12 +37,8 @@ export class DevtoolsAPIImpl {
   public simpleExecutor: SimpleExecutor = new SimpleExecutor();
   public abortingSingleTaskExecutor: AbortingSingleTaskExecutor = new AbortingSingleTaskExecutor(this.simpleExecutor);
   public queuedSingleTaskExecutor: QueuedSingleTaskExecutor = new QueuedSingleTaskExecutor(this.simpleExecutor);
-  public concurrencyLimitingExecutor = new CpuUsageBasedExecutor(
-    new ConcurrencyLimitingExecutor(this.simpleExecutor)
-  );
-  public concurrencyLimitingExecutorForDelta = new CpuUsageBasedExecutor(
-    new ConcurrencyLimitingExecutor(this.simpleExecutor)
-  );
+  public concurrencyLimitingExecutor = createCpuAwareConcurrencyExecutor(this.simpleExecutor);
+  public concurrencyLimitingExecutorForDelta = createCpuAwareConcurrencyExecutor(this.simpleExecutor);
   public preflightJson?: string;
   public networkError: boolean = false;
 

--- a/src/devtools-api/devtools-api-impl.ts
+++ b/src/devtools-api/devtools-api-impl.ts
@@ -23,6 +23,7 @@ import { logOutputChannel } from '../log';
 import { DevtoolsError } from './devtools-error';
 import { CreditsInfoError } from './credits-info-error';
 import { AbortError } from './abort-error';
+import { CpuUsageBasedExecutor } from '../cpu-usage-based-executor';
 
 function presentCommand(obj: Task | Command, cwd: string): string {
   const trimmedObj = {
@@ -37,11 +38,11 @@ export class DevtoolsAPIImpl {
   public simpleExecutor: SimpleExecutor = new SimpleExecutor();
   public abortingSingleTaskExecutor: AbortingSingleTaskExecutor = new AbortingSingleTaskExecutor(this.simpleExecutor);
   public queuedSingleTaskExecutor: QueuedSingleTaskExecutor = new QueuedSingleTaskExecutor(this.simpleExecutor);
-  public concurrencyLimitingExecutor: ConcurrencyLimitingExecutor = new ConcurrencyLimitingExecutor(
-    this.simpleExecutor
+  public concurrencyLimitingExecutor = new CpuUsageBasedExecutor(
+    new ConcurrencyLimitingExecutor(this.simpleExecutor)
   );
-  public concurrencyLimitingExecutorForDelta: ConcurrencyLimitingExecutor = new ConcurrencyLimitingExecutor(
-    this.simpleExecutor
+  public concurrencyLimitingExecutorForDelta = new CpuUsageBasedExecutor(
+    new ConcurrencyLimitingExecutor(this.simpleExecutor)
   );
   public preflightJson?: string;
   public networkError: boolean = false;

--- a/src/devtools-api/index.ts
+++ b/src/devtools-api/index.ts
@@ -30,13 +30,14 @@ import { MissingAuthTokenError } from '../missing-auth-token-error';
 import { DevtoolsAPIImpl, BinaryOpts } from './devtools-api-impl';
 import { DevtoolsError } from './devtools-error';
 import { AbortError } from './abort-error';
+import { IsCpuTooBusyFn } from '../cpu-usage-based-executor';
 
 export class DevtoolsAPI {
   private static instance: DevtoolsAPIImpl;
   private static reviewCache: ReviewCache;
 
-  static init(binaryPath: string, context: ExtensionContext) {
-    DevtoolsAPI.instance = new DevtoolsAPIImpl(binaryPath, context);
+  static init(binaryPath: string, context: ExtensionContext, isCpuTooBusyFn?: IsCpuTooBusyFn) {
+    DevtoolsAPI.instance = new DevtoolsAPIImpl(binaryPath, context, isCpuTooBusyFn);
     DevtoolsAPI.reviewCache = new ReviewCache(context);
   }
 

--- a/src/test/mocks/mock-iscputoobusy.ts
+++ b/src/test/mocks/mock-iscputoobusy.ts
@@ -1,0 +1,16 @@
+export class MockIsCpuTooBusy {
+  private responses: boolean[] = [];
+  private callIndex = 0;
+  calls: number = 0;
+
+  constructor(responses: boolean[]) {
+    this.responses = responses;
+  }
+
+  async isCpuTooBusy(): Promise<boolean> {
+    const result = this.responses[this.callIndex % this.responses.length];
+    this.callIndex++;
+    this.calls++;
+    return result;
+  }
+}

--- a/src/test/mocks/mock-settimeout.ts
+++ b/src/test/mocks/mock-settimeout.ts
@@ -1,0 +1,30 @@
+export class MockSetTimeout {
+  calls: Array<{ callback: () => void; ms: number }> = [];
+  private pendingWaits: Array<() => void> = [];
+
+  setTimeout(callback: () => void, ms: number): any {
+    this.calls.push({ callback, ms });
+    const waiter = this.pendingWaits.shift();
+    if (waiter) {
+      waiter();
+    }
+    return this.calls.length - 1;
+  }
+
+  waitForNextCall(): Promise<void> {
+    return new Promise(resolve => {
+      this.pendingWaits.push(resolve);
+    });
+  }
+
+  runNext(): void {
+    const call = this.calls.shift();
+    if (call) {
+      call.callback();
+    }
+  }
+
+  get callCount(): number {
+    return this.calls.length;
+  }
+}

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -55,7 +55,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     mockContext = createMockExtensionContext(repoRoot);
     CsExtensionState.init(mockContext);
     Reviewer.init(mockContext, () => new Map());
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   setup(() => {

--- a/src/test/suite/check-rules.test.ts
+++ b/src/test/suite/check-rules.test.ts
@@ -46,7 +46,7 @@ suite('Check Rules Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {

--- a/src/test/suite/code-health-rules-template.test.ts
+++ b/src/test/suite/code-health-rules-template.test.ts
@@ -30,7 +30,7 @@ suite('Code Health Rules Template Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {

--- a/src/test/suite/cpu-aware-concurrency-executor.test.ts
+++ b/src/test/suite/cpu-aware-concurrency-executor.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert';
+import { ExecOptions } from 'child_process';
+import { createCpuAwareConcurrencyExecutor } from '../../cpu-usage-based-executor';
+import { Command, ExecResult, Executor, Task } from '../../executor';
+import { MockSetTimeout } from '../mocks/mock-settimeout';
+import { MockIsCpuTooBusy } from '../mocks/mock-iscputoobusy';
+
+class MockExecutor implements Executor {
+  executeCalls: Array<{ command: Command | Task; options: ExecOptions; input?: string }> = [];
+  executeTaskCalls: Array<() => Promise<any>> = [];
+  private pending: Array<{ resolve: (result: any) => void; reject: (error: Error) => void }> = [];
+  private resolveNextExecute?: () => void;
+
+  async execute(command: Command | Task, options: ExecOptions = {}, input?: string): Promise<ExecResult> {
+    this.executeCalls.push({ command, options, input });
+    if (this.resolveNextExecute) {
+      this.resolveNextExecute();
+      this.resolveNextExecute = undefined;
+    }
+    return new Promise<ExecResult>((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+    });
+  }
+
+  async executeTask<T>(task: () => Promise<T>): Promise<T> {
+    this.executeTaskCalls.push(task as any);
+    if (this.resolveNextExecute) {
+      this.resolveNextExecute();
+      this.resolveNextExecute = undefined;
+    }
+    return new Promise<T>((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+    });
+  }
+
+  waitForExecuteCount(count: number): Promise<void> {
+    if (this.executeCalls.length + this.executeTaskCalls.length >= count) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      this.resolveNextExecute = resolve;
+    });
+  }
+
+  waitForNextExecute(): Promise<void> {
+    return this.waitForExecuteCount(this.executeCalls.length + this.executeTaskCalls.length + 1);
+  }
+
+  logStats(): void {}
+
+  complete(index: number, result: any = { stdout: '', stderr: '', exitCode: 0, duration: 100 }): void {
+    this.pending[index]?.resolve(result);
+  }
+
+  fail(index: number, error: Error): void {
+    this.pending[index]?.reject(error);
+  }
+
+  abortAllTasks(): void {}
+}
+
+suite('createCpuAwareConcurrencyExecutor Test Suite', () => {
+  test('concurrent requests do not redundantly check CPU', async () => {
+    const mockCpu = new MockIsCpuTooBusy([true, false, false, false]);
+    const mockSetTimeout = new MockSetTimeout();
+    const mock = new MockExecutor();
+    const exec = createCpuAwareConcurrencyExecutor(
+      mock,
+      1,
+      mockSetTimeout.setTimeout.bind(mockSetTimeout),
+      mockCpu.isCpuTooBusy.bind(mockCpu)
+    );
+
+    const promise1 = exec.execute({ command: 'test1', args: [] }, {});
+    const promise2 = exec.execute({ command: 'test2', args: [] }, {});
+    const promise3 = exec.execute({ command: 'test3', args: [] }, {});
+
+    await mockSetTimeout.waitForNextCall();
+    assert.strictEqual(mockCpu.calls, 1, 'only first request should check CPU initially');
+    assert.strictEqual(mock.executeCalls.length, 0, 'no executions yet while CPU busy');
+
+    mockSetTimeout.runNext();
+    await mock.waitForNextExecute();
+
+    assert.strictEqual(mockCpu.calls, 2, 'first request checked CPU twice (busy then free)');
+    assert.strictEqual(mock.executeCalls.length, 1, 'first request executing');
+
+    mock.complete(0);
+    await mock.waitForNextExecute();
+
+    assert.strictEqual(mockCpu.calls, 3, 'second request now checks CPU');
+    assert.strictEqual(mock.executeCalls.length, 2, 'second request executing');
+
+    mock.complete(1);
+    await mock.waitForNextExecute();
+
+    assert.strictEqual(mockCpu.calls, 4, 'third request now checks CPU');
+    assert.strictEqual(mock.executeCalls.length, 3, 'third request executing');
+
+    mock.complete(2);
+    await Promise.all([promise1, promise2, promise3]);
+  });
+});

--- a/src/test/suite/cpu-monitor.test.ts
+++ b/src/test/suite/cpu-monitor.test.ts
@@ -1,0 +1,159 @@
+import * as assert from 'assert';
+import * as os from 'os';
+import { isCpuTooBusy, setCpuProvider, resetCpuProvider } from '../../cpu-monitor';
+
+suite('CPU Monitor Test Suite', () => {
+  teardown(() => {
+    resetCpuProvider();
+  });
+
+  const createCpuInfo = (idle: number, total: number) => {
+    const nonIdle = total - idle;
+    return {
+      model: 'Test CPU',
+      speed: 2400,
+      times: {
+        user: nonIdle * 0.6,
+        nice: 0,
+        sys: nonIdle * 0.4,
+        idle: idle,
+        irq: 0,
+      },
+    };
+  };
+
+  suite('with 8+ cores (75% threshold)', () => {
+    [
+      { usagePercent: 20, expected: false, desc: '20% usage (below threshold)' },
+      { usagePercent: 70, expected: false, desc: '70% usage (below threshold)' },
+      { usagePercent: 75, expected: false, desc: '75% usage (at threshold)' },
+      { usagePercent: 80, expected: true, desc: '80% usage (above threshold)' },
+      { usagePercent: 90, expected: true, desc: '90% usage (above threshold)' },
+    ].forEach(({ usagePercent, expected, desc }) => {
+      test(desc, async () => {
+        const coreCount = 8;
+        const deltaTotal = 1000;
+        const deltaIdle = deltaTotal * (100 - usagePercent) / 100;
+
+        const snapshots: os.CpuInfo[][] = [];
+        let baseIdle = 5000;
+        let baseTotal = 10000;
+
+        for (let i = 0; i < 6; i++) {
+          snapshots.push(Array(coreCount).fill(null).map(() => createCpuInfo(baseIdle, baseTotal)));
+          baseIdle += deltaIdle;
+          baseTotal += deltaTotal;
+        }
+
+        let providerCallCount = 0;
+        const mockProvider = () => {
+          const result = snapshots[providerCallCount % snapshots.length];
+          providerCallCount++;
+          return result;
+        };
+        setCpuProvider(mockProvider);
+
+        const result = await isCpuTooBusy();
+        assert.strictEqual(result, expected);
+      });
+    });
+  });
+
+  suite('with 4-7 cores (70% threshold)', () => {
+    [
+      { usagePercent: 20, expected: false, desc: '20% usage (below threshold)' },
+      { usagePercent: 70, expected: false, desc: '70% usage (at threshold)' },
+      { usagePercent: 75, expected: true, desc: '75% usage (above threshold)' },
+      { usagePercent: 80, expected: true, desc: '80% usage (above threshold)' },
+    ].forEach(({ usagePercent, expected, desc }) => {
+      test(desc, async () => {
+        const coreCount = 4;
+        const deltaTotal = 1000;
+        const deltaIdle = deltaTotal * (100 - usagePercent) / 100;
+
+        const snapshots: os.CpuInfo[][] = [];
+        let baseIdle = 5000;
+        let baseTotal = 10000;
+
+        for (let i = 0; i < 6; i++) {
+          snapshots.push(Array(coreCount).fill(null).map(() => createCpuInfo(baseIdle, baseTotal)));
+          baseIdle += deltaIdle;
+          baseTotal += deltaTotal;
+        }
+
+        let providerCallCount = 0;
+        const mockProvider = () => {
+          const result = snapshots[providerCallCount % snapshots.length];
+          providerCallCount++;
+          return result;
+        };
+        setCpuProvider(mockProvider);
+
+        const result = await isCpuTooBusy();
+        assert.strictEqual(result, expected);
+      });
+    });
+  });
+
+  suite('with <4 cores (65% threshold)', () => {
+    [
+      { usagePercent: 20, expected: false, desc: '20% usage (below threshold)' },
+      { usagePercent: 60, expected: false, desc: '60% usage (below threshold)' },
+      { usagePercent: 65, expected: false, desc: '65% usage (at threshold)' },
+      { usagePercent: 70, expected: true, desc: '70% usage (above threshold)' },
+      { usagePercent: 80, expected: true, desc: '80% usage (above threshold)' },
+    ].forEach(({ usagePercent, expected, desc }) => {
+      test(desc, async () => {
+        const coreCount = 2;
+        const deltaTotal = 1000;
+        const deltaIdle = deltaTotal * (100 - usagePercent) / 100;
+
+        const snapshots: os.CpuInfo[][] = [];
+        let baseIdle = 5000;
+        let baseTotal = 10000;
+
+        for (let i = 0; i < 6; i++) {
+          snapshots.push(Array(coreCount).fill(null).map(() => createCpuInfo(baseIdle, baseTotal)));
+          baseIdle += deltaIdle;
+          baseTotal += deltaTotal;
+        }
+
+        let providerCallCount = 0;
+        const mockProvider = () => {
+          const result = snapshots[providerCallCount % snapshots.length];
+          providerCallCount++;
+          return result;
+        };
+        setCpuProvider(mockProvider);
+
+        const result = await isCpuTooBusy();
+        assert.strictEqual(result, expected);
+      });
+    });
+  });
+
+  suite('with mixed CPU loads', () => {
+    test('calculates average across cores with different loads (8 cores)', async () => {
+      const snapshots: os.CpuInfo[][] = [];
+      let baseIdles = [5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000];
+      let baseTotals = [10000, 10000, 10000, 10000, 10000, 10000, 10000, 10000];
+
+      for (let i = 0; i < 6; i++) {
+        snapshots.push(baseIdles.map((idle, idx) => createCpuInfo(idle, baseTotals[idx])));
+        baseIdles = baseIdles.map((idle, idx) => idle + (idx < 4 ? 900 : 100));
+        baseTotals = baseTotals.map(total => total + 1000);
+      }
+
+      let providerCallCount = 0;
+      const mockProvider = () => {
+        const result = snapshots[providerCallCount % snapshots.length];
+        providerCallCount++;
+        return result;
+      };
+      setCpuProvider(mockProvider);
+
+      const result = await isCpuTooBusy();
+      assert.strictEqual(result, false);
+    });
+  });
+});

--- a/src/test/suite/cpu-monitor.test.ts
+++ b/src/test/suite/cpu-monitor.test.ts
@@ -132,6 +132,45 @@ suite('CPU Monitor Test Suite', () => {
     });
   });
 
+  suite('core count boundaries', () => {
+    [
+      { coreCount: 1, threshold: 65, desc: '1 core uses 65% threshold' },
+      { coreCount: 3, threshold: 65, desc: '3 cores uses 65% threshold' },
+      { coreCount: 4, threshold: 70, desc: '4 cores uses 70% threshold' },
+      { coreCount: 5, threshold: 70, desc: '5 cores uses 70% threshold' },
+      { coreCount: 7, threshold: 70, desc: '7 cores uses 70% threshold' },
+      { coreCount: 8, threshold: 75, desc: '8 cores uses 75% threshold' },
+      { coreCount: 9, threshold: 75, desc: '9 cores uses 75% threshold' },
+    ].forEach(({ coreCount, threshold, desc }) => {
+      test(desc, async () => {
+        const usageAboveThreshold = threshold + 1;
+        const deltaTotal = 1000;
+        const deltaIdle = deltaTotal * (100 - usageAboveThreshold) / 100;
+
+        const snapshots: os.CpuInfo[][] = [];
+        let baseIdle = 5000;
+        let baseTotal = 10000;
+
+        for (let i = 0; i < 6; i++) {
+          snapshots.push(Array(coreCount).fill(null).map(() => createCpuInfo(baseIdle, baseTotal)));
+          baseIdle += deltaIdle;
+          baseTotal += deltaTotal;
+        }
+
+        let providerCallCount = 0;
+        const mockProvider = () => {
+          const result = snapshots[providerCallCount % snapshots.length];
+          providerCallCount++;
+          return result;
+        };
+        setCpuProvider(mockProvider);
+
+        const result = await isCpuTooBusy();
+        assert.strictEqual(result, true, `${coreCount} cores at ${usageAboveThreshold}% should be too busy`);
+      });
+    });
+  });
+
   suite('with mixed CPU loads', () => {
     test('calculates average across cores with different loads (8 cores)', async () => {
       const snapshots: os.CpuInfo[][] = [];

--- a/src/test/suite/cpu-usage-based-executor.test.ts
+++ b/src/test/suite/cpu-usage-based-executor.test.ts
@@ -1,0 +1,195 @@
+import * as assert from 'assert';
+import { ExecOptions } from 'child_process';
+import { CpuUsageBasedExecutor } from '../../cpu-usage-based-executor';
+import { Command, ExecResult, Executor, Task } from '../../executor';
+import { MockSetTimeout } from '../mocks/mock-settimeout';
+import { MockIsCpuTooBusy } from '../mocks/mock-iscputoobusy';
+
+class MockExecutor implements Executor {
+  executeCalls: Array<{ command: Command | Task; options: ExecOptions; input?: string }> = [];
+  executeTaskCalls: Array<() => Promise<any>> = [];
+  private pending: Array<{ resolve: (result: any) => void; reject: (error: Error) => void }> = [];
+  private resolveNextExecute?: () => void;
+
+  async execute(command: Command | Task, options: ExecOptions = {}, input?: string): Promise<ExecResult> {
+    this.executeCalls.push({ command, options, input });
+    if (this.resolveNextExecute) {
+      this.resolveNextExecute();
+      this.resolveNextExecute = undefined;
+    }
+    return new Promise<ExecResult>((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+    });
+  }
+
+  async executeTask<T>(task: () => Promise<T>): Promise<T> {
+    this.executeTaskCalls.push(task as any);
+    if (this.resolveNextExecute) {
+      this.resolveNextExecute();
+      this.resolveNextExecute = undefined;
+    }
+    return new Promise<T>((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+    });
+  }
+
+  waitForExecuteCount(count: number): Promise<void> {
+    if (this.executeCalls.length + this.executeTaskCalls.length >= count) {
+      return Promise.resolve();
+    }
+    return new Promise(resolve => {
+      this.resolveNextExecute = resolve;
+    });
+  }
+
+  waitForNextExecute(): Promise<void> {
+    return this.waitForExecuteCount(this.executeCalls.length + this.executeTaskCalls.length + 1);
+  }
+
+  logStats(): void {}
+
+  complete(index: number, result: any = { stdout: '', stderr: '', exitCode: 0, duration: 100 }): void {
+    this.pending[index]?.resolve(result);
+  }
+
+  fail(index: number, error: Error): void {
+    this.pending[index]?.reject(error);
+  }
+
+  abortAllTasks(): void {}
+}
+
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+suite('CpuUsageBasedExecutor Test Suite', () => {
+  [
+    { cpuResponses: [false], desc: 'execute [false]', expectedWaits: 0 },
+    { cpuResponses: [true, false], desc: 'execute [true, false]', expectedWaits: 1 },
+    { cpuResponses: [false, true], desc: 'execute [false, true]', expectedWaits: 0 },
+    { cpuResponses: [false, true, false], desc: 'execute [false, true, false]', expectedWaits: 0 },
+    { cpuResponses: [true, false, true], desc: 'execute [true, false, true]', expectedWaits: 1 },
+    { cpuResponses: [true, true, false], desc: 'execute [true, true, false]', expectedWaits: 2 },
+  ].forEach(({ cpuResponses, desc, expectedWaits }) => {
+    test(desc, async () => {
+      const mockCpu = new MockIsCpuTooBusy(cpuResponses);
+      const mockSetTimeout = new MockSetTimeout();
+      const mock = new MockExecutor();
+      const exec = new CpuUsageBasedExecutor(
+        mock,
+        mockSetTimeout.setTimeout.bind(mockSetTimeout),
+        mockCpu.isCpuTooBusy.bind(mockCpu)
+      );
+
+      const promise = exec.execute({ command: 'test', args: [] });
+
+      if (expectedWaits === 0) {
+        await mock.waitForNextExecute();
+      } else {
+        for (let i = 0; i < expectedWaits; i++) {
+          await mockSetTimeout.waitForNextCall();
+          assert.strictEqual(mock.executeCalls.length, 0);
+          assert.strictEqual(mockSetTimeout.calls.length, 1);
+          assert.strictEqual(mockSetTimeout.calls[0].ms, 9000);
+
+          mockSetTimeout.runNext();
+
+          if (i === expectedWaits - 1) {
+            await mock.waitForNextExecute();
+          }
+        }
+      }
+
+      assert.strictEqual(mockCpu.calls, expectedWaits + 1);
+      assert.strictEqual(mockSetTimeout.callCount, 0);
+      assert.strictEqual(mock.executeCalls.length, 1);
+      mock.complete(0);
+      await promise;
+    });
+  });
+
+  [
+    { cpuResponses: [false], desc: 'executeTask [false]', expectedWaits: 0 },
+    { cpuResponses: [true, false], desc: 'executeTask [true, false]', expectedWaits: 1 },
+    { cpuResponses: [false, true], desc: 'executeTask [false, true]', expectedWaits: 0 },
+    { cpuResponses: [false, true, false], desc: 'executeTask [false, true, false]', expectedWaits: 0 },
+    { cpuResponses: [true, false, true], desc: 'executeTask [true, false, true]', expectedWaits: 1 },
+    { cpuResponses: [true, true, false], desc: 'executeTask [true, true, false]', expectedWaits: 2 },
+  ].forEach(({ cpuResponses, desc, expectedWaits }) => {
+    test(desc, async () => {
+      const mockCpu = new MockIsCpuTooBusy(cpuResponses);
+      const mockSetTimeout = new MockSetTimeout();
+      const mock = new MockExecutor();
+      const exec = new CpuUsageBasedExecutor(
+        mock,
+        mockSetTimeout.setTimeout.bind(mockSetTimeout),
+        mockCpu.isCpuTooBusy.bind(mockCpu)
+      );
+
+      const promise = exec.executeTask(async () => 'result');
+
+      if (expectedWaits === 0) {
+        await mock.waitForNextExecute();
+      } else {
+        for (let i = 0; i < expectedWaits; i++) {
+          await mockSetTimeout.waitForNextCall();
+          assert.strictEqual(mock.executeTaskCalls.length, 0);
+          assert.strictEqual(mockSetTimeout.calls.length, 1);
+          assert.strictEqual(mockSetTimeout.calls[0].ms, 9000);
+
+          mockSetTimeout.runNext();
+
+          if (i === expectedWaits - 1) {
+            await mock.waitForNextExecute();
+          }
+        }
+      }
+
+      assert.strictEqual(mockCpu.calls, expectedWaits + 1);
+      assert.strictEqual(mockSetTimeout.callCount, 0);
+      assert.strictEqual(mock.executeTaskCalls.length, 1);
+      mock.complete(0, 'result');
+      const result = await promise;
+      assert.strictEqual(result, 'result');
+    });
+  });
+
+  test('propagates errors from wrapped executor', async () => {
+    const mockCpu = new MockIsCpuTooBusy([false]);
+    const mockSetTimeout = new MockSetTimeout();
+    const mock = new MockExecutor();
+    const exec = new CpuUsageBasedExecutor(
+      mock,
+      mockSetTimeout.setTimeout.bind(mockSetTimeout),
+      mockCpu.isCpuTooBusy.bind(mockCpu)
+    );
+
+    const promise = exec.execute({ command: 'test', args: [] });
+    await mock.waitForNextExecute();
+
+    mock.fail(0, new Error('Test error'));
+    await assert.rejects(promise, { message: 'Test error' });
+  });
+
+  test('delegates logStats to wrapped executor', () => {
+    const mock = new MockExecutor();
+    let called = false;
+    mock.logStats = () => { called = true; };
+
+    const exec = new CpuUsageBasedExecutor(mock);
+    exec.logStats();
+
+    assert.strictEqual(called, true);
+  });
+
+  test('delegates abortAllTasks to wrapped executor', () => {
+    const mock = new MockExecutor();
+    let called = false;
+    mock.abortAllTasks = () => { called = true; };
+
+    const exec = new CpuUsageBasedExecutor(mock);
+    exec.abortAllTasks();
+
+    assert.strictEqual(called, true);
+  });
+
+});

--- a/src/test/suite/cs-diagnostics.test.ts
+++ b/src/test/suite/cs-diagnostics.test.ts
@@ -28,7 +28,7 @@ suite('CsDiagnostics Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
     mockCollection = new MockDiagnosticCollection();
     originalCollection = (CsDiagnostics as any).collection;
     (CsDiagnostics as any).collection = mockCollection;

--- a/src/test/suite/delta.test.ts
+++ b/src/test/suite/delta.test.ts
@@ -66,7 +66,7 @@ suite('Delta Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
 
     deltaEventFired = false;
     lastDeltaEvent = undefined;

--- a/src/test/suite/device-id.test.ts
+++ b/src/test/suite/device-id.test.ts
@@ -20,7 +20,7 @@ suite('Device ID Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {

--- a/src/test/suite/devtools-api-no-ace.test.ts
+++ b/src/test/suite/devtools-api-no-ace.test.ts
@@ -14,7 +14,7 @@ noAceSuite('DevtoolsAPI no-ACE guard Test Suite', () => {
     mockWorkspaceFolders([createMockWorkspaceFolder(testDir)]);
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {

--- a/src/test/suite/fns-to-refactor.test.ts
+++ b/src/test/suite/fns-to-refactor.test.ts
@@ -40,7 +40,7 @@ aceSuite('FnsToRefactor Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
 
     analysisError = undefined;
 

--- a/src/test/suite/post-refactoring.test.ts
+++ b/src/test/suite/post-refactoring.test.ts
@@ -73,7 +73,7 @@ aceSuite('PostRefactoring Integration Test Suite', () => {
       configurable: true
     });
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
 
     analysisError = undefined;
     refactoringError = undefined;

--- a/src/test/suite/preflight.test.ts
+++ b/src/test/suite/preflight.test.ts
@@ -43,7 +43,7 @@ aceSuite('Preflight Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
 
     preflightStateChangeFired = false;
     lastPreflightState = undefined;

--- a/src/test/suite/review-baseline.test.ts
+++ b/src/test/suite/review-baseline.test.ts
@@ -33,7 +33,7 @@ suite('Review Baseline Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {

--- a/src/test/suite/telemetry-integration.test.ts
+++ b/src/test/suite/telemetry-integration.test.ts
@@ -21,7 +21,7 @@ suite('Telemetry Integration Test Suite', () => {
     const binaryPath = await ensureBinary();
     const mockContext = createMockExtensionContext(testDir);
 
-    DevtoolsAPI.init(binaryPath, mockContext);
+    DevtoolsAPI.init(binaryPath, mockContext, async () => false);
   });
 
   teardown(() => {


### PR DESCRIPTION
* feat: add CPU monitoring module with configurable thresholds
* feat: add CpuUsageBasedExecutor to throttle analysis during high CPU load

The overall idea is to not run analysis if the CPUs have, been, on average, overly busy for a recent period. That busy-ness can be caused for an arbitrary reason (external or our own).

So, as long as the system cannot reasonably be used, we yield execution and retry later.

The CPU check is not continuous, but on-demand, before a would-be analysis.

## Verification

I ran a script that kept most cores intentionally busy (`while true`). While it was running , this was logged, indicating that we were refraining from running analyses:

<img width="602" height="74" alt="image" src="https://github.com/user-attachments/assets/52b22274-c242-42ca-99d9-80a55b8c3ee1" />

Afterwards, I closed the script and the extension correctly exited from the intentional `CPU too busy, waiting 9000ms before retry` loop.

## Notes on the algo

The algo for detecting if a CPU is "too busy" was a simple heuristic I came up with.

A more advanced algo may be based instead on the concept of `Load Average vs CPU core count`. Unfortunately though, there's no Windows api for that.

A future iteration may use Load Average, falling back to this PR's algo if unavailable.