### PR TITLE
feat: add targeted .codescene file discovery using git lookups

### DIFF
--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -38,6 +38,7 @@ import { OpenFilesObserver } from './review/open-files-observer';
 import { acquireGitApi, clearMainBranchCandidatesCache, deactivate as deactivateGitUtils, fireFileDeletedFromGit } from './git-utils';
 import { DefaultBranchGate } from './git/default-branch-gate';
 import { gitRootFromCodesceneConfigUri } from './git/codescene-repo-config';
+import { discoverCodeHealthRulesFileUris } from './git/codescene-file-discovery';
 import { DroppingScheduledExecutor } from './dropping-scheduled-executor';
 import { SimpleExecutor } from './simple-executor';
 import { getHomeViewInstance } from './code-health-monitor/home/home-view';
@@ -168,7 +169,15 @@ export function setWindowFocusedForTesting(focused: boolean): void {
 }
 
 async function initializeCodeHealthFileVersions() {
-  const rulesFiles = await vscode.workspace.findFiles('**/.codescene/code-health-rules.json');
+  const gitApi = acquireGitApi();
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  if (!workspaceFolder) return;
+
+  const workspacePath = workspaceFolder.uri.fsPath;
+  const repo = gitApi?.getRepository(workspaceFolder.uri);
+  const gitRootPath = repo?.rootUri.fsPath;
+
+  const rulesFiles = await discoverCodeHealthRulesFileUris(workspacePath, gitRootPath);
 
   for (const uri of rulesFiles) {
     try {

--- a/src/git/codescene-file-discovery.ts
+++ b/src/git/codescene-file-discovery.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import vscode from 'vscode';
+import { gitExecutor, GIT_TASK_ID } from '../git-utils';
+import { CODE_SCENE_DIR } from './codescene-repo-config';
+
+const CODE_HEALTH_RULES_FILE = 'code-health-rules.json';
+
+function isCodeHealthRulesFile(filePath: string): boolean {
+  const normalized = path.normalize(filePath).replace(/\\/g, '/');
+  return normalized.endsWith(`/${CODE_SCENE_DIR}/${CODE_HEALTH_RULES_FILE}`);
+}
+
+/** Finds code-health-rules.json files without vscode.workspace.findFiles (avoids ripgrep). */
+export async function discoverCodeHealthRulesFileUris(
+  workspacePath: string,
+  gitRootPath?: string
+): Promise<vscode.Uri[]> {
+  const absolutePaths = new Set<string>();
+
+  const workspaceRules = path.join(workspacePath, CODE_SCENE_DIR, CODE_HEALTH_RULES_FILE);
+  if (fs.existsSync(workspaceRules)) {
+    absolutePaths.add(path.normalize(workspaceRules));
+  }
+
+  if (gitRootPath) {
+    const trackedPaths = await listTrackedCodeHealthRulesPaths(gitRootPath);
+    for (const relativePath of trackedPaths) {
+      const absolutePath = path.normalize(path.resolve(gitRootPath, relativePath));
+      if (isWithinDirectory(absolutePath, workspacePath)) {
+        absolutePaths.add(absolutePath);
+      }
+    }
+  }
+
+  return Array.from(absolutePaths, (filePath) => vscode.Uri.file(filePath));
+}
+
+async function listTrackedCodeHealthRulesPaths(gitRootPath: string): Promise<string[]> {
+  try {
+    const result = await gitExecutor.execute(
+      {
+        command: 'git',
+        args: ['ls-files', '--', ':(glob)**/.codescene/code-health-rules.json'],
+        ignoreError: true,
+        taskId: GIT_TASK_ID,
+      },
+      { cwd: gitRootPath }
+    );
+
+    if (result.exitCode !== 0 || !result.stdout.trim()) {
+      return listTrackedCodeHealthRulesPathsFallback(gitRootPath);
+    }
+
+    return result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && isCodeHealthRulesFile(path.resolve(gitRootPath, line)));
+  } catch {
+    return [];
+  }
+}
+
+async function listTrackedCodeHealthRulesPathsFallback(gitRootPath: string): Promise<string[]> {
+  try {
+    const result = await gitExecutor.execute(
+      { command: 'git', args: ['ls-files'], ignoreError: true, taskId: GIT_TASK_ID },
+      { cwd: gitRootPath }
+    );
+
+    if (result.exitCode !== 0) {
+      return [];
+    }
+
+    return result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && isCodeHealthRulesFile(path.resolve(gitRootPath, line)));
+  } catch {
+    return [];
+  }
+}
+
+function isWithinDirectory(filePath: string, directoryPath: string): boolean {
+  const normalizedFile = path.normalize(filePath);
+  const normalizedDirectory = path.normalize(directoryPath);
+  return normalizedFile === normalizedDirectory || normalizedFile.startsWith(normalizedDirectory + path.sep);
+}

--- a/src/git/codescene-file-discovery.ts
+++ b/src/git/codescene-file-discovery.ts
@@ -16,6 +16,10 @@ export async function discoverCodeHealthRulesFileUris(
   workspacePath: string,
   gitRootPath?: string
 ): Promise<vscode.Uri[]> {
+  if (!gitRootPath) {
+    return vscode.workspace.findFiles('**/.codescene/code-health-rules.json');
+  }
+
   const absolutePaths = new Set<string>();
 
   const workspaceRules = path.join(workspacePath, CODE_SCENE_DIR, CODE_HEALTH_RULES_FILE);
@@ -23,13 +27,11 @@ export async function discoverCodeHealthRulesFileUris(
     absolutePaths.add(path.normalize(workspaceRules));
   }
 
-  if (gitRootPath) {
-    const trackedPaths = await listTrackedCodeHealthRulesPaths(gitRootPath);
-    for (const relativePath of trackedPaths) {
-      const absolutePath = path.normalize(path.resolve(gitRootPath, relativePath));
-      if (isWithinDirectory(absolutePath, workspacePath)) {
-        absolutePaths.add(absolutePath);
-      }
+  const trackedPaths = await listTrackedCodeHealthRulesPaths(gitRootPath);
+  for (const relativePath of trackedPaths) {
+    const absolutePath = path.normalize(path.resolve(gitRootPath, relativePath));
+    if (isWithinDirectory(absolutePath, workspacePath)) {
+      absolutePaths.add(absolutePath);
     }
   }
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,6 +42,15 @@ export function restoreDefaultWorkspaceFolders() {
 }
 
 let mockGitRepositories: any[] = [];
+let mockFindFilesResults: any[] = [];
+
+export function setMockFindFilesResults(results: any[]) {
+  mockFindFilesResults = results;
+}
+
+export function clearMockFindFilesResults() {
+  mockFindFilesResults = [];
+}
 
 export type MockWebviewPanel = {
   visible: boolean;
@@ -206,6 +215,9 @@ const vscodeStub = {
   },
   workspace: {
     workspaceFolders: defaultWorkspaceFolders as any,
+    findFiles: async () => {
+      return mockFindFilesResults;
+    },
     onDidChangeConfiguration: (listener: any) => {
       void listener;
       return { dispose: () => {} };

--- a/src/test/suite/codescene-file-discovery.test.ts
+++ b/src/test/suite/codescene-file-discovery.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+import { discoverCodeHealthRulesFileUris } from '../../git/codescene-file-discovery';
+import { createTestDir } from '../integration_helper';
+
+suite('CodeScene File Discovery Test Suite', function () {
+  const testDir = createTestDir('test-codescene-file-discovery');
+
+  function createCodeHealthRulesFile(relativePath: string): string {
+    const fullPath = path.join(testDir, relativePath);
+    const dir = path.dirname(fullPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(fullPath, '{}');
+    return fullPath;
+  }
+
+  function gitAdd(filePath: string) {
+    const relativePath = path.relative(testDir, filePath);
+    execSync(`git add "${relativePath}"`, { cwd: testDir });
+  }
+
+  function gitCommit(message: string) {
+    execSync(`git commit -m "${message}"`, { cwd: testDir });
+  }
+
+  setup(function () {
+    this.timeout(20000);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testDir, { recursive: true });
+
+    execSync('git init', { cwd: testDir });
+    execSync('git config user.email "test@example.com"', { cwd: testDir });
+    execSync('git config user.name "Test User"', { cwd: testDir });
+    execSync('git config advice.defaultBranchName false', { cwd: testDir });
+  });
+
+  teardown(function () {
+    this.timeout(20000);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  const discoveryTestCases = [
+    {
+      name: 'returns empty array when no files exist',
+      files: [],
+      tracked: [],
+      expectedCount: 0,
+    },
+    {
+      name: 'discovers file at workspace root',
+      files: ['.codescene/code-health-rules.json'],
+      tracked: ['.codescene/code-health-rules.json'],
+      expectedCount: 1,
+    },
+    {
+      name: 'discovers file at depth 1',
+      files: ['sub/.codescene/code-health-rules.json'],
+      tracked: ['sub/.codescene/code-health-rules.json'],
+      expectedCount: 1,
+    },
+    {
+      name: 'discovers file at depth 2',
+      files: ['a/b/.codescene/code-health-rules.json'],
+      tracked: ['a/b/.codescene/code-health-rules.json'],
+      expectedCount: 1,
+    },
+    {
+      name: 'discovers file at depth 3',
+      files: ['a/b/c/.codescene/code-health-rules.json'],
+      tracked: ['a/b/c/.codescene/code-health-rules.json'],
+      expectedCount: 1,
+    },
+    {
+      name: 'discovers multiple files at various depths',
+      files: [
+        '.codescene/code-health-rules.json',
+        'sub/.codescene/code-health-rules.json',
+        'a/b/c/.codescene/code-health-rules.json',
+      ],
+      tracked: [
+        '.codescene/code-health-rules.json',
+        'sub/.codescene/code-health-rules.json',
+        'a/b/c/.codescene/code-health-rules.json',
+      ],
+      expectedCount: 3,
+    },
+    {
+      name: 'discovers untracked file at workspace root via fs.existsSync',
+      files: ['.codescene/code-health-rules.json'],
+      tracked: [],
+      expectedCount: 1,
+    },
+  ];
+
+  for (const tc of discoveryTestCases) {
+    test(tc.name, async function () {
+      this.timeout(10000);
+
+      const createdPaths: string[] = [];
+      for (const file of tc.files) {
+        createdPaths.push(createCodeHealthRulesFile(file));
+      }
+
+      if (tc.tracked.length > 0) {
+        for (const file of tc.tracked) {
+          gitAdd(path.join(testDir, file));
+        }
+        gitCommit('Add rules files');
+      }
+
+      const uris = await discoverCodeHealthRulesFileUris(testDir, testDir);
+
+      assert.strictEqual(uris.length, tc.expectedCount, `Expected ${tc.expectedCount} files`);
+
+      if (tc.expectedCount > 0) {
+        const fsPaths = uris.map((u) => path.normalize(u.fsPath)).sort();
+        const expectedPaths = createdPaths.map((p) => path.normalize(p)).sort();
+        assert.deepStrictEqual(fsPaths, expectedPaths);
+      }
+    });
+  }
+
+  test('filters out files outside workspace when git root differs', async function () {
+    this.timeout(10000);
+
+    const subWorkspace = path.join(testDir, 'workspace');
+    fs.mkdirSync(subWorkspace, { recursive: true });
+
+    createCodeHealthRulesFile('.codescene/code-health-rules.json');
+    const insideRules = createCodeHealthRulesFile('workspace/.codescene/code-health-rules.json');
+
+    gitAdd(path.join(testDir, '.codescene/code-health-rules.json'));
+    gitAdd(path.join(testDir, 'workspace/.codescene/code-health-rules.json'));
+    gitCommit('Add rules files');
+
+    const uris = await discoverCodeHealthRulesFileUris(subWorkspace, testDir);
+
+    assert.strictEqual(uris.length, 1);
+    assert.strictEqual(path.normalize(uris[0].fsPath), path.normalize(insideRules));
+  });
+});

--- a/src/test/suite/codescene-file-discovery.test.ts
+++ b/src/test/suite/codescene-file-discovery.test.ts
@@ -1,12 +1,26 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as os from 'os';
 import { execSync } from 'child_process';
 import { discoverCodeHealthRulesFileUris } from '../../git/codescene-file-discovery';
-import { createTestDir } from '../integration_helper';
+import { setMockFindFilesResults, clearMockFindFilesResults } from '../setup';
+
+function assertNotInGitRepo(dir: string): void {
+  let current = dir;
+  const root = path.parse(current).root;
+
+  while (current !== root) {
+    const gitDir = path.join(current, '.git');
+    if (fs.existsSync(gitDir)) {
+      throw new Error(`Test directory ${dir} is inside a Git repository at ${current}`);
+    }
+    current = path.dirname(current);
+  }
+}
 
 suite('CodeScene File Discovery Test Suite', function () {
-  const testDir = createTestDir('test-codescene-file-discovery');
+  let testDir: string;
 
   function createCodeHealthRulesFile(relativePath: string): string {
     const fullPath = path.join(testDir, relativePath);
@@ -20,24 +34,25 @@ suite('CodeScene File Discovery Test Suite', function () {
 
   function gitAdd(filePath: string) {
     const relativePath = path.relative(testDir, filePath);
-    execSync(`git add "${relativePath}"`, { cwd: testDir });
+    execSync(`git add "${relativePath}"`, { cwd: testDir, stdio: 'pipe' });
   }
 
   function gitCommit(message: string) {
-    execSync(`git commit -m "${message}"`, { cwd: testDir });
+    execSync(`git commit -m "${message}"`, { cwd: testDir, stdio: 'pipe' });
   }
 
   setup(function () {
     this.timeout(20000);
-    if (fs.existsSync(testDir)) {
-      fs.rmSync(testDir, { recursive: true, force: true });
+    const testBaseDir = path.join(os.homedir(), '.codescene-test-data');
+    if (!fs.existsSync(testBaseDir)) {
+      fs.mkdirSync(testBaseDir, { recursive: true });
     }
-    fs.mkdirSync(testDir, { recursive: true });
+    testDir = fs.mkdtempSync(path.join(testBaseDir, 'codescene-file-discovery-test-'));
 
-    execSync('git init', { cwd: testDir });
-    execSync('git config user.email "test@example.com"', { cwd: testDir });
-    execSync('git config user.name "Test User"', { cwd: testDir });
-    execSync('git config advice.defaultBranchName false', { cwd: testDir });
+    execSync('git init', { cwd: testDir, stdio: 'pipe' });
+    execSync('git config user.email "test@example.com"', { cwd: testDir, stdio: 'pipe' });
+    execSync('git config user.name "Test User"', { cwd: testDir, stdio: 'pipe' });
+    execSync('git config advice.defaultBranchName false', { cwd: testDir, stdio: 'pipe' });
   });
 
   teardown(function () {
@@ -145,5 +160,52 @@ suite('CodeScene File Discovery Test Suite', function () {
 
     assert.strictEqual(uris.length, 1);
     assert.strictEqual(path.normalize(uris[0].fsPath), path.normalize(insideRules));
+  });
+
+  suite('non-git workspace (uses findFiles fallback)', function () {
+    let nonGitTempDir: string;
+
+    setup(function () {
+      nonGitTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codescene-nongit-test-'));
+      assertNotInGitRepo(nonGitTempDir);
+    });
+
+    teardown(function () {
+      clearMockFindFilesResults();
+      if (fs.existsSync(nonGitTempDir)) {
+        fs.rmSync(nonGitTempDir, { recursive: true, force: true });
+      }
+    });
+
+    const nonGitTestCases = [
+      {
+        name: 'uses findFiles fallback in non-git workspace with files',
+        mockResultPaths: ['.codescene/code-health-rules.json', 'sub/.codescene/code-health-rules.json'],
+        expectedCount: 2,
+      },
+      {
+        name: 'uses findFiles fallback in non-git workspace with no files',
+        mockResultPaths: [],
+        expectedCount: 0,
+      },
+    ];
+
+    for (const tc of nonGitTestCases) {
+      test(tc.name, async function () {
+        this.timeout(10000);
+
+        const mockResults = tc.mockResultPaths.map((p) => ({ fsPath: path.join(nonGitTempDir, p) }));
+        setMockFindFilesResults(mockResults);
+
+        const uris = await discoverCodeHealthRulesFileUris(nonGitTempDir, undefined);
+
+        assert.strictEqual(uris.length, tc.expectedCount);
+        if (tc.expectedCount > 0) {
+          const fsPaths = uris.map((u) => u.fsPath).sort();
+          const expectedPaths = mockResults.map((r) => r.fsPath).sort();
+          assert.deepStrictEqual(fsPaths, expectedPaths);
+        }
+      });
+    }
   });
 });


### PR DESCRIPTION
Replaces `vscode.workspace.findFiles` with `git ls-files` queries to discover `code-health-rules.json` files.

This avoids triggering ripgrep scans across the entire workspace, improving performance in large or contrived repos.

On non-git repos, we fall back to the old implementation.