### PR TITLE
feat: remove stale files from Code Health Monitor after GitChangeLister runs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(npm:*)",
+      "Bash(npx:*)"
+    ]
+  }
+}

--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -2,7 +2,7 @@ import vscode, { Uri } from 'vscode';
 import { API, Repository } from '../../types/git';
 import Reviewer from '../review/reviewer';
 import { register as registerCodeLens } from './codelens';
-import { register as registerHomeView } from './home/home-view';
+import { register as registerHomeView, getHomeViewInstance } from './home/home-view';
 import { acquireGitApi, getMergeBaseCommit, getRepoRootPath, updateGitState } from '../git-utils';
 import { CsExtensionState } from '../cs-extension-state';
 import { InteractiveDocsParams } from '../documentation/commands';
@@ -17,6 +17,8 @@ import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
 import { isVSCodeWindowFocused } from '../extension-impl';
 import { DefaultBranchGate } from '../git/default-branch-gate';
+import { getOpenFilesObserverInstance } from '../review/open-files-observer';
+import { getCodeHealthMonitorViewInstance } from './tree-view';
 
 const GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS = 9;
 
@@ -28,6 +30,13 @@ const clearTreeEmitter = new vscode.EventEmitter<void>();
 export const onTreeDataCleared = clearTreeEmitter.event;
 
 let ALL_DISPOSABLES: vscode.Disposable[] = [];
+
+function removeStaleFilesFromMonitors(changedFiles: Set<string>): void {
+  const visibleFiles = getOpenFilesObserverInstance()?.getAllVisibleFileNames() ?? new Set<string>();
+
+  getCodeHealthMonitorViewInstance()?.removeStaleFiles(changedFiles, visibleFiles);
+  getHomeViewInstance()?.removeStaleFiles(changedFiles, visibleFiles);
+}
 
 export async function runScheduledGitChangeReview(): Promise<void> {
   if (!isVSCodeWindowFocused()) {
@@ -42,7 +51,8 @@ export async function runScheduledGitChangeReview(): Promise<void> {
   logOutputChannel.info('Starting scheduled git change review');
 
   const startTime = Date.now();
-  await gitChangeListerInstance!.start();
+  const changedFiles = await gitChangeListerInstance!.start();
+  removeStaleFilesFromMonitors(changedFiles);
   const elapsedMs = Date.now() - startTime;
   const elapsedSeconds = Math.ceil(elapsedMs / 1000);
 
@@ -181,7 +191,8 @@ export async function runGitChangeLister(): Promise<void> {
   if (!gitChangeListerInstance || !isGitAvailable()) {
     return;
   }
-  await gitChangeListerInstance.start();
+  const changedFiles = await gitChangeListerInstance.start();
+  removeStaleFilesFromMonitors(changedFiles);
 }
 
 export function deactivate() {

--- a/src/code-health-monitor/home/home-view.ts
+++ b/src/code-health-monitor/home/home-view.ts
@@ -1,4 +1,5 @@
 import vscode, { Disposable, ExtensionContext, WebviewViewProvider } from 'vscode';
+import * as path from 'path';
 import throttle from 'lodash.throttle';
 import Telemetry from '../../telemetry';
 import { commonResourceRoots } from '../../webview-utils';
@@ -267,6 +268,37 @@ export class HomeView implements WebviewViewProvider, Disposable {
 
   dispose() {
     this.disposables.forEach((d) => d.dispose());
+  }
+
+  private isPathInSet(filePath: string, pathSet: Set<string>): boolean {
+    const normalized = path.normalize(filePath);
+    for (const p of pathSet) {
+      if (path.normalize(p) === normalized) return true;
+    }
+    return false;
+  }
+
+  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
+    const stalePaths: string[] = [];
+
+    for (const filePath of this.fileIssueMap.keys()) {
+      const inChangedFiles = this.isPathInSet(filePath, changedFiles);
+      const inVisibleFiles = this.isPathInSet(filePath, visibleFiles);
+
+      if (!inChangedFiles && !inVisibleFiles) {
+        stalePaths.push(filePath);
+      }
+    }
+
+    for (const stalePath of stalePaths) {
+      this.removeTreeEntry(stalePath);
+    }
+
+    if (stalePaths.length > 0) {
+      this.updateBadgeIfSignedIn();
+      this.rebuildFileDeltaData();
+      this.update();
+    }
   }
 
   private async updateHomeRenderer() {

--- a/src/code-health-monitor/tree-view.ts
+++ b/src/code-health-monitor/tree-view.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import * as path from 'path';
 import { DevtoolsAPI, DeltaAnalysisEvent } from '../devtools-api';
 import { logOutputChannel } from '../log';
 import Telemetry from '../telemetry';
@@ -11,6 +12,12 @@ import { onFileDeletedFromGit } from '../git-utils';
 import { onTreeDataCleared } from './addon';
 import { DeltaAnalysisTreeProvider } from './delta-analysis-tree-provider';
 
+let codeHealthMonitorViewInstance: CodeHealthMonitorView | undefined;
+
+export function getCodeHealthMonitorViewInstance(): CodeHealthMonitorView | undefined {
+  return codeHealthMonitorViewInstance;
+}
+
 export class CodeHealthMonitorView implements vscode.Disposable {
   private disposables: vscode.Disposable[] = [];
   private treeDataProvider: DeltaAnalysisTreeProvider;
@@ -20,6 +27,7 @@ export class CodeHealthMonitorView implements vscode.Disposable {
     registerDeltaAnalysisDecorations(context);
 
     this.treeDataProvider = new DeltaAnalysisTreeProvider();
+    codeHealthMonitorViewInstance = this;
 
     this.view = vscode.window.createTreeView('codescene.codeHealthMonitorView', {
       treeDataProvider: this.treeDataProvider,
@@ -116,6 +124,35 @@ export class CodeHealthMonitorView implements vscode.Disposable {
 
   isVisible() {
     return this.view.visible;
+  }
+
+  getFileIssueMap(): Map<string, FileWithIssues> {
+    return this.treeDataProvider.fileIssueMap;
+  }
+
+  private isPathInSet(filePath: string, pathSet: Set<string>): boolean {
+    const normalized = path.normalize(filePath);
+    for (const p of pathSet) {
+      if (path.normalize(p) === normalized) return true;
+    }
+    return false;
+  }
+
+  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
+    const stalePaths: string[] = [];
+
+    for (const filePath of this.treeDataProvider.fileIssueMap.keys()) {
+      const inChangedFiles = this.isPathInSet(filePath, changedFiles);
+      const inVisibleFiles = this.isPathInSet(filePath, visibleFiles);
+
+      if (!inChangedFiles && !inVisibleFiles) {
+        stalePaths.push(filePath);
+      }
+    }
+
+    for (const stalePath of stalePaths) {
+      this.treeDataProvider.removeTreeEntry(stalePath);
+    }
   }
 
   dispose() {

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -37,7 +37,7 @@ export class GitChangeLister {
   // However, that doesn't matter, because GitChangeLister is always run within a DroppingScheduledExecutor,
   // so if it fails at the first run, a second one will succeed.
   // We used to have some code trying to avoid that unreliability, but it turned out to be complex and expensive.
-  async start(): Promise<void> {
+  async start(): Promise<Set<string>> {
     const workspaceFolder = getWorkspaceFolder();
     if (workspaceFolder) {
       const workspacePath = getWorkspacePath(workspaceFolder);
@@ -46,13 +46,15 @@ export class GitChangeLister {
 
       if (repo && await this.defaultBranchGate.shouldSkipBasedOnDefaultBranch(repo)) {
         logOutputChannel.debug('GitChangeLister: skipping processing, current branch matches default branch');
-        return;
+        return new Set<string>();
       }
 
       const baselineCommit = repo ? await getMergeBaseCommit(repo) : '';
       const allChangedFiles = await this.getAllChangedFiles(gitRootPath, workspacePath, baselineCommit);
       this.reviewFiles(allChangedFiles, baselineCommit);
+      return allChangedFiles;
     }
+    return new Set<string>();
   }
 
   async getAllChangedFiles(gitRootPath: string, workspacePath: string, baselineCommit: string): Promise<Set<string>> {

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -5,6 +5,12 @@ import { FilteringReviewer } from './filtering-reviewer';
 import { getMergeBaseCommitForWorkspace } from '../code-health-monitor/addon';
 import { logOutputChannel } from '../log';
 
+let openFilesObserverInstance: OpenFilesObserver | undefined;
+
+export function getOpenFilesObserverInstance(): OpenFilesObserver | undefined {
+  return openFilesObserverInstance;
+}
+
 /**
  * Observes open file events, and triggers reviews accordingly (only meant for Problems, not for the Code Health Monitor).
  */
@@ -24,6 +30,7 @@ export class OpenFilesObserver {
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.docSelector = reviewDocumentSelector();
+    openFilesObserverInstance = this;
   }
 
   private reviewDocument(document: vscode.TextDocument, baselineCommit: string, reason: string, skipMonitorUpdateForDelta?: boolean): boolean {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -218,6 +218,71 @@ const vscodeStub = {
     findFiles: async () => {
       return mockFindFilesResults;
     },
+    openTextDocument: async (pathOrUri: string | { fsPath: string }) => {
+      const filePath = typeof pathOrUri === 'string' ? pathOrUri : pathOrUri.fsPath;
+      const content = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+      const lines = content.split('\n');
+      return {
+        uri: {
+          scheme: 'file',
+          authority: '',
+          path: filePath,
+          query: '',
+          fragment: '',
+          fsPath: filePath,
+          with: () => ({}),
+          toString: () => filePath,
+          toJSON: () => ({ scheme: 'file', path: filePath }),
+        },
+        fileName: filePath,
+        isUntitled: false,
+        languageId: filePath.endsWith('.ts') ? 'typescript' : filePath.endsWith('.js') ? 'javascript' : 'plaintext',
+        version: 1,
+        isDirty: false,
+        isClosed: false,
+        eol: 1,
+        lineCount: lines.length,
+        getText: (range?: any) => {
+          if (!range) return content;
+          const startLine = range.start?.line ?? 0;
+          const endLine = range.end?.line ?? lines.length - 1;
+          return lines.slice(startLine, endLine + 1).join('\n');
+        },
+        lineAt: (lineOrPosition: number | { line: number }) => {
+          const lineNum = typeof lineOrPosition === 'number' ? lineOrPosition : lineOrPosition.line;
+          const text = lines[lineNum] || '';
+          return {
+            lineNumber: lineNum,
+            text,
+            range: { start: { line: lineNum, character: 0 }, end: { line: lineNum, character: text.length } },
+            rangeIncludingLineBreak: { start: { line: lineNum, character: 0 }, end: { line: lineNum + 1, character: 0 } },
+            firstNonWhitespaceCharacterIndex: text.search(/\S/),
+            isEmptyOrWhitespace: text.trim().length === 0,
+          };
+        },
+        offsetAt: (position: { line: number; character: number }) => {
+          let offset = 0;
+          for (let i = 0; i < position.line && i < lines.length; i++) {
+            offset += lines[i].length + 1;
+          }
+          return offset + position.character;
+        },
+        positionAt: (offset: number) => {
+          let remaining = offset;
+          for (let i = 0; i < lines.length; i++) {
+            if (remaining <= lines[i].length) {
+              return { line: i, character: remaining };
+            }
+            remaining -= lines[i].length + 1;
+          }
+          return { line: lines.length - 1, character: lines[lines.length - 1]?.length || 0 };
+        },
+        getWordRangeAtPosition: () => undefined,
+        validateRange: (range: any) => range,
+        validatePosition: (position: any) => position,
+        save: () => Promise.resolve(true),
+      };
+    },
     onDidChangeConfiguration: (listener: any) => {
       void listener;
       return { dispose: () => {} };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -188,13 +188,27 @@ const vscodeStub = {
       void provider;
       return { dispose: () => {} };
     },
+    registerFileDecorationProvider: (provider: any) => {
+      void provider;
+      return { dispose: () => {} };
+    },
     createTreeView: (id: string, opts: any) => {
       void id;
       void opts;
       return {
-      badge: undefined,
-      dispose: () => {},
-    };
+        visible: false,
+        selection: [],
+        badge: undefined,
+        message: undefined,
+        title: undefined,
+        description: undefined,
+        onDidChangeSelection: () => ({ dispose: () => {} }),
+        onDidChangeVisibility: () => ({ dispose: () => {} }),
+        onDidCollapseElement: () => ({ dispose: () => {} }),
+        onDidExpandElement: () => ({ dispose: () => {} }),
+        reveal: () => Promise.resolve(),
+        dispose: () => {},
+      };
     },
     createStatusBarItem: () => ({
       text: '',

--- a/src/test/stubs/event-emitter-stub.ts
+++ b/src/test/stubs/event-emitter-stub.ts
@@ -1,20 +1,31 @@
 export class EventEmitterStub<T = any> {
-  private listeners: Array<(e: T) => any> = [];
+  private listeners: Array<{ fn: (e: T) => any; thisArg?: any }> = [];
 
-  event = (listener: (e: T) => any) => {
-    this.listeners.push(listener);
-    return {
+  event = (listener: (e: T) => any, thisArg?: any, disposables?: any[]) => {
+    const entry = { fn: listener, thisArg };
+    this.listeners.push(entry);
+    const disposable = {
       dispose: () => {
-        const index = this.listeners.indexOf(listener);
+        const index = this.listeners.indexOf(entry);
         if (index > -1) {
           this.listeners.splice(index, 1);
         }
       }
     };
+    if (disposables) {
+      disposables.push(disposable);
+    }
+    return disposable;
   };
 
   fire(data: T) {
-    this.listeners.forEach(listener => listener(data));
+    this.listeners.forEach(({ fn, thisArg }) => {
+      if (thisArg) {
+        fn.call(thisArg, data);
+      } else {
+        fn(data);
+      }
+    });
   }
 
   dispose() {

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -225,6 +225,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     const originalStart = GitChangeLister.prototype.start;
     GitChangeLister.prototype.start = async function () {
       await new Promise((resolve) => setTimeout(resolve, 10));
+      return new Set<string>();
     };
 
     const originalDateNow = Date.now;
@@ -259,6 +260,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     const originalStart = GitChangeLister.prototype.start;
     GitChangeLister.prototype.start = async function () {
       await new Promise((resolve) => setTimeout(resolve, 10));
+      return new Set<string>();
     };
 
     const originalDateNow = Date.now;

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -82,10 +82,6 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('refreshMergeBaseBaselines updates review baselines for all repositories', async () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
-
-    // Wait for activation's initial setBaseline call to complete
-    await new Promise(resolve => setTimeout(resolve, 100));
 
     let setBaselineCalls = 0;
     const originalSetBaseline = Reviewer.instance.setBaseline.bind(Reviewer.instance);
@@ -93,6 +89,20 @@ suite('Code Health Monitor Addon Test Suite', () => {
       setBaselineCalls += 1;
       return originalSetBaseline(fileFilter, baselineCommit);
     };
+
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+
+    // Wait for activation's initial setBaseline call to complete
+    const maxWaitMs = 12000;
+    const startTime = Date.now();
+    while (setBaselineCalls < 1) {
+      if (Date.now() - startTime > maxWaitMs) {
+        assert.fail('Timed out waiting for activation setBaseline call');
+      }
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+
+    setBaselineCalls = 0;
 
     await refreshMergeBaseBaselines();
 

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -11,6 +11,10 @@ import { setGitApiForTesting } from '../../code-health-monitor/addon';
 import { MockGitAPI } from '../mocks/mock-git-api';
 import { CsExtensionState } from '../../cs-extension-state';
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import { ensureBinary } from '../integration_helper';
+import { DevtoolsAPI, DeltaAnalysisEvent } from '../../devtools-api';
+import Reviewer from '../../review/reviewer';
+import { DeltaAnalysisTreeProvider } from '../../code-health-monitor/delta-analysis-tree-provider';
 
 suite('GitChangeLister Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo');
@@ -228,6 +232,177 @@ suite('GitChangeLister Test Suite', () => {
         setGitApiForTesting(undefined);
         restoreDefaultWorkspaceFolders();
         clearMockGitRepositories();
+      });
+    });
+  });
+
+  suite('DeltaAnalysisTreeProvider integration', () => {
+    const integrationRepoPath = path.join(__dirname, '../../../test-git-repo-integration');
+    let treeProvider: DeltaAnalysisTreeProvider;
+    let deltaSubscription: { dispose: () => void };
+
+    suiteSetup(async function () {
+      this.timeout(60000);
+      const binaryPath = await ensureBinary();
+      const mockContext = createMockExtensionContext(integrationRepoPath);
+      if (!CsExtensionState.hasInstance) {
+        CsExtensionState.init(mockContext);
+      }
+      Reviewer.init(mockContext, () => new Map());
+      DevtoolsAPI.init(binaryPath, mockContext, async () => false);
+    });
+
+    setup(async function () {
+      this.timeout(20000);
+
+      if (deltaSubscription) {
+        deltaSubscription.dispose();
+      }
+
+      if (fs.existsSync(integrationRepoPath)) {
+        fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+      }
+      fs.mkdirSync(integrationRepoPath, { recursive: true });
+
+      const { execSync } = require('child_process');
+      execSync('git init', { cwd: integrationRepoPath });
+      execSync('git config user.email "test@example.com"', { cwd: integrationRepoPath });
+      execSync('git config user.name "Test User"', { cwd: integrationRepoPath });
+      execSync('git config advice.defaultBranchName false', { cwd: integrationRepoPath });
+
+      fs.writeFileSync(path.join(integrationRepoPath, 'README.md'), '# Test Repository');
+      execSync('git add README.md', { cwd: integrationRepoPath });
+      execSync('git commit -m "Initial commit"', { cwd: integrationRepoPath });
+
+      treeProvider = new DeltaAnalysisTreeProvider();
+      deltaSubscription = DevtoolsAPI.onDidDeltaAnalysisComplete((e: DeltaAnalysisEvent) => {
+        if (e.updateMonitor) {
+          treeProvider.syncTree(e);
+        }
+      });
+    });
+
+    teardown(async function () {
+      this.timeout(20000);
+      deltaSubscription?.dispose();
+      treeProvider.clearTree();
+      Reviewer.instance.clearCache();
+      setGitApiForTesting(undefined);
+      restoreDefaultWorkspaceFolders();
+      clearMockGitRepositories();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      if (fs.existsSync(integrationRepoPath)) {
+        fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+      }
+    });
+
+    const testCases = [
+      {
+        name: 'degradation via nested conditionals',
+        baseCode: `function process(a: number): number {\n  return a + 1;\n}\n`,
+        modifiedCode: `function process(a: number, b: number, c: number, d: number, e: number, f: number): number {
+  if (a > 0) {
+    if (b > 0) {
+      if (c > 0) {
+        if (d > 0) {
+          if (e > 0) {
+            return a + b + c + d + e + f;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}
+`,
+        expectScoreDirection: 'negative' as const,
+      },
+      {
+        name: 'degradation via deep nesting and complexity',
+        baseCode: `function simple(): number {\n  return 42;\n}\n`,
+        modifiedCode: `function complex(a: number, b: number, c: number): number {
+  if (a > 0) {
+    if (b > 0) {
+      if (c > 0) {
+        if (a + b > 10) {
+          if (b + c > 10) {
+            return a + b + c;
+          }
+        }
+      }
+    }
+  }
+  return 0;
+}
+`,
+        expectScoreDirection: 'negative' as const,
+      },
+      {
+        name: 'degradation via function arguments',
+        baseCode: `function calc(a: number): number {\n  return a * 2;\n}\n`,
+        modifiedCode: `function calc(a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number): number {
+  return a + b + c + d + e + f + g + h;
+}
+`,
+        expectScoreDirection: 'negative' as const,
+      },
+    ];
+
+    testCases.forEach(({ name, baseCode, modifiedCode, expectScoreDirection }) => {
+      test(`detects ${name}`, async function () {
+        this.timeout(60000);
+        const { execSync } = require('child_process');
+
+        const testFile = path.join(integrationRepoPath, 'code.ts');
+
+        if (baseCode !== null) {
+          fs.writeFileSync(testFile, baseCode);
+          execSync('git add code.ts', { cwd: integrationRepoPath });
+          execSync('git commit -m "Add baseline"', { cwd: integrationRepoPath });
+        }
+
+        const baselineCommit = execSync('git rev-parse HEAD', { cwd: integrationRepoPath, encoding: 'utf-8' }).trim();
+
+        fs.writeFileSync(testFile, modifiedCode);
+
+        const mockRepo = {
+          rootUri: Uri.file(integrationRepoPath),
+          state: {
+            HEAD: { name: 'master', commit: baselineCommit },
+            refs: [],
+            remotes: [],
+            submodules: [],
+            onDidChange: () => ({ dispose: () => {} }),
+          },
+        };
+
+        const mockGitApi = new MockGitAPI();
+        mockGitApi.repositories = [mockRepo];
+        setGitApiForTesting(mockGitApi as any);
+
+        mockWorkspaceFolders([createMockWorkspaceFolder(integrationRepoPath)]);
+        setMockGitRepositories([mockRepo]);
+
+        const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
+        const mockDefaultBranchGate = { shouldSkipBasedOnDefaultBranch: async () => false } as any;
+        const lister = new GitChangeLister(new MockExecutor(), mockSavedFilesTracker, mockDefaultBranchGate);
+
+        await lister.start();
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+
+        assert.ok(treeProvider.fileIssueMap.size > 0, `Expected fileIssueMap to have entries, but it was empty`);
+
+        const fileEntry = treeProvider.fileIssueMap.get(testFile);
+        assert.ok(fileEntry, `Expected fileIssueMap to contain entry for ${testFile}`);
+
+        if (expectScoreDirection === 'negative') {
+          assert.ok(fileEntry.scoreChange < 0, `Expected negative score change (degradation), got ${fileEntry.scoreChange}`);
+        } else if (expectScoreDirection === 'positive') {
+          assert.ok(fileEntry.scoreChange > 0, `Expected positive score change (improvement), got ${fileEntry.scoreChange}`);
+        } else {
+          assert.ok(Math.abs(fileEntry.scoreChange) < 0.5, `Expected near-zero score change, got ${fileEntry.scoreChange}`);
+        }
       });
     });
   });

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -15,6 +15,8 @@ import { ensureBinary } from '../integration_helper';
 import { DevtoolsAPI, DeltaAnalysisEvent } from '../../devtools-api';
 import Reviewer from '../../review/reviewer';
 import { DeltaAnalysisTreeProvider } from '../../code-health-monitor/delta-analysis-tree-provider';
+import { CodeHealthMonitorView } from '../../code-health-monitor/tree-view';
+import { FileWithIssues } from '../../code-health-monitor/file-with-issues';
 
 suite('GitChangeLister Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo');
@@ -403,6 +405,145 @@ suite('GitChangeLister Test Suite', () => {
         } else {
           assert.ok(Math.abs(fileEntry.scoreChange) < 0.5, `Expected near-zero score change, got ${fileEntry.scoreChange}`);
         }
+      });
+    });
+  });
+
+  suite('removeStaleFiles', () => {
+    let codeHealthMonitorView: CodeHealthMonitorView;
+    const mockDocument = (filePath: string) => ({
+      uri: Uri.file(filePath),
+      fileName: filePath,
+    } as any);
+
+    const mockDeltaResult = {
+      'old-score': 9.0,
+      'new-score': 8.0,
+      'score-change': -1.0,
+      'file-level-findings': [],
+      'function-level-findings': [],
+    };
+
+    suiteSetup(() => {
+      const mockContext = createMockExtensionContext(testRepoPath);
+      if (!CsExtensionState.hasInstance) {
+        CsExtensionState.init(mockContext);
+      }
+    });
+
+    setup(() => {
+      const mockContext = createMockExtensionContext(testRepoPath);
+      codeHealthMonitorView = new CodeHealthMonitorView(mockContext);
+    });
+
+    teardown(() => {
+      codeHealthMonitorView.getFileIssueMap().clear();
+      codeHealthMonitorView.dispose();
+    });
+
+    function addFileToMap(filePath: string) {
+      const doc = mockDocument(filePath);
+      const fileWithIssues = new FileWithIssues(mockDeltaResult, doc);
+      codeHealthMonitorView.getFileIssueMap().set(filePath, fileWithIssues);
+    }
+
+    const testCases = [
+      {
+        name: 'empty fileIssueMap, empty changedFiles, empty visibleFiles - no changes',
+        initialFiles: [] as string[],
+        changedFiles: [] as string[],
+        visibleFiles: [] as string[],
+        expectedFiles: [] as string[],
+      },
+      {
+        name: 'empty fileIssueMap, has changedFiles, empty visibleFiles - no changes',
+        initialFiles: [],
+        changedFiles: ['/workspace/file1.ts'],
+        visibleFiles: [],
+        expectedFiles: [],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has A,B - keeps A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        visibleFiles: [],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has only A - removes B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileA.ts'],
+        visibleFiles: [],
+        expectedFiles: ['/workspace/fileA.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles empty, visibleFiles has A - removes B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: [],
+        visibleFiles: ['/workspace/fileA.ts'],
+        expectedFiles: ['/workspace/fileA.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has B, visibleFiles has A - keeps A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileB.ts'],
+        visibleFiles: ['/workspace/fileA.ts'],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles empty, visibleFiles empty - removes A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: [],
+        visibleFiles: [],
+        expectedFiles: [],
+      },
+      {
+        name: 'has files A,B,C in map, changedFiles has A, visibleFiles has B - removes C',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts', '/workspace/fileC.ts'],
+        changedFiles: ['/workspace/fileA.ts'],
+        visibleFiles: ['/workspace/fileB.ts'],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+    ];
+
+    testCases.forEach(({ name, initialFiles, changedFiles, visibleFiles, expectedFiles }) => {
+      test(name, () => {
+        initialFiles.forEach(addFileToMap);
+
+        codeHealthMonitorView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles));
+
+        const fileIssueMap = codeHealthMonitorView.getFileIssueMap();
+        assert.strictEqual(fileIssueMap.size, expectedFiles.length);
+        expectedFiles.forEach(file => assert.ok(fileIssueMap.has(file), `Expected ${file} to be in map`));
+      });
+    });
+
+    const pathNormalizationCases = [
+      {
+        name: 'matches paths with same separators',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/file.ts',
+      },
+      {
+        name: 'matches paths with redundant slashes',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace//src/file.ts',
+      },
+      {
+        name: 'matches paths with dot segments',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/./file.ts',
+      },
+    ];
+
+    pathNormalizationCases.forEach(({ name, mapPath, changedPath }) => {
+      test(`path normalization: ${name}`, () => {
+        addFileToMap(mapPath);
+
+        codeHealthMonitorView.removeStaleFiles(new Set([changedPath]), new Set());
+
+        const fileIssueMap = codeHealthMonitorView.getFileIssueMap();
+        assert.strictEqual(fileIssueMap.size, 1, `Expected file to be kept when matching via ${changedPath}`);
       });
     });
   });

--- a/src/test/suite/git-change-observer.test.ts
+++ b/src/test/suite/git-change-observer.test.ts
@@ -16,6 +16,7 @@ import { CsReview } from '../../review/cs-review';
 import { DevtoolsAPI } from '../../devtools-api';
 import { TestTextDocument } from '../mocks/test-text-document';
 import { DefaultBranchGate } from '../../git/default-branch-gate';
+import { resetGitAvailability } from '../../git/git-detection';
 
 suite('GitChangeObserver Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo-observer');
@@ -76,6 +77,7 @@ suite('GitChangeObserver Test Suite', () => {
 
   setup(async function () {
     this.timeout(20000);
+    resetGitAvailability();
 
     if (fs.existsSync(testRepoPath)) {
       fs.rmSync(testRepoPath, { recursive: true, force: true });

--- a/src/test/suite/home-view.test.ts
+++ b/src/test/suite/home-view.test.ts
@@ -1,0 +1,197 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { Uri } from '../mocks/vscode';
+import { HomeView } from '../../code-health-monitor/home/home-view';
+import { BackgroundServiceView } from '../../code-health-monitor/background-view';
+import { CsExtensionState } from '../../cs-extension-state';
+import { createMockExtensionContext } from '../mocks/mock-extension-context';
+import { FileWithIssues } from '../../code-health-monitor/file-with-issues';
+
+suite('HomeView', () => {
+  suite('removeStaleFiles', () => {
+    let homeView: HomeView;
+    let mockBackgroundServiceView: BackgroundServiceView;
+    let mockContext: ReturnType<typeof createMockExtensionContext>;
+
+    const mockDocument = (filePath: string) => ({
+      uri: Uri.file(filePath),
+      fileName: filePath,
+    } as any);
+
+    const mockDeltaResult = {
+      'old-score': 9.0,
+      'new-score': 8.0,
+      'score-change': -1.0,
+      'file-level-findings': [],
+      'function-level-findings': [],
+    };
+
+    suiteSetup(() => {
+      const testRepoPath = path.join(__dirname, '../../../test-home-view-repo');
+      mockContext = createMockExtensionContext(testRepoPath);
+      if (!CsExtensionState.hasInstance) {
+        CsExtensionState.init(mockContext);
+      }
+    });
+
+    setup(() => {
+      mockBackgroundServiceView = {
+        updateBadge: () => {},
+        dispose: () => {},
+      } as any;
+      homeView = new HomeView(mockContext, mockBackgroundServiceView);
+    });
+
+    teardown(() => {
+      homeView.getFileIssueMap().clear();
+    });
+
+    function addFileToHomeView(filePath: string) {
+      const doc = mockDocument(filePath);
+      const fileWithIssues = new FileWithIssues(mockDeltaResult, doc);
+      homeView.getFileIssueMap().set(filePath, fileWithIssues);
+    }
+
+    const testCases = [
+      {
+        name: 'empty fileIssueMap, empty changedFiles, empty visibleFiles - no changes',
+        initialFiles: [] as string[],
+        changedFiles: [] as string[],
+        visibleFiles: [] as string[],
+        expectedFiles: [] as string[],
+      },
+      {
+        name: 'empty fileIssueMap, has changedFiles, empty visibleFiles - no changes',
+        initialFiles: [],
+        changedFiles: ['/workspace/file1.ts'],
+        visibleFiles: [],
+        expectedFiles: [],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has A,B - keeps A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        visibleFiles: [],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has only A - removes B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileA.ts'],
+        visibleFiles: [],
+        expectedFiles: ['/workspace/fileA.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles empty, visibleFiles has A - removes B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: [],
+        visibleFiles: ['/workspace/fileA.ts'],
+        expectedFiles: ['/workspace/fileA.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles has B, visibleFiles has A - keeps A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: ['/workspace/fileB.ts'],
+        visibleFiles: ['/workspace/fileA.ts'],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+      {
+        name: 'has files A,B in map, changedFiles empty, visibleFiles empty - removes A,B',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+        changedFiles: [],
+        visibleFiles: [],
+        expectedFiles: [],
+      },
+      {
+        name: 'has files A,B,C in map, changedFiles has A, visibleFiles has B - removes C',
+        initialFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts', '/workspace/fileC.ts'],
+        changedFiles: ['/workspace/fileA.ts'],
+        visibleFiles: ['/workspace/fileB.ts'],
+        expectedFiles: ['/workspace/fileA.ts', '/workspace/fileB.ts'],
+      },
+    ];
+
+    testCases.forEach(({ name, initialFiles, changedFiles, visibleFiles, expectedFiles }) => {
+      test(name, () => {
+        initialFiles.forEach(addFileToHomeView);
+
+        homeView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles));
+
+        const fileIssueMap = homeView.getFileIssueMap();
+        assert.strictEqual(fileIssueMap.size, expectedFiles.length);
+        expectedFiles.forEach(file => assert.ok(fileIssueMap.has(file), `Expected ${file} to be in map`));
+      });
+    });
+
+    const pathNormalizationCases = [
+      {
+        name: 'matches paths with same separators',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/file.ts',
+      },
+      {
+        name: 'matches paths with redundant slashes',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace//src/file.ts',
+      },
+      {
+        name: 'matches paths with dot segments',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/./file.ts',
+      },
+    ];
+
+    pathNormalizationCases.forEach(({ name, mapPath, changedPath }) => {
+      test(`path normalization: ${name}`, () => {
+        addFileToHomeView(mapPath);
+
+        homeView.removeStaleFiles(new Set([changedPath]), new Set());
+
+        const fileIssueMap = homeView.getFileIssueMap();
+        assert.strictEqual(fileIssueMap.size, 1, `Expected file to be kept when matching via ${changedPath}`);
+      });
+    });
+
+    test('calls updateBadge when files are removed', () => {
+      let badgeUpdateCalled = false;
+      mockBackgroundServiceView.updateBadge = () => {
+        badgeUpdateCalled = true;
+      };
+
+      addFileToHomeView('/workspace/fileA.ts');
+      addFileToHomeView('/workspace/fileB.ts');
+
+      homeView.removeStaleFiles(new Set(), new Set());
+
+      assert.ok(badgeUpdateCalled, 'Expected updateBadge to be called when files are removed');
+    });
+
+    test('does not call updateBadge when no files are removed', () => {
+      let badgeUpdateCalled = false;
+      mockBackgroundServiceView.updateBadge = () => {
+        badgeUpdateCalled = true;
+      };
+
+      addFileToHomeView('/workspace/fileA.ts');
+
+      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set());
+
+      assert.ok(!badgeUpdateCalled, 'Expected updateBadge not to be called when no files are removed');
+    });
+
+    test('updates badge with correct count when files removed', () => {
+      let badgeCount: number | undefined;
+      mockBackgroundServiceView.updateBadge = (count: number) => {
+        badgeCount = count;
+      };
+
+      addFileToHomeView('/workspace/fileA.ts');
+      addFileToHomeView('/workspace/fileB.ts');
+      addFileToHomeView('/workspace/fileC.ts');
+
+      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set());
+
+      assert.strictEqual(badgeCount, 1, 'Expected badge count to be 1 after removing 2 files');
+    });
+  });
+});


### PR DESCRIPTION
It is possible that files in `fileIssueMap` (i.e. the Code Health Monitor) could have stale files that should have been removed from it because of filesystem changes.

We can fail to pick them up those changes arbitrary reasons.

So to alleviate that, we can opportunistically use the periodic GitChangeLister runs to see if any item should have been removed, as of run, using info from GitChangeLister among other sources.

Specifically, after each `GitChangeLister.start()` call, files are removed from the monitor if they are not in the changed files set AND not currently visible in the editor.

Uses `path.normalize()` for consistent comparison.