### PR TITLE
Extract `StaleFileRemover`

### DIFF
--- a/src/code-health-monitor/home/home-view.ts
+++ b/src/code-health-monitor/home/home-view.ts
@@ -1,5 +1,4 @@
 import vscode, { Disposable, ExtensionContext, WebviewViewProvider } from 'vscode';
-import * as path from 'path';
 import throttle from 'lodash.throttle';
 import Telemetry from '../../telemetry';
 import { commonResourceRoots } from '../../webview-utils';
@@ -20,6 +19,7 @@ import { getAutoRefactorConfig } from '../../codescene-tab/webview/ace/acknowled
 import { onDidChangeConfiguration, getServerUrl } from '../../configuration';
 import { onFileDeletedFromGit } from '../../git-utils';
 import { logOutputChannel } from '../../log';
+import { StaleFileRemover } from '../stale-file-remover';
 
 type CancelableVoid = (() => void) & { cancel(): void; flush(): void };
 
@@ -271,25 +271,9 @@ export class HomeView implements WebviewViewProvider, Disposable {
     this.disposables.forEach((d) => d.dispose());
   }
 
-  private isPathInSet(filePath: string, pathSet: Set<string>): boolean {
-    const normalized = path.normalize(filePath);
-    for (const p of pathSet) {
-      if (path.normalize(p) === normalized) return true;
-    }
-    return false;
-  }
-
   removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
-    const stalePaths: string[] = [];
-
-    for (const filePath of this.fileIssueMap.keys()) {
-      const inChangedFiles = this.isPathInSet(filePath, changedFiles);
-      const inVisibleFiles = this.isPathInSet(filePath, visibleFiles);
-
-      if (!inChangedFiles && !inVisibleFiles) {
-        stalePaths.push(filePath);
-      }
-    }
+    const staleFileRemover = new StaleFileRemover();
+    const stalePaths = staleFileRemover.findStaleFiles(this.fileIssueMap, changedFiles, visibleFiles);
 
     for (const stalePath of stalePaths) {
       logOutputChannel.debug(`Removing stale file from Home View: ${stalePath}`);

--- a/src/code-health-monitor/home/home-view.ts
+++ b/src/code-health-monitor/home/home-view.ts
@@ -19,6 +19,7 @@ import { ignoreSessionStateFeatureFlag, initBaseContent } from '../../centralize
 import { getAutoRefactorConfig } from '../../codescene-tab/webview/ace/acknowledgement/ace-acknowledgement-mapper';
 import { onDidChangeConfiguration, getServerUrl } from '../../configuration';
 import { onFileDeletedFromGit } from '../../git-utils';
+import { logOutputChannel } from '../../log';
 
 type CancelableVoid = (() => void) & { cancel(): void; flush(): void };
 
@@ -291,6 +292,7 @@ export class HomeView implements WebviewViewProvider, Disposable {
     }
 
     for (const stalePath of stalePaths) {
+      logOutputChannel.debug(`Removing stale file from Home View: ${stalePath}`);
       this.removeTreeEntry(stalePath);
     }
 

--- a/src/code-health-monitor/stale-file-remover.ts
+++ b/src/code-health-monitor/stale-file-remover.ts
@@ -1,0 +1,25 @@
+import * as path from 'path';
+
+export class StaleFileRemover {
+  private isPathInSet(filePath: string, pathSet: Set<string>): boolean {
+    const normalized = path.normalize(filePath);
+    for (const p of pathSet) {
+      if (path.normalize(p) === normalized) return true;
+    }
+    return false;
+  }
+
+  findStaleFiles(
+    fileIssueMap: Map<string, unknown>,
+    changedFiles: Set<string>,
+    visibleFiles: Set<string>
+  ): string[] {
+    const stalePaths: string[] = [];
+    for (const filePath of fileIssueMap.keys()) {
+      if (!this.isPathInSet(filePath, changedFiles) && !this.isPathInSet(filePath, visibleFiles)) {
+        stalePaths.push(filePath);
+      }
+    }
+    return stalePaths;
+  }
+}

--- a/src/code-health-monitor/tree-view.ts
+++ b/src/code-health-monitor/tree-view.ts
@@ -151,6 +151,7 @@ export class CodeHealthMonitorView implements vscode.Disposable {
     }
 
     for (const stalePath of stalePaths) {
+      logOutputChannel.debug(`Removing stale file from Code Health Monitor: ${stalePath}`);
       this.treeDataProvider.removeTreeEntry(stalePath);
     }
   }

--- a/src/code-health-monitor/tree-view.ts
+++ b/src/code-health-monitor/tree-view.ts
@@ -1,5 +1,4 @@
 import vscode from 'vscode';
-import * as path from 'path';
 import { DevtoolsAPI, DeltaAnalysisEvent } from '../devtools-api';
 import { logOutputChannel } from '../log';
 import Telemetry from '../telemetry';
@@ -11,6 +10,7 @@ import { FileWithIssues } from './file-with-issues';
 import { onFileDeletedFromGit } from '../git-utils';
 import { onTreeDataCleared } from './addon';
 import { DeltaAnalysisTreeProvider } from './delta-analysis-tree-provider';
+import { StaleFileRemover } from './stale-file-remover';
 
 let codeHealthMonitorViewInstance: CodeHealthMonitorView | undefined;
 
@@ -130,25 +130,9 @@ export class CodeHealthMonitorView implements vscode.Disposable {
     return this.treeDataProvider.fileIssueMap;
   }
 
-  private isPathInSet(filePath: string, pathSet: Set<string>): boolean {
-    const normalized = path.normalize(filePath);
-    for (const p of pathSet) {
-      if (path.normalize(p) === normalized) return true;
-    }
-    return false;
-  }
-
   removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
-    const stalePaths: string[] = [];
-
-    for (const filePath of this.treeDataProvider.fileIssueMap.keys()) {
-      const inChangedFiles = this.isPathInSet(filePath, changedFiles);
-      const inVisibleFiles = this.isPathInSet(filePath, visibleFiles);
-
-      if (!inChangedFiles && !inVisibleFiles) {
-        stalePaths.push(filePath);
-      }
-    }
+    const staleFileRemover = new StaleFileRemover();
+    const stalePaths = staleFileRemover.findStaleFiles(this.treeDataProvider.fileIssueMap, changedFiles, visibleFiles);
 
     for (const stalePath of stalePaths) {
       logOutputChannel.debug(`Removing stale file from Code Health Monitor: ${stalePath}`);

--- a/src/test/suite/stale-file-remover.test.ts
+++ b/src/test/suite/stale-file-remover.test.ts
@@ -1,0 +1,126 @@
+import * as assert from 'assert';
+import { StaleFileRemover } from '../../code-health-monitor/stale-file-remover';
+
+suite('StaleFileRemover', () => {
+  let remover: StaleFileRemover;
+
+  setup(() => {
+    remover = new StaleFileRemover();
+  });
+
+  suite('findStaleFiles', () => {
+    const testCases = [
+      {
+        name: 'empty map returns empty',
+        mapKeys: [] as string[],
+        changed: [] as string[],
+        visible: [] as string[],
+        expected: [] as string[],
+      },
+      {
+        name: 'file in changed set is not stale',
+        mapKeys: ['/workspace/a.ts'],
+        changed: ['/workspace/a.ts'],
+        visible: [],
+        expected: [],
+      },
+      {
+        name: 'file in visible set is not stale',
+        mapKeys: ['/workspace/a.ts'],
+        changed: [],
+        visible: ['/workspace/a.ts'],
+        expected: [],
+      },
+      {
+        name: 'file in neither set is stale',
+        mapKeys: ['/workspace/a.ts'],
+        changed: [],
+        visible: [],
+        expected: ['/workspace/a.ts'],
+      },
+      {
+        name: 'file in both sets is not stale',
+        mapKeys: ['/workspace/a.ts'],
+        changed: ['/workspace/a.ts'],
+        visible: ['/workspace/a.ts'],
+        expected: [],
+      },
+      {
+        name: 'multiple files - mixed stale and non-stale',
+        mapKeys: ['/workspace/a.ts', '/workspace/b.ts', '/workspace/c.ts'],
+        changed: ['/workspace/a.ts'],
+        visible: ['/workspace/b.ts'],
+        expected: ['/workspace/c.ts'],
+      },
+      {
+        name: 'all files stale when both sets empty',
+        mapKeys: ['/workspace/a.ts', '/workspace/b.ts'],
+        changed: [],
+        visible: [],
+        expected: ['/workspace/a.ts', '/workspace/b.ts'],
+      },
+      {
+        name: 'no files stale when all in changed set',
+        mapKeys: ['/workspace/a.ts', '/workspace/b.ts'],
+        changed: ['/workspace/a.ts', '/workspace/b.ts'],
+        visible: [],
+        expected: [],
+      },
+    ];
+
+    testCases.forEach(({ name, mapKeys, changed, visible, expected }) => {
+      test(name, () => {
+        const fileIssueMap = new Map<string, unknown>();
+        mapKeys.forEach((key) => fileIssueMap.set(key, {}));
+
+        const result = remover.findStaleFiles(fileIssueMap, new Set(changed), new Set(visible));
+
+        assert.deepStrictEqual(result.sort(), expected.sort());
+      });
+    });
+  });
+
+  suite('path normalization', () => {
+    const normalizationCases = [
+      {
+        name: 'matches paths with same separators',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/file.ts',
+        shouldBeStale: false,
+      },
+      {
+        name: 'matches paths with redundant slashes',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace//src/file.ts',
+        shouldBeStale: false,
+      },
+      {
+        name: 'matches paths with dot segments',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/./file.ts',
+        shouldBeStale: false,
+      },
+      {
+        name: 'matches paths with parent traversal',
+        mapPath: '/workspace/src/file.ts',
+        changedPath: '/workspace/src/sub/../file.ts',
+        shouldBeStale: false,
+      },
+    ];
+
+    normalizationCases.forEach(({ name, mapPath, changedPath, shouldBeStale }) => {
+      test(name, () => {
+        const fileIssueMap = new Map<string, unknown>();
+        fileIssueMap.set(mapPath, {});
+
+        const result = remover.findStaleFiles(fileIssueMap, new Set([changedPath]), new Set());
+
+        if (shouldBeStale) {
+          assert.strictEqual(result.length, 1, `Expected ${mapPath} to be stale`);
+        } else {
+          assert.strictEqual(result.length, 0, `Expected ${mapPath} to NOT be stale when matched via ${changedPath}`);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
* chore: add debug logging when stale files are removed from the monitors
* refactor: extract `StaleFileRemover` class to deduplicate stale-file detection
  * Both `CodeHealthMonitorView` and `HomeView` had identical `isPathInSet` helpers and nearly identical `removeStaleFiles` logic.
  * The shared `StaleFileRemover` class now owns the path-normalized comparison and stale-file identification, while each view retains its own removal side effects.