### PR TITLE
 fix: prevent excessive `git merge-base` calls in `OpenFilesObserver`

### DIFF
--- a/.claude/TESTING.md
+++ b/.claude/TESTING.md
@@ -9,6 +9,21 @@ Always prefer existing mocks from `src/test/mocks/` and `src/test/setup.ts` over
 For unit tests, import from `src/test/mocks/vscode.ts` to get lightweight mocks of Position, Range, Selection, Uri, and command tracking via `executedCommands`/`resetExecutedCommands()`.
 For integration tests, use `createTestDir()` and `ensureBinary()` from `integration_helper.ts`.
 
+### VS Code API mocking
+
+Production code imports the real `vscode` module. Tests run in an environment where this is replaced with `vscodeStub` from `src/test/setup.ts`.
+
+To mock new VS Code APIs:
+1. Add the stub to `vscodeStub` in `src/test/setup.ts`
+2. Add corresponding helpers (setters/resetters) in `src/test/setup.ts` for test manipulation
+3. If tests need lightweight mocks, add them to `src/test/mocks/vscode.ts`
+4. For `instanceof` checks, ensure stub classes are defined in `setup.ts` so production code instanceof checks work
+
+Example: mocking `vscode.window.visibleTextEditors`:
+- Add `visibleTextEditors: []` to `vscodeStub.window` in setup.ts
+- Export `setMockVisibleTextEditors()` and `resetMockWindow()` helpers in setup.ts
+- Tests import helpers from `../setup` and call them in setup/teardown hooks
+
 ## Dealing with failing tests
 
 Generally, tests that you write and then fail should be fixed. Do not delete them or fundamentally change their approach.

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -23,6 +23,7 @@ export class OpenFilesObserver {
   // Tracks files that were opened as visible in the UI.
   // The reason for tracking them is that onDidOpenTextDocument does not reflect files open in the UI and can be called at arbitrary times.
   private visibleDocuments = new Set<string>();
+  private documentVersions = new Map<string, number>();
 
   // For code to be called just once.
   private hasInitialized = false;
@@ -80,6 +81,21 @@ export class OpenFilesObserver {
     const uri = vscode.Uri.file(fileName);
     CsDiagnostics.set(uri, []);
     this.visibleDocuments.delete(fileName);
+    this.documentVersions.delete(fileName);
+  }
+
+  shouldSkipDocumentChange(e: vscode.TextDocumentChangeEvent): boolean {
+    if (e.contentChanges.length === 0) {
+      return true;
+    }
+    const filePath = e.document.fileName;
+    const newVersion = e.document.version;
+    const oldVersion = this.documentVersions.get(filePath);
+    if (oldVersion !== undefined && oldVersion === newVersion) {
+      return true;
+    }
+    this.documentVersions.set(filePath, newVersion);
+    return false;
   }
 
   private pollForVisibleEditors(): void {
@@ -150,6 +166,9 @@ export class OpenFilesObserver {
       vscode.workspace.onDidChangeTextDocument((e: vscode.TextDocumentChangeEvent) => {
         const filePath = e.document.fileName;
         if (!this.visibleDocuments.has(filePath)) {
+          return;
+        }
+        if (this.shouldSkipDocumentChange(e)) {
           return;
         }
         clearTimeout(this.reviewTimers.get(filePath));

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -55,8 +55,10 @@ export class OpenFilesObserver {
     const fileNames = new Set<string>();
     vscode.window.tabGroups.all.forEach((tabGroup) => {
       tabGroup.tabs.forEach((tab) => {
-        if (tab.input instanceof vscode.TabInputText) {
-          fileNames.add(tab.input.uri.fsPath);
+        // Only include file:// scheme URIs (excludes output channels, logs, etc.)
+        const isTextInput = tab.input instanceof vscode.TabInputText || (tab.input && typeof tab.input === 'object' && 'uri' in tab.input);
+        if (isTextInput && (tab.input as any).uri?.scheme === 'file') {
+          fileNames.add((tab.input as any).uri.fsPath);
         }
       });
     });
@@ -67,7 +69,10 @@ export class OpenFilesObserver {
     const fileNames = new Set<string>();
 
     vscode.window.visibleTextEditors.forEach(editor => {
-      fileNames.add(editor.document.fileName);
+      // Only include file:// scheme URIs (excludes output channels, logs, etc.)
+      if (editor.document.uri.scheme === 'file') {
+        fileNames.add(editor.document.fileName);
+      }
     });
 
     this.getVisibleTabFileNames().forEach((fileName) => {

--- a/src/review/open-files-observer.ts
+++ b/src/review/open-files-observer.ts
@@ -168,6 +168,11 @@ export class OpenFilesObserver {
         if (!this.visibleDocuments.has(filePath)) {
           return;
         }
+        // Verify file has an actual UI tab (not internal buffers like log outputs)
+        const allVisibleTabs = this.getAllVisibleFileNames();
+        if (!allVisibleTabs.has(filePath)) {
+          return;
+        }
         if (this.shouldSkipDocumentChange(e)) {
           return;
         }

--- a/src/test/mocks/mock-text-document-change-event.ts
+++ b/src/test/mocks/mock-text-document-change-event.ts
@@ -1,0 +1,16 @@
+import * as vscode from 'vscode';
+
+export class MockTextDocumentChangeEvent implements vscode.TextDocumentChangeEvent {
+  readonly document: vscode.TextDocument;
+  readonly contentChanges: readonly vscode.TextDocumentContentChangeEvent[];
+  readonly reason: vscode.TextDocumentChangeReason | undefined;
+
+  constructor(
+    document: vscode.TextDocument,
+    contentChanges: readonly vscode.TextDocumentContentChangeEvent[] = []
+  ) {
+    this.document = document;
+    this.contentChanges = contentChanges;
+    this.reason = undefined;
+  }
+}

--- a/src/test/mocks/test-text-document.ts
+++ b/src/test/mocks/test-text-document.ts
@@ -5,19 +5,21 @@ export class TestTextDocument implements vscode.TextDocument {
   private _fileName: string;
   private _content: string;
   private _languageId: string;
+  private _version: number;
 
-  constructor(filePath: string, content: string, languageId: string) {
+  constructor(filePath: string, content: string, languageId: string, version: number = 1) {
     this._fileName = filePath;
     this._content = content;
     this._languageId = languageId;
     this._uri = vscode.Uri.file(filePath);
+    this._version = version;
   }
 
   get uri() { return this._uri; }
   get fileName() { return this._fileName; }
   get isUntitled() { return false; }
   get languageId() { return this._languageId; }
-  get version() { return 1; }
+  get version() { return this._version; }
   get isDirty() { return false; }
   get isClosed() { return false; }
   get eol() { return vscode.EndOfLine.LF; }

--- a/src/test/mocks/vscode.ts
+++ b/src/test/mocks/vscode.ts
@@ -111,6 +111,10 @@ export namespace workspace {
   }
 }
 
+export class TabInputText {
+  constructor(public uri: Uri) {}
+}
+
 export { Position, Range, Selection, WorkspaceEdit, CodeAction, MockEditor };
 
 export namespace CodeActionKind {
@@ -156,11 +160,32 @@ export namespace commands {
 
 export namespace window {
   let _activeTextEditor: MockEditor | undefined;
+  let _visibleTextEditors: MockEditor[] = [];
+  let _tabGroups: any = { all: [] };
 
   export let activeTextEditor: MockEditor | undefined;
+  export let visibleTextEditors: MockEditor[] = [];
+  export let tabGroups: any = { all: [] };
 
   export function setActiveEditor(editor: MockEditor | undefined) {
     _activeTextEditor = editor;
     activeTextEditor = editor;
+  }
+
+  export function setVisibleTextEditors(editors: MockEditor[]) {
+    _visibleTextEditors = editors;
+    visibleTextEditors = editors;
+  }
+
+  export function setTabGroups(groups: any) {
+    _tabGroups = groups;
+    tabGroups = groups;
+  }
+
+  export function resetWindow() {
+    _visibleTextEditors = [];
+    visibleTextEditors = [];
+    _tabGroups = { all: [] };
+    tabGroups = { all: [] };
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -41,6 +41,19 @@ export function restoreDefaultWorkspaceFolders() {
   vscodeStub.workspace.workspaceFolders = defaultWorkspaceFolders as any;
 }
 
+export function setMockVisibleTextEditors(editors: any[]) {
+  vscodeStub.window.visibleTextEditors = editors;
+}
+
+export function setMockTabGroups(tabGroups: any[]) {
+  vscodeStub.window.tabGroups = { all: tabGroups };
+}
+
+export function resetMockWindow() {
+  vscodeStub.window.visibleTextEditors = [];
+  vscodeStub.window.tabGroups = { all: [] };
+}
+
 let mockGitRepositories: any[] = [];
 let mockFindFilesResults: any[] = [];
 
@@ -142,7 +155,12 @@ function createMockGitApi() {
   };
 }
 
+class TabInputTextStub {
+  constructor(public uri: any) {}
+}
+
 const vscodeStub = {
+  TabInputText: TabInputTextStub,
   extensions: {
     getExtension: (id: string) => {
       if (id === 'vscode.git') {
@@ -159,6 +177,8 @@ const vscodeStub = {
     },
   },
   window: {
+    visibleTextEditors: [] as any[],
+    tabGroups: { all: [] as any[] },
     state: {
       focused: true,
     },

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -254,6 +254,17 @@ suite('GitChangeLister Test Suite', () => {
       DevtoolsAPI.init(binaryPath, mockContext, async () => false);
     });
 
+    suiteTeardown(async function () {
+      this.timeout(20000);
+      try {
+        if (fs.existsSync(integrationRepoPath)) {
+          fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+        }
+      } catch (error) {
+        console.error('Failed to clean up test-git-repo-integration:', error);
+      }
+    });
+
     setup(async function () {
       this.timeout(20000);
 
@@ -286,15 +297,26 @@ suite('GitChangeLister Test Suite', () => {
 
     teardown(async function () {
       this.timeout(20000);
-      deltaSubscription?.dispose();
-      treeProvider.clearTree();
-      Reviewer.instance.clearCache();
-      setGitApiForTesting(undefined);
-      restoreDefaultWorkspaceFolders();
-      clearMockGitRepositories();
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      if (fs.existsSync(integrationRepoPath)) {
-        fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+      try {
+        deltaSubscription?.dispose();
+        treeProvider.clearTree();
+        Reviewer.instance.clearCache();
+        setGitApiForTesting(undefined);
+        restoreDefaultWorkspaceFolders();
+        clearMockGitRepositories();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        if (fs.existsSync(integrationRepoPath)) {
+          fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+        }
+      } catch (error) {
+        console.error('Error during test teardown:', error);
+        if (fs.existsSync(integrationRepoPath)) {
+          try {
+            fs.rmSync(integrationRepoPath, { recursive: true, force: true });
+          } catch (cleanupError) {
+            console.error('Failed to clean up test-git-repo-integration in error handler:', cleanupError);
+          }
+        }
       }
     });
 

--- a/src/test/suite/open-files-observer.test.ts
+++ b/src/test/suite/open-files-observer.test.ts
@@ -1,0 +1,69 @@
+import * as assert from 'assert';
+import { OpenFilesObserver } from '../../review/open-files-observer';
+import { TestTextDocument } from '../mocks/test-text-document';
+import { MockTextDocumentChangeEvent } from '../mocks/mock-text-document-change-event';
+import { ExtensionContext } from '../mocks/vscode';
+
+suite('OpenFilesObserver Test Suite', () => {
+  let observer: OpenFilesObserver;
+
+  setup(() => {
+    const mockContext = {
+      subscriptions: [],
+    } as unknown as ExtensionContext;
+    observer = new OpenFilesObserver(mockContext as any);
+  });
+
+  suite('shouldSkipDocumentChange', () => {
+    const testCases = [
+      {
+        name: 'returns true when contentChanges is empty',
+        filePath: '/test/file1.ts',
+        version: 1,
+        contentChanges: [],
+        priorVersion: undefined,
+        expected: true,
+      },
+      {
+        name: 'returns false on first call (no prior version stored)',
+        filePath: '/test/file2.ts',
+        version: 1,
+        contentChanges: [{}],
+        priorVersion: undefined,
+        expected: false,
+      },
+      {
+        name: 'returns true when document version unchanged',
+        filePath: '/test/file3.ts',
+        version: 5,
+        contentChanges: [{}],
+        priorVersion: 5,
+        expected: true,
+      },
+      {
+        name: 'returns false when document version changed',
+        filePath: '/test/file4.ts',
+        version: 6,
+        contentChanges: [{}],
+        priorVersion: 5,
+        expected: false,
+      },
+    ];
+
+    testCases.forEach(({ name, filePath, version, contentChanges, priorVersion, expected }) => {
+      test(name, () => {
+        if (priorVersion !== undefined) {
+          const priorDoc = new TestTextDocument(filePath, '', 'typescript', priorVersion);
+          const priorEvent = new MockTextDocumentChangeEvent(priorDoc, [{}] as any);
+          observer.shouldSkipDocumentChange(priorEvent);
+        }
+
+        const doc = new TestTextDocument(filePath, '', 'typescript', version);
+        const event = new MockTextDocumentChangeEvent(doc, contentChanges as any);
+        const result = observer.shouldSkipDocumentChange(event);
+
+        assert.strictEqual(result, expected, name);
+      });
+    });
+  });
+});

--- a/src/test/suite/open-files-observer.test.ts
+++ b/src/test/suite/open-files-observer.test.ts
@@ -23,6 +23,7 @@ suite('OpenFilesObserver Test Suite', () => {
         contentChanges: [],
         priorVersion: undefined,
         expected: true,
+        description: 'Diagnostic-only updates have no content changes',
       },
       {
         name: 'returns false on first call (no prior version stored)',
@@ -31,6 +32,7 @@ suite('OpenFilesObserver Test Suite', () => {
         contentChanges: [{}],
         priorVersion: undefined,
         expected: false,
+        description: 'First edit should trigger review',
       },
       {
         name: 'returns true when document version unchanged',
@@ -39,6 +41,7 @@ suite('OpenFilesObserver Test Suite', () => {
         contentChanges: [{}],
         priorVersion: 5,
         expected: true,
+        description: 'Duplicate events with same version should be skipped',
       },
       {
         name: 'returns false when document version changed',
@@ -47,6 +50,16 @@ suite('OpenFilesObserver Test Suite', () => {
         contentChanges: [{}],
         priorVersion: 5,
         expected: false,
+        description: 'New version should trigger review',
+      },
+      {
+        name: 'returns true when contentChanges empty even with new version',
+        filePath: '/test/file5.ts',
+        version: 7,
+        contentChanges: [],
+        priorVersion: 6,
+        expected: true,
+        description: 'Empty contentChanges check takes precedence',
       },
     ];
 
@@ -64,6 +77,29 @@ suite('OpenFilesObserver Test Suite', () => {
 
         assert.strictEqual(result, expected, name);
       });
+    });
+  });
+
+  suite('getAllVisibleFileNames interaction', () => {
+    test('getAllVisibleFileNames is called during document change processing', () => {
+      const filePath = '/test/visible-file.ts';
+      const originalGetAllVisibleFileNames = observer.getAllVisibleFileNames.bind(observer);
+      let getAllVisibleFileNamesCalled = false;
+
+      observer.getAllVisibleFileNames = () => {
+        getAllVisibleFileNamesCalled = true;
+        return originalGetAllVisibleFileNames();
+      };
+
+      (observer as any).visibleDocuments.add(filePath);
+
+      const doc = new TestTextDocument(filePath, '', 'typescript', 1);
+      const event = new MockTextDocumentChangeEvent(doc, [{}] as any);
+
+      observer.shouldSkipDocumentChange(event);
+
+      assert.strictEqual(getAllVisibleFileNamesCalled, false,
+        'getAllVisibleFileNames should not be called by shouldSkipDocumentChange - it is called in onDidChangeTextDocument handler');
     });
   });
 });

--- a/src/test/suite/open-files-observer.test.ts
+++ b/src/test/suite/open-files-observer.test.ts
@@ -1,17 +1,25 @@
 import * as assert from 'assert';
+import * as vscode from '../mocks/vscode';
 import { OpenFilesObserver } from '../../review/open-files-observer';
 import { TestTextDocument } from '../mocks/test-text-document';
 import { MockTextDocumentChangeEvent } from '../mocks/mock-text-document-change-event';
-import { ExtensionContext } from '../mocks/vscode';
+import { MockEditor } from '../mocks/mock-editor';
+import { setMockVisibleTextEditors, setMockTabGroups, resetMockWindow } from '../setup';
 
 suite('OpenFilesObserver Test Suite', () => {
   let observer: OpenFilesObserver;
 
   setup(() => {
+    resetMockWindow();
+
     const mockContext = {
       subscriptions: [],
-    } as unknown as ExtensionContext;
+    } as unknown as vscode.ExtensionContext;
     observer = new OpenFilesObserver(mockContext as any);
+  });
+
+  teardown(() => {
+    resetMockWindow();
   });
 
   suite('shouldSkipDocumentChange', () => {
@@ -100,6 +108,55 @@ suite('OpenFilesObserver Test Suite', () => {
 
       assert.strictEqual(getAllVisibleFileNamesCalled, false,
         'getAllVisibleFileNames should not be called by shouldSkipDocumentChange - it is called in onDidChangeTextDocument handler');
+    });
+  });
+
+  suite('scheme filtering', () => {
+    const testCases = [
+      {
+        name: 'excludes non-file scheme from visibleTextEditors',
+        editors: [
+          { document: new TestTextDocument('/test/file.ts', '', 'typescript'), scheme: 'file' },
+          { document: { fileName: 'output.log', uri: { scheme: 'output', fsPath: 'output.log' } }, scheme: 'output' },
+        ],
+        expectedCount: 1,
+      },
+      {
+        name: 'excludes non-file scheme from tabGroups',
+        tabGroups: [
+          { tabs: [{ input: new vscode.TabInputText(vscode.Uri.file('/test/file1.ts')) }] },
+          { tabs: [{ input: new vscode.TabInputText({ scheme: 'output', fsPath: 'log.log', path: 'log.log' } as any) }] },
+        ],
+        expectedCount: 1,
+      },
+      {
+        name: 'includes only file scheme URIs',
+        editors: [
+          { document: new TestTextDocument('/test/file1.ts', '', 'typescript'), scheme: 'file' },
+          { document: new TestTextDocument('/test/file2.ts', '', 'typescript'), scheme: 'file' },
+        ],
+        tabGroups: [
+          { tabs: [{ input: new vscode.TabInputText(vscode.Uri.file('/test/file3.ts')) }] },
+        ],
+        expectedCount: 3,
+      },
+    ];
+
+    testCases.forEach(({ name, editors, tabGroups, expectedCount }) => {
+      test(name, () => {
+        if (editors) {
+          const mockEditors = editors.map(e => new MockEditor(e.document));
+          setMockVisibleTextEditors(mockEditors);
+        }
+        if (tabGroups) {
+          setMockTabGroups(tabGroups);
+        }
+
+        const result = observer.getAllVisibleFileNames();
+
+        assert.strictEqual(result.size, expectedCount,
+          `Expected ${expectedCount} files, got ${result.size}: ${Array.from(result).join(', ')}`);
+      });
     });
   });
 });


### PR DESCRIPTION
`onDidChangeTextDocument` was firing repeatedly even without user edits,
likely triggered by diagnostics updates. This caused `git merge-base` to
run once per second on feature branches.

Add `shouldSkipDocumentChange()` with two early-exit checks:

- Skip when `contentChanges` is empty (diagnostic-only updates)
 - Skip when document version is unchanged from last seen

---

* fix: skip document change events for files without UI tabs
  * `onDidChangeTextDocument` fires for all documents including internal
buffers like log outputs. This caused unnecessary `git merge-base` calls
for non-user files.
Add check to verify file has an actual UI tab via
`getAllVisibleFileNames()` before processing changes.
* fix: filter non-file scheme URIs in getAllVisibleFileNames
  * `getAllVisibleFileNames()` was returning all visible editors including
output channels and logs (non-file:// scheme). This caused excessive
`git merge-base` calls for internal buffers.
Add scheme filtering to only include file:// URIs in both
`visibleTextEditors` and `tabGroups`.