### PR TITLE
fix: update extension ID to match marketplace identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1591,7 +1591,8 @@
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -1694,6 +1695,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1877,6 +1879,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3108,6 +3111,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3189,6 +3193,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5596,6 +5601,7 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6657,6 +6663,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7927,7 +7934,8 @@
     "@types/node": {
       "version": "16.18.126",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw=="
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "peer": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.4",
@@ -8004,6 +8012,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -8103,7 +8112,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -8955,6 +8965,7 @@
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
       "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@esbuild/aix-ppc64": "0.25.10",
         "@esbuild/android-arm": "0.25.10",
@@ -9013,6 +9024,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10684,7 +10696,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "proxy-from-env": {
       "version": "1.1.0",
@@ -11424,7 +11437,8 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "icon": "assets/cs-logo.png",
   "displayName": "CodeScene",
   "author": "CodeScene AB",
-  "publisher": "codescene",
+  "publisher": "CodeScene",
   "description": "Integrates CodeScene analysis into VS Code. Keeps your code clean and maintainable.",
   "version": "0.27.5",
   "license": "MIT",

--- a/src/extension-id.ts
+++ b/src/extension-id.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 
-let extensionId = 'codescene.codescene-vscode';
+let extensionId = 'CodeScene.codescene-vscode';
 
 export function initExtensionId(context: vscode.ExtensionContext): void {
   extensionId = context.extension.id;

--- a/src/test/suite/cwf-webview-docs-panel.test.ts
+++ b/src/test/suite/cwf-webview-docs-panel.test.ts
@@ -36,7 +36,7 @@ suite('CodeSceneCWFDocsTabPanel Test Suite', () => {
     resetWebviewPanelMocks();
     resetDocsPanel();
     mockContext = createMockExtensionContext('/test/docs-panel');
-    initExtensionId({ extension: { id: 'codescene.codescene-vscode' } } as vscode.ExtensionContext);
+    initExtensionId({ extension: { id: 'CodeScene.codescene-vscode' } } as vscode.ExtensionContext);
     CsExtensionState.init(mockContext);
 
     originalExecuteCommand = vscode.commands.executeCommand;
@@ -94,7 +94,7 @@ suite('CodeSceneCWFDocsTabPanel Test Suite', () => {
       executedCommands.some((c) => c.command === 'workbench.action.openWorkspaceSettings'),
       'Expected workspace settings command'
     );
-    assert.strictEqual(executedCommands[0].args[0], '@ext:codescene.codescene-vscode');
+    assert.strictEqual(executedCommands[0].args[0], '@ext:CodeScene.codescene-vscode');
   });
 
   test('open-settings falls back to user settings when workspace settings fail', async () => {

--- a/src/test/suite/extension-id.test.ts
+++ b/src/test/suite/extension-id.test.ts
@@ -3,8 +3,8 @@ import { initExtensionId, getExtensionId, getExtensionSettingsFilter } from '../
 
 suite('Extension ID Test Suite', () => {
   test('returns default extension id before init', () => {
-    assert.strictEqual(getExtensionId(), 'codescene.codescene-vscode');
-    assert.strictEqual(getExtensionSettingsFilter(), '@ext:codescene.codescene-vscode');
+    assert.strictEqual(getExtensionId(), 'CodeScene.codescene-vscode');
+    assert.strictEqual(getExtensionSettingsFilter(), '@ext:CodeScene.codescene-vscode');
   });
 
   test('initExtensionId updates getExtensionId and filter', () => {


### PR DESCRIPTION
The extension's unique identifier in the VS Code marketplace is `CodeScene.codescene-vscode` (with capitalized publisher name), not `codescene.codescene-vscode`. This updates the default extension ID and all test references to match the actual marketplace identifier as shown at https://marketplace.visualstudio.com/items?itemName=CodeScene.codescene-vscode

<img width="442" height="279" alt="image" src="https://github.com/user-attachments/assets/db480cb5-2b27-4f6c-9606-18191b144d8b" />

I believe this will fix installation issues.