### PR TITLE
refactor: remove `DefaultBranchGate` from `GitChangeLister`

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -16,7 +16,6 @@ import { SimpleExecutor } from '../simple-executor';
 import { isGitAvailable } from '../git/git-detection';
 import { SavedFilesTracker } from '../saved-files-tracker';
 import { isVSCodeWindowFocused } from '../extension-impl';
-import { DefaultBranchGate } from '../git/default-branch-gate';
 import { getOpenFilesObserverInstance } from '../review/open-files-observer';
 import { getCodeHealthMonitorViewInstance } from './tree-view';
 
@@ -68,12 +67,9 @@ export async function runScheduledGitChangeReview(): Promise<void> {
   }
 }
 
-export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate | undefined) {
+export function activate(context: vscode.ExtensionContext, savedFilesTracker: SavedFilesTracker) {
   if (!savedFilesTracker) {
     throw new Error('SavedFilesTracker must be provided to activate Code Health Monitor');
-  }
-  if (!defaultBranchGate) {
-    throw new Error('DefaultBranchGate must be provided to activate Code Health Monitor');
   }
 
   gitApi = acquireGitApi();
@@ -98,7 +94,7 @@ export function activate(context: vscode.ExtensionContext, savedFilesTracker: Sa
   // Review all changed/added files periodically.
   // NOTE: while this spawns Git processes that often, it does not trigger CLI processed that often,
   // because `CsDiagnostics.review` has built-in caching.
-  gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker, defaultBranchGate);
+  gitChangeListerInstance = new GitChangeLister(DevtoolsAPI.concurrencyLimitingExecutor, savedFilesTracker);
   scheduledExecutorInstance = new DroppingScheduledExecutor(new SimpleExecutor(), GIT_CHANGE_LISTER_BASE_PERIOD_SECONDS);
 
   void scheduledExecutorInstance.executeTask(runScheduledGitChangeReview);

--- a/src/extension-impl.ts
+++ b/src/extension-impl.ts
@@ -300,7 +300,7 @@ async function startExtension(context: vscode.ExtensionContext) {
 
   initializeGitIntegration();
 
-  activateCHMonitor(context, savedFilesTrackerInstance, defaultBranchGateInstance);
+  activateCHMonitor(context, savedFilesTrackerInstance);
 
   setupCodeLensProviders(context);
 

--- a/src/git/git-change-lister.ts
+++ b/src/git/git-change-lister.ts
@@ -10,7 +10,6 @@ import { getRepo } from '../code-health-monitor/addon';
 import { getCommittedChanges, getStatusChanges } from './git-diff-utils';
 import { getWorkspaceFolder } from '../utils';
 import { SavedFilesTracker } from '../saved-files-tracker';
-import { DefaultBranchGate } from './default-branch-gate';
 
 /**
  * Lists all changed files exhaustively from Git status, and Git diff vs. merge-base.
@@ -18,18 +17,13 @@ import { DefaultBranchGate } from './default-branch-gate';
 export class GitChangeLister {
   private executor: Executor;
   private savedFilesTracker: SavedFilesTracker;
-  private defaultBranchGate: DefaultBranchGate;
 
-  constructor(executor: Executor, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate) {
+  constructor(executor: Executor, savedFilesTracker: SavedFilesTracker) {
     if (!savedFilesTracker) {
       throw new Error('SavedFilesTracker must be provided to GitChangeLister');
     }
-    if (!defaultBranchGate) {
-      throw new Error('DefaultBranchGate must be provided to GitChangeLister');
-    }
     this.executor = executor;
     this.savedFilesTracker = savedFilesTracker;
-    this.defaultBranchGate = defaultBranchGate;
   }
 
   // NOTE:
@@ -43,11 +37,6 @@ export class GitChangeLister {
       const workspacePath = getWorkspacePath(workspaceFolder);
       const repo = getRepo(workspaceFolder.uri);
       const gitRootPath = repo?.rootUri.fsPath || workspacePath;
-
-      if (repo && await this.defaultBranchGate.shouldSkipBasedOnDefaultBranch(repo)) {
-        logOutputChannel.debug('GitChangeLister: skipping processing, current branch matches default branch');
-        return new Set<string>();
-      }
 
       const baselineCommit = repo ? await getMergeBaseCommit(repo) : '';
       const allChangedFiles = await this.getAllChangedFiles(gitRootPath, workspacePath, baselineCommit);

--- a/src/git/git-change-observer.ts
+++ b/src/git/git-change-observer.ts
@@ -49,7 +49,7 @@ export class GitChangeObserver {
     this.scheduledExecutor = new DroppingScheduledExecutor(new SimpleExecutor(), 1);
     this.fileWatcher = this.createWatcher('**/*');
 
-    this.initializeTracker(executor, savedFilesTracker, defaultBranchGate);
+    this.initializeTracker(executor, savedFilesTracker);
   }
 
   private validateDependencies(savedFilesTracker: SavedFilesTracker, openFilesObserver: OpenFilesObserver, defaultBranchGate: DefaultBranchGate): void {
@@ -64,9 +64,9 @@ export class GitChangeObserver {
     }
   }
 
-  private initializeTracker(executor: Executor, savedFilesTracker: SavedFilesTracker, defaultBranchGate: DefaultBranchGate): void {
+  private initializeTracker(executor: Executor, savedFilesTracker: SavedFilesTracker): void {
     // Initially fill the tracker - this ensures `handleFileDelete` works well
-    const lister = new GitChangeLister(executor, savedFilesTracker, defaultBranchGate);
+    const lister = new GitChangeLister(executor, savedFilesTracker);
     const workspaceFolder = getWorkspaceFolder();
     if (!workspaceFolder) return;
 

--- a/src/test/suite/addon.test.ts
+++ b/src/test/suite/addon.test.ts
@@ -18,11 +18,9 @@ import { setWindowFocusedForTesting } from '../../extension-impl';
 import { createMockExtensionContext } from '../mocks/mock-extension-context';
 import { setMockGitRepositories, clearMockGitRepositories, mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders } from '../setup';
 import { ensureBinary } from '../integration_helper';
-import { DefaultBranchGate } from '../../git/default-branch-gate';
 
 suite('Code Health Monitor Addon Test Suite', () => {
   let mockContext: ReturnType<typeof createMockExtensionContext>;
-  let mockDefaultBranchGate: DefaultBranchGate;
   const repoRoot = path.join(__dirname, '../../../test-git-repo-addon');
 
   function createMockRepo(rootPath: string = repoRoot) {
@@ -43,12 +41,6 @@ suite('Code Health Monitor Addon Test Suite', () => {
     };
   }
 
-  function createMockDefaultBranchGate(): DefaultBranchGate {
-    return {
-      shouldSkipBasedOnDefaultBranch: async () => false,
-    } as any;
-  }
-
   suiteSetup(async function () {
     this.timeout(60000);
     const binaryPath = await ensureBinary();
@@ -62,7 +54,6 @@ suite('Code Health Monitor Addon Test Suite', () => {
     resetGitAvailability();
     clearMockGitRepositories();
     mockWorkspaceFolders([createMockWorkspaceFolder(repoRoot)]);
-    mockDefaultBranchGate = createMockDefaultBranchGate();
   });
 
   teardown(() => {
@@ -90,7 +81,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
       return originalSetBaseline(fileFilter, baselineCommit);
     };
 
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
 
     // Wait for activation's initial setBaseline call to complete
     const maxWaitMs = 12000;
@@ -113,7 +104,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runGitChangeLister invokes lister after activation', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
 
     let startCalled = false;
     const originalStart = GitChangeLister.prototype.start;
@@ -130,7 +121,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('runGitChangeLister is a no-op when git is unavailable', async () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
     markGitAsUnavailable();
 
     let startCalled = false;
@@ -148,7 +139,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
 
   test('deactivate clears git change lister instance', async () => {
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
     deactivateCodeHealthMonitor();
 
     let startCalled = false;
@@ -171,7 +162,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     test(`runScheduledGitChangeReview ${description}`, async function () {
       this.timeout(20000);
       setMockGitRepositories([createMockRepo()]);
-      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
 
       setWindowFocusedForTesting(focused);
 
@@ -199,7 +190,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
     test(`runScheduledGitChangeReview ${description}`, async function () {
       this.timeout(20000);
       setMockGitRepositories([createMockRepo()]);
-      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+      activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
 
       setWindowFocusedForTesting(true);
       DevtoolsAPI.setAnalysesRunningForTesting(analysesRunning);
@@ -224,7 +215,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runScheduledGitChangeReview increases period when git operations exceed base period', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
     setWindowFocusedForTesting(true);
 
     const executor = getScheduledExecutorForTesting();
@@ -258,7 +249,7 @@ suite('Code Health Monitor Addon Test Suite', () => {
   test('runScheduledGitChangeReview does not decrease period', async function () {
     this.timeout(20000);
     setMockGitRepositories([createMockRepo()]);
-    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any, mockDefaultBranchGate);
+    activateCodeHealthMonitor(mockContext, { getSavedFiles: () => new Set<string>() } as any);
     setWindowFocusedForTesting(true);
 
     const executor = getScheduledExecutorForTesting();

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -5,7 +5,6 @@ import { Uri, ExtensionContext } from '../mocks/vscode';
 import { GitChangeLister } from '../../git/git-change-lister';
 import { MockExecutor } from '../mocks/mock-executor';
 import { API } from '../../../types/git';
-import { DefaultBranchGate } from '../../git/default-branch-gate';
 import { mockWorkspaceFolders, createMockWorkspaceFolder, restoreDefaultWorkspaceFolders, setMockGitRepositories, clearMockGitRepositories } from '../setup';
 import { setGitApiForTesting } from '../../code-health-monitor/addon';
 import { MockGitAPI } from '../mocks/mock-git-api';
@@ -22,7 +21,6 @@ suite('GitChangeLister Test Suite', () => {
   const testRepoPath = path.join(__dirname, '../../../test-git-repo');
   let gitChangeLister: GitChangeLister;
   let mockExecutor: MockExecutor;
-  let mockDefaultBranchGate: DefaultBranchGate;
 
   setup(async function () {
     this.timeout(20000);
@@ -43,8 +41,7 @@ suite('GitChangeLister Test Suite', () => {
 
     mockExecutor = new MockExecutor();
     const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
-    mockDefaultBranchGate = { shouldSkipBasedOnDefaultBranch: async () => false } as any;
-    gitChangeLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker, mockDefaultBranchGate);
+    gitChangeLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker);
   });
 
   teardown(async function () {
@@ -174,68 +171,6 @@ suite('GitChangeLister Test Suite', () => {
     const fileNames = Array.from(changedFiles).map(f => path.basename(f));
     assert.ok(fileNames.includes('my file.ts'), 'Should include file with spaces: my file.ts');
     assert.ok(fileNames.includes('test file with spaces.js'), 'Should include file with spaces: test file with spaces.js');
-  });
-
-  suite('DefaultBranchGate integration', () => {
-    test('getAllChangedFiles still works when gate returns false', async function () {
-      this.timeout(20000);
-      const newFile = path.join(testRepoPath, 'test.ts');
-      fs.writeFileSync(newFile, 'console.log("test");');
-
-      const changedFiles = await gitChangeLister.getAllChangedFiles(testRepoPath, testRepoPath, '');
-      assert.ok(Array.from(changedFiles).some(f => f.endsWith('test.ts')));
-    });
-
-    [
-      { gateReturns: true,  expectGetAllChangedFilesCalled: false, description: 'skips review when gate returns true' },
-      { gateReturns: false, expectGetAllChangedFilesCalled: true,  description: 'proceeds with review when gate returns false' },
-    ].forEach(({ gateReturns, expectGetAllChangedFilesCalled, description }) => {
-      test(`start ${description}`, async function () {
-        this.timeout(20000);
-
-        const mockRepo = {
-          rootUri: Uri.file(testRepoPath),
-          state: {
-            HEAD: { name: 'main', commit: 'abc123' },
-            refs: [],
-            remotes: [],
-            submodules: [],
-            onDidChange: () => ({ dispose: () => {} }),
-          },
-        };
-
-        const mockGitApi = new MockGitAPI();
-        mockGitApi.repositories = [mockRepo];
-        setGitApiForTesting(mockGitApi as any);
-
-        const mockContext = createMockExtensionContext(testRepoPath);
-        if (!CsExtensionState.hasInstance) {
-          CsExtensionState.init(mockContext);
-        }
-
-        mockWorkspaceFolders([createMockWorkspaceFolder(testRepoPath)]);
-        setMockGitRepositories([mockRepo]);
-
-        const skipGate = { shouldSkipBasedOnDefaultBranch: async () => gateReturns } as any;
-        const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
-        const skipLister = new GitChangeLister(mockExecutor, mockSavedFilesTracker, skipGate);
-
-        let getAllChangedFilesCalled = false;
-        const originalGetAllChangedFiles = skipLister.getAllChangedFiles.bind(skipLister);
-        skipLister.getAllChangedFiles = async function (...args) {
-          getAllChangedFilesCalled = true;
-          return originalGetAllChangedFiles(...args);
-        };
-
-        await skipLister.start();
-
-        assert.strictEqual(getAllChangedFilesCalled, expectGetAllChangedFilesCalled);
-
-        setGitApiForTesting(undefined);
-        restoreDefaultWorkspaceFolders();
-        clearMockGitRepositories();
-      });
-    });
   });
 
   suite('DeltaAnalysisTreeProvider integration', () => {
@@ -408,8 +343,7 @@ suite('GitChangeLister Test Suite', () => {
         setMockGitRepositories([mockRepo]);
 
         const mockSavedFilesTracker = { getSavedFiles: () => new Set<string>() } as any;
-        const mockDefaultBranchGate = { shouldSkipBasedOnDefaultBranch: async () => false } as any;
-        const lister = new GitChangeLister(new MockExecutor(), mockSavedFilesTracker, mockDefaultBranchGate);
+        const lister = new GitChangeLister(new MockExecutor(), mockSavedFilesTracker);
 
         await lister.start();
 


### PR DESCRIPTION
The default branch skip logic was introduced to prevent file change stampedes, but `GitChangeLister` runs on a scheduled executor and doesn't suffer from this issue. Only `GitChangeObserver` needs this optimization since it responds to real-time file system events.