### PR TITLE
fix: exclude in-flight jobs from stale file removal

### DIFF
--- a/src/code-health-monitor/addon.ts
+++ b/src/code-health-monitor/addon.ts
@@ -32,9 +32,10 @@ let ALL_DISPOSABLES: vscode.Disposable[] = [];
 
 function removeStaleFilesFromMonitors(changedFiles: Set<string>): void {
   const visibleFiles = getOpenFilesObserverInstance()?.getAllVisibleFileNames() ?? new Set<string>();
+  const filesInJob = DevtoolsAPI.jobs;
 
-  getCodeHealthMonitorViewInstance()?.removeStaleFiles(changedFiles, visibleFiles);
-  getHomeViewInstance()?.removeStaleFiles(changedFiles, visibleFiles);
+  getCodeHealthMonitorViewInstance()?.removeStaleFiles(changedFiles, visibleFiles, filesInJob);
+  getHomeViewInstance()?.removeStaleFiles(changedFiles, visibleFiles, filesInJob);
 }
 
 export async function runScheduledGitChangeReview(): Promise<void> {

--- a/src/code-health-monitor/home/home-view.ts
+++ b/src/code-health-monitor/home/home-view.ts
@@ -271,9 +271,9 @@ export class HomeView implements WebviewViewProvider, Disposable {
     this.disposables.forEach((d) => d.dispose());
   }
 
-  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
+  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>, filesInJob: Set<string>): void {
     const staleFileRemover = new StaleFileRemover();
-    const stalePaths = staleFileRemover.findStaleFiles(this.fileIssueMap, changedFiles, visibleFiles);
+    const stalePaths = staleFileRemover.findStaleFiles(this.fileIssueMap, changedFiles, visibleFiles, filesInJob);
 
     for (const stalePath of stalePaths) {
       logOutputChannel.debug(`Removing stale file from Home View: ${stalePath}`);

--- a/src/code-health-monitor/stale-file-remover.ts
+++ b/src/code-health-monitor/stale-file-remover.ts
@@ -9,14 +9,20 @@ export class StaleFileRemover {
     return false;
   }
 
+  private isPathInAnySets(filePath: string, sets: Set<string>[]): boolean {
+    return sets.some((set) => this.isPathInSet(filePath, set));
+  }
+
   findStaleFiles(
     fileIssueMap: Map<string, unknown>,
     changedFiles: Set<string>,
-    visibleFiles: Set<string>
+    visibleFiles: Set<string>,
+    filesInJob: Set<string>
   ): string[] {
     const stalePaths: string[] = [];
+    const activeSets = [changedFiles, visibleFiles, filesInJob];
     for (const filePath of fileIssueMap.keys()) {
-      if (!this.isPathInSet(filePath, changedFiles) && !this.isPathInSet(filePath, visibleFiles)) {
+      if (!this.isPathInAnySets(filePath, activeSets)) {
         stalePaths.push(filePath);
       }
     }

--- a/src/code-health-monitor/tree-view.ts
+++ b/src/code-health-monitor/tree-view.ts
@@ -130,9 +130,14 @@ export class CodeHealthMonitorView implements vscode.Disposable {
     return this.treeDataProvider.fileIssueMap;
   }
 
-  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>): void {
+  removeStaleFiles(changedFiles: Set<string>, visibleFiles: Set<string>, filesInJob: Set<string>): void {
     const staleFileRemover = new StaleFileRemover();
-    const stalePaths = staleFileRemover.findStaleFiles(this.treeDataProvider.fileIssueMap, changedFiles, visibleFiles);
+    const stalePaths = staleFileRemover.findStaleFiles(
+      this.treeDataProvider.fileIssueMap,
+      changedFiles,
+      visibleFiles,
+      filesInJob
+    );
 
     for (const stalePath of stalePaths) {
       logOutputChannel.debug(`Removing stale file from Code Health Monitor: ${stalePath}`);

--- a/src/test/suite/git-change-lister.test.ts
+++ b/src/test/suite/git-change-lister.test.ts
@@ -466,7 +466,7 @@ suite('GitChangeLister Test Suite', () => {
       test(name, () => {
         initialFiles.forEach(addFileToMap);
 
-        codeHealthMonitorView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles));
+        codeHealthMonitorView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles), new Set());
 
         const fileIssueMap = codeHealthMonitorView.getFileIssueMap();
         assert.strictEqual(fileIssueMap.size, expectedFiles.length);
@@ -496,7 +496,7 @@ suite('GitChangeLister Test Suite', () => {
       test(`path normalization: ${name}`, () => {
         addFileToMap(mapPath);
 
-        codeHealthMonitorView.removeStaleFiles(new Set([changedPath]), new Set());
+        codeHealthMonitorView.removeStaleFiles(new Set([changedPath]), new Set(), new Set());
 
         const fileIssueMap = codeHealthMonitorView.getFileIssueMap();
         assert.strictEqual(fileIssueMap.size, 1, `Expected file to be kept when matching via ${changedPath}`);

--- a/src/test/suite/home-view.test.ts
+++ b/src/test/suite/home-view.test.ts
@@ -115,7 +115,7 @@ suite('HomeView', () => {
       test(name, () => {
         initialFiles.forEach(addFileToHomeView);
 
-        homeView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles));
+        homeView.removeStaleFiles(new Set(changedFiles), new Set(visibleFiles), new Set());
 
         const fileIssueMap = homeView.getFileIssueMap();
         assert.strictEqual(fileIssueMap.size, expectedFiles.length);
@@ -145,7 +145,7 @@ suite('HomeView', () => {
       test(`path normalization: ${name}`, () => {
         addFileToHomeView(mapPath);
 
-        homeView.removeStaleFiles(new Set([changedPath]), new Set());
+        homeView.removeStaleFiles(new Set([changedPath]), new Set(), new Set());
 
         const fileIssueMap = homeView.getFileIssueMap();
         assert.strictEqual(fileIssueMap.size, 1, `Expected file to be kept when matching via ${changedPath}`);
@@ -161,7 +161,7 @@ suite('HomeView', () => {
       addFileToHomeView('/workspace/fileA.ts');
       addFileToHomeView('/workspace/fileB.ts');
 
-      homeView.removeStaleFiles(new Set(), new Set());
+      homeView.removeStaleFiles(new Set(), new Set(), new Set());
 
       assert.ok(badgeUpdateCalled, 'Expected updateBadge to be called when files are removed');
     });
@@ -174,7 +174,7 @@ suite('HomeView', () => {
 
       addFileToHomeView('/workspace/fileA.ts');
 
-      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set());
+      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set(), new Set());
 
       assert.ok(!badgeUpdateCalled, 'Expected updateBadge not to be called when no files are removed');
     });
@@ -189,7 +189,7 @@ suite('HomeView', () => {
       addFileToHomeView('/workspace/fileB.ts');
       addFileToHomeView('/workspace/fileC.ts');
 
-      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set());
+      homeView.removeStaleFiles(new Set(['/workspace/fileA.ts']), new Set(), new Set());
 
       assert.strictEqual(badgeCount, 1, 'Expected badge count to be 1 after removing 2 files');
     });

--- a/src/test/suite/stale-file-remover.test.ts
+++ b/src/test/suite/stale-file-remover.test.ts
@@ -15,6 +15,7 @@ suite('StaleFileRemover', () => {
         mapKeys: [] as string[],
         changed: [] as string[],
         visible: [] as string[],
+        inJob: [] as string[],
         expected: [] as string[],
       },
       {
@@ -22,6 +23,7 @@ suite('StaleFileRemover', () => {
         mapKeys: ['/workspace/a.ts'],
         changed: ['/workspace/a.ts'],
         visible: [],
+        inJob: [],
         expected: [],
       },
       {
@@ -29,6 +31,15 @@ suite('StaleFileRemover', () => {
         mapKeys: ['/workspace/a.ts'],
         changed: [],
         visible: ['/workspace/a.ts'],
+        inJob: [],
+        expected: [],
+      },
+      {
+        name: 'file in filesInJob set is not stale',
+        mapKeys: ['/workspace/a.ts'],
+        changed: [],
+        visible: [],
+        inJob: ['/workspace/a.ts'],
         expected: [],
       },
       {
@@ -36,6 +47,7 @@ suite('StaleFileRemover', () => {
         mapKeys: ['/workspace/a.ts'],
         changed: [],
         visible: [],
+        inJob: [],
         expected: ['/workspace/a.ts'],
       },
       {
@@ -43,20 +55,23 @@ suite('StaleFileRemover', () => {
         mapKeys: ['/workspace/a.ts'],
         changed: ['/workspace/a.ts'],
         visible: ['/workspace/a.ts'],
+        inJob: [],
         expected: [],
       },
       {
         name: 'multiple files - mixed stale and non-stale',
-        mapKeys: ['/workspace/a.ts', '/workspace/b.ts', '/workspace/c.ts'],
+        mapKeys: ['/workspace/a.ts', '/workspace/b.ts', '/workspace/c.ts', '/workspace/d.ts'],
         changed: ['/workspace/a.ts'],
         visible: ['/workspace/b.ts'],
-        expected: ['/workspace/c.ts'],
+        inJob: ['/workspace/c.ts'],
+        expected: ['/workspace/d.ts'],
       },
       {
-        name: 'all files stale when both sets empty',
+        name: 'all files stale when all sets empty',
         mapKeys: ['/workspace/a.ts', '/workspace/b.ts'],
         changed: [],
         visible: [],
+        inJob: [],
         expected: ['/workspace/a.ts', '/workspace/b.ts'],
       },
       {
@@ -64,16 +79,17 @@ suite('StaleFileRemover', () => {
         mapKeys: ['/workspace/a.ts', '/workspace/b.ts'],
         changed: ['/workspace/a.ts', '/workspace/b.ts'],
         visible: [],
+        inJob: [],
         expected: [],
       },
     ];
 
-    testCases.forEach(({ name, mapKeys, changed, visible, expected }) => {
+    testCases.forEach(({ name, mapKeys, changed, visible, inJob, expected }) => {
       test(name, () => {
         const fileIssueMap = new Map<string, unknown>();
         mapKeys.forEach((key) => fileIssueMap.set(key, {}));
 
-        const result = remover.findStaleFiles(fileIssueMap, new Set(changed), new Set(visible));
+        const result = remover.findStaleFiles(fileIssueMap, new Set(changed), new Set(visible), new Set(inJob));
 
         assert.deepStrictEqual(result.sort(), expected.sort());
       });
@@ -113,7 +129,7 @@ suite('StaleFileRemover', () => {
         const fileIssueMap = new Map<string, unknown>();
         fileIssueMap.set(mapPath, {});
 
-        const result = remover.findStaleFiles(fileIssueMap, new Set([changedPath]), new Set());
+        const result = remover.findStaleFiles(fileIssueMap, new Set([changedPath]), new Set(), new Set());
 
         if (shouldBeStale) {
           assert.strictEqual(result.length, 1, `Expected ${mapPath} to be stale`);


### PR DESCRIPTION
Files currently being analyzed (`DevtoolsAPI.jobs`) are now preserved during stale file removal.

This could potentially prevent UI flicker where files would be removed and re-added when analysis completes
(not that I've seen such flickering, but seems possible).