### PR TITLE
chore: bump cli version

### DIFF
--- a/scripts/cli-config.js
+++ b/scripts/cli-config.js
@@ -6,7 +6,7 @@
  * - TypeScript source files (via artifact-info.ts) that import from this file
  */
 
-const requiredDevtoolsVersion = '0bfb30fca2c1c9dfce83a2d0393315dc14a5eeef';
+const requiredDevtoolsVersion = '8a7257420cc2dec1cf6ff7866db4da8c58f67602';
 
 const artifacts = {
   darwin: {


### PR DESCRIPTION
## Summary
- Bump the bundled CodeScene CLI/devtools pin to `8a7257420cc2dec1cf6ff7866db4da8c58f67602`.

## Test plan
- [ ] Confirm the extension downloads/bundles artifacts for SHA `8a7257420cc2dec1cf6ff7866db4da8c58f67602`
- [ ] Smoke-test CLI-backed analysis after rebuild

Made with [Cursor](https://cursor.com)