### PR TITLE
fix: match Code Health Monitor E2E webview to marketplace extension ID

### DIFF
--- a/e2e/Playwright/PageObjects/CSHealthMonitor.cs
+++ b/e2e/Playwright/PageObjects/CSHealthMonitor.cs
@@ -10,12 +10,12 @@ public sealed class CSHealthMonitor : BasePO
 
     // CodeScene renders the Health Monitor as a VS Code WebView.
     // From the DOM dump, the iframe is:
-    // <iframe class="webview" src="...&extensionId=codescene.codescene-vscode&...&purpose=webviewView">
+    // <iframe class="webview" src="...&extensionId=CodeScene.codescene-vscode&...&purpose=webviewView">
 
     private static readonly IReadOnlyDictionary<string, string> LocatorMap =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["webview"] = "//iframe[contains(@class, 'webview') and contains(@src, 'extensionId=codescene.codescene-vscode') and contains(@src, 'purpose=webviewView')]",
+            ["webview"] = "//iframe[contains(@class, 'webview') and contains(translate(@src, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), 'extensionid=codescene.codescene-vscode') and contains(@src, 'purpose=webviewView')]",
             ["cshealthmonitorframe"] = "#active-frame",
 
             ["Id"] = "//iframe[contains(@class, 'webview') and contains(@src, 'vscode-app')]",

--- a/e2e/appsettings.json
+++ b/e2e/appsettings.json
@@ -15,7 +15,7 @@
   },
   "Extension": {
     "Name": ".vscode-test/extensions/codescene.codescene-vscode-0.26.1@win32-x64.vsix",
-    "Id": "codescene.codescene-vscode",
+    "Id": "CodeScene.codescene-vscode",
     "AuthToken": ""
   }
 }


### PR DESCRIPTION
## Summary
- Windows E2E monitor tests have been failing since #335 because the webview iframe locator still used lowercase `codescene.codescene-vscode`. VS Code emits `extensionId=CodeScene.codescene-vscode`, and XPath `contains()` is case-sensitive, so Playwright never entered the monitor iframe.
- This is not a CLI-bump regression and does not require `CS_ACCESS_TOKEN`. The monitor renders without sign-in (`ignoreSessionStateFeatureFlag`), and the packaged CWF still contains `No code health impact` / `monitor-file-card`.
- Locator now matches the marketplace id case-insensitively; `e2e/appsettings.json` `Extension.Id` is aligned.

## Test plan
- [ ] Confirm E2E job on this PR: `CodeHealthMonitor_ShouldShowNoCodeSmell` and `CodeHealthMonitor_AddDirtyFile_ShouldShowCodeSmell` pass on windows-latest
- [ ] Confirm `VSCode_ShouldOpenWindow` and `VSCode_OpenFile_ShouldBeActive` still pass
- [ ] Confirm `CS_ACCESS_TOKEN` remains empty in the job env and tests still pass (token is ACE-only)
