### PR TITLE
fix: exclude merge-commit files from Code Health Monitor (#343)

### DIFF
--- a/src/git/git-diff-utils.ts
+++ b/src/git/git-diff-utils.ts
@@ -93,7 +93,15 @@ export async function getCommittedChanges(gitRootPath: string, baseCommit: strin
   const result = await gitExecutor.execute(
     {
       command: 'git',
-      args: ['log', '--first-parent', '--name-only', '--pretty=format:', '--diff-filter=ACMR', `${baseCommit}..HEAD`],
+      args: [
+        'log',
+        '--first-parent',
+        '--diff-merges=off',
+        '--name-only',
+        '--pretty=format:',
+        '--diff-filter=ACMR',
+        `${baseCommit}..HEAD`,
+      ],
       ignoreError: true,
       taskId: 'git',
     },

--- a/src/git/git-diff-utils.ts
+++ b/src/git/git-diff-utils.ts
@@ -91,7 +91,12 @@ export async function getCommittedChanges(gitRootPath: string, baseCommit: strin
   }
 
   const result = await gitExecutor.execute(
-    { command: 'git', args: ['diff', '--name-only', `${baseCommit}...HEAD`], ignoreError: true, taskId: 'git' },
+    {
+      command: 'git',
+      args: ['log', '--first-parent', '--name-only', '--pretty=format:', '--diff-filter=ACMR', `${baseCommit}..HEAD`],
+      ignoreError: true,
+      taskId: 'git',
+    },
     { cwd: gitRootPath, env: GIT_ENV_NO_OPTIONAL_LOCKS }
   );
 

--- a/src/test/suite/git-diff-utils.test.ts
+++ b/src/test/suite/git-diff-utils.test.ts
@@ -583,5 +583,73 @@ suite('Git Diff Utils Test Suite', () => {
         assert.ok(fs.existsSync(filePath), `File should exist: ${fileName}`);
       }
     });
+
+    test('excludes files introduced only by merging baseline into feature branch', async function () {
+      this.timeout(20000);
+
+      execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+      const baseCommit = execSync('git rev-parse HEAD', { cwd: testRepoPath }).toString().trim();
+
+      execSync('git checkout -b feature', { cwd: testRepoPath, stdio: 'pipe' });
+      fs.writeFileSync(path.join(testRepoPath, 'feature.ts'), 'export const feature = true;');
+      execSync('git add feature.ts', { cwd: testRepoPath });
+      execSync('git commit -m "Add feature file"', { cwd: testRepoPath });
+
+      execSync('git checkout -b upstream main', { cwd: testRepoPath, stdio: 'pipe' });
+      const upstreamOnlyFiles = ['upstream-a.ts', 'upstream-b.ts', 'upstream-c.ts'];
+      for (const fileName of upstreamOnlyFiles) {
+        fs.writeFileSync(path.join(testRepoPath, fileName), `export const ${fileName.replace(/[.-]/g, '_')} = 1;`);
+      }
+      execSync('git add .', { cwd: testRepoPath });
+      execSync('git commit -m "Advance upstream baseline"', { cwd: testRepoPath });
+
+      execSync('git checkout feature', { cwd: testRepoPath, stdio: 'pipe' });
+      execSync('git merge upstream -m "Merge upstream into feature"', { cwd: testRepoPath, stdio: 'pipe' });
+
+      const changes = await getCommittedChanges(testRepoPath, baseCommit, testRepoPath);
+      const fileNames = Array.from(changes);
+
+      assert.ok(fileNames.includes('feature.ts'), `Should include feature.ts. Found: ${JSON.stringify(fileNames)}`);
+      for (const fileName of upstreamOnlyFiles) {
+        assert.ok(
+          !fileNames.includes(fileName),
+          `Should exclude merge-introduced file ${fileName}. Found: ${JSON.stringify(fileNames)}`
+        );
+      }
+    });
+
+    test('includes feature commits made after merging baseline', async function () {
+      this.timeout(20000);
+
+      execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
+      const baseCommit = execSync('git rev-parse HEAD', { cwd: testRepoPath }).toString().trim();
+
+      execSync('git checkout -b feature', { cwd: testRepoPath, stdio: 'pipe' });
+      fs.writeFileSync(path.join(testRepoPath, 'feature.ts'), 'export const feature = true;');
+      execSync('git add feature.ts', { cwd: testRepoPath });
+      execSync('git commit -m "Add feature file"', { cwd: testRepoPath });
+
+      execSync('git checkout -b upstream main', { cwd: testRepoPath, stdio: 'pipe' });
+      fs.writeFileSync(path.join(testRepoPath, 'upstream-only.ts'), 'export const upstream = 1;');
+      execSync('git add upstream-only.ts', { cwd: testRepoPath });
+      execSync('git commit -m "Advance upstream baseline"', { cwd: testRepoPath });
+
+      execSync('git checkout feature', { cwd: testRepoPath, stdio: 'pipe' });
+      execSync('git merge upstream -m "Merge upstream into feature"', { cwd: testRepoPath, stdio: 'pipe' });
+
+      fs.writeFileSync(path.join(testRepoPath, 'after-merge.ts'), 'export const after = true;');
+      execSync('git add after-merge.ts', { cwd: testRepoPath });
+      execSync('git commit -m "Feature work after merge"', { cwd: testRepoPath });
+
+      const changes = await getCommittedChanges(testRepoPath, baseCommit, testRepoPath);
+      const fileNames = Array.from(changes);
+
+      assert.ok(fileNames.includes('feature.ts'), `Should include feature.ts. Found: ${JSON.stringify(fileNames)}`);
+      assert.ok(fileNames.includes('after-merge.ts'), `Should include after-merge.ts. Found: ${JSON.stringify(fileNames)}`);
+      assert.ok(
+        !fileNames.includes('upstream-only.ts'),
+        `Should exclude merge-introduced upstream-only.ts. Found: ${JSON.stringify(fileNames)}`
+      );
+    });
   });
 });

--- a/src/test/suite/git-diff-utils.test.ts
+++ b/src/test/suite/git-diff-utils.test.ts
@@ -585,7 +585,7 @@ suite('Git Diff Utils Test Suite', () => {
     });
 
     test('excludes files introduced only by merging baseline into feature branch', async function () {
-      this.timeout(20000);
+      this.timeout(60000);
 
       execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
       const baseCommit = execSync('git rev-parse HEAD', { cwd: testRepoPath }).toString().trim();
@@ -619,7 +619,7 @@ suite('Git Diff Utils Test Suite', () => {
     });
 
     test('includes feature commits made after merging baseline', async function () {
-      this.timeout(20000);
+      this.timeout(60000);
 
       execSync('git branch -M main', { cwd: testRepoPath, stdio: 'pipe' });
       const baseCommit = execSync('git rev-parse HEAD', { cwd: testRepoPath }).toString().trim();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#343](https://github.com/codescene-oss/codescene-vscode/issues/343): after merging an advanced baseline into a feature branch, the Code Health Monitor no longer lists every file brought in by the merge commit.

`getCommittedChanges` now walks first-parent history with merge diffs disabled:

```bash
git log --first-parent --diff-merges=off --name-only --pretty=format: --diff-filter=ACMR ${base}..HEAD
```

instead of a tree diff (`git diff base...HEAD`). Clean merges contribute no files; feature commits before and after the merge still appear.

`--diff-merges=off` is required: `git log --first-parent` alone still emits merge-introduced paths on this Git version.

## Test plan

- [x] RED: regression test failed with upstream files included under old `git diff`
- [x] GREEN: `make test1 TEST='excludes files introduced only by merging|includes feature commits made after merging'`
- [x] `make lint` (commitlint + eslint)

### Before / after (same scenario as the regression test)

```
=== BEFORE (git diff base...HEAD) — includes merge noise ===
feature.ts
upstream-a.ts
upstream-b.ts
upstream-c.ts

=== AFTER (git log --first-parent --diff-merges=off) — feature only ===
feature.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8c79a10e-c4c5-40b8-ac37-4516f436670c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8c79a10e-c4c5-40b8-ac37-4516f436670c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

